### PR TITLE
[STUDIO-610] Fix missing filtering of pull requests by repository when creating PRs

### DIFF
--- a/.meta/STUDIO-610.md
+++ b/.meta/STUDIO-610.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-610
+
+Created at 2020-10-27T01:30:23.524Z

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -15536,18 +15536,19 @@ exports.recursiveGetEpic = (key) => __awaiter(void 0, void 0, void 0, function* 
  * Fetches the numbers of the pull requests attached to this issue. Note that
  * this is a **PRIVATE API**, and may break in the future.
  *
- * @param {string} issueId The ID of the Jira issue (eg. '10910').
+ * @param {string}     issueId The ID of the Jira issue (eg. '10910').
+ * @param {Repository} repo    The name of the repository we're dealing with.
  *
  * @returns {number[]} The PR numbers.
  */
-exports.getIssuePullRequestNumbers = (issueId) => __awaiter(void 0, void 0, void 0, function* () {
+exports.getIssuePullRequestNumbers = (issueId, repo) => __awaiter(void 0, void 0, void 0, function* () {
     const host = `https://${Inputs_1.jiraEmail()}:${Inputs_1.jiraToken()}@${Inputs_1.jiraHost()}/`;
     const url = `${host}/rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=GitHub&dataType=branch`;
     const response = yield node_fetch_1.default(url);
     const data = (yield response.json());
     const ids = data.detail
         .map((detail) => detail.pullRequests
-        .filter((pr) => pr.status === 'OPEN')
+        .filter((pr) => pr.url.startsWith(`https://github.com/${Inputs_1.organizationName()}/${repo}/`) && pr.status === 'OPEN')
         .map((pr) => pr.id))
         .flat()
         .map((id) => parseInt(id.replace(/[^\d]/, ''), 10));
@@ -51699,7 +51700,7 @@ exports.createEpicPullRequest = (epic, repositoryName) => __awaiter(void 0, void
     core_1.info('Checking if there is an open pull request for this epic...');
     let pullRequestNumber;
     const repo = yield Repository_1.getRepository(repositoryName);
-    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id);
+    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id, repo.name);
     if (pullRequestNumbers.length > 0) {
         ;
         [pullRequestNumber] = pullRequestNumbers;

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -15536,18 +15536,19 @@ exports.recursiveGetEpic = (key) => __awaiter(void 0, void 0, void 0, function* 
  * Fetches the numbers of the pull requests attached to this issue. Note that
  * this is a **PRIVATE API**, and may break in the future.
  *
- * @param {string} issueId The ID of the Jira issue (eg. '10910').
+ * @param {string}     issueId The ID of the Jira issue (eg. '10910').
+ * @param {Repository} repo    The name of the repository we're dealing with.
  *
  * @returns {number[]} The PR numbers.
  */
-exports.getIssuePullRequestNumbers = (issueId) => __awaiter(void 0, void 0, void 0, function* () {
+exports.getIssuePullRequestNumbers = (issueId, repo) => __awaiter(void 0, void 0, void 0, function* () {
     const host = `https://${Inputs_1.jiraEmail()}:${Inputs_1.jiraToken()}@${Inputs_1.jiraHost()}/`;
     const url = `${host}/rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=GitHub&dataType=branch`;
     const response = yield node_fetch_1.default(url);
     const data = (yield response.json());
     const ids = data.detail
         .map((detail) => detail.pullRequests
-        .filter((pr) => pr.status === 'OPEN')
+        .filter((pr) => pr.url.startsWith(`https://github.com/${Inputs_1.organizationName()}/${repo}/`) && pr.status === 'OPEN')
         .map((pr) => pr.id))
         .flat()
         .map((id) => parseInt(id.replace(/[^\d]/, ''), 10));
@@ -51698,7 +51699,7 @@ exports.createEpicPullRequest = (epic, repositoryName) => __awaiter(void 0, void
     core_1.info('Checking if there is an open pull request for this epic...');
     let pullRequestNumber;
     const repo = yield Repository_1.getRepository(repositoryName);
-    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id);
+    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id, repo.name);
     if (pullRequestNumbers.length > 0) {
         ;
         [pullRequestNumber] = pullRequestNumbers;

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -15592,18 +15592,19 @@ exports.recursiveGetEpic = (key) => __awaiter(void 0, void 0, void 0, function* 
  * Fetches the numbers of the pull requests attached to this issue. Note that
  * this is a **PRIVATE API**, and may break in the future.
  *
- * @param {string} issueId The ID of the Jira issue (eg. '10910').
+ * @param {string}     issueId The ID of the Jira issue (eg. '10910').
+ * @param {Repository} repo    The name of the repository we're dealing with.
  *
  * @returns {number[]} The PR numbers.
  */
-exports.getIssuePullRequestNumbers = (issueId) => __awaiter(void 0, void 0, void 0, function* () {
+exports.getIssuePullRequestNumbers = (issueId, repo) => __awaiter(void 0, void 0, void 0, function* () {
     const host = `https://${Inputs_1.jiraEmail()}:${Inputs_1.jiraToken()}@${Inputs_1.jiraHost()}/`;
     const url = `${host}/rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=GitHub&dataType=branch`;
     const response = yield node_fetch_1.default(url);
     const data = (yield response.json());
     const ids = data.detail
         .map((detail) => detail.pullRequests
-        .filter((pr) => pr.status === 'OPEN')
+        .filter((pr) => pr.url.startsWith(`https://github.com/${Inputs_1.organizationName()}/${repo}/`) && pr.status === 'OPEN')
         .map((pr) => pr.id))
         .flat()
         .map((id) => parseInt(id.replace(/[^\d]/, ''), 10));
@@ -51698,7 +51699,7 @@ exports.createEpicPullRequest = (epic, repositoryName) => __awaiter(void 0, void
     core_1.info('Checking if there is an open pull request for this epic...');
     let pullRequestNumber;
     const repo = yield Repository_1.getRepository(repositoryName);
-    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id);
+    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id, repo.name);
     if (pullRequestNumbers.length > 0) {
         ;
         [pullRequestNumber] = pullRequestNumbers;

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -16198,18 +16198,19 @@ exports.recursiveGetEpic = (key) => __awaiter(void 0, void 0, void 0, function* 
  * Fetches the numbers of the pull requests attached to this issue. Note that
  * this is a **PRIVATE API**, and may break in the future.
  *
- * @param {string} issueId The ID of the Jira issue (eg. '10910').
+ * @param {string}     issueId The ID of the Jira issue (eg. '10910').
+ * @param {Repository} repo    The name of the repository we're dealing with.
  *
  * @returns {number[]} The PR numbers.
  */
-exports.getIssuePullRequestNumbers = (issueId) => __awaiter(void 0, void 0, void 0, function* () {
+exports.getIssuePullRequestNumbers = (issueId, repo) => __awaiter(void 0, void 0, void 0, function* () {
     const host = `https://${Inputs_1.jiraEmail()}:${Inputs_1.jiraToken()}@${Inputs_1.jiraHost()}/`;
     const url = `${host}/rest/dev-status/latest/issue/detail?issueId=${issueId}&applicationType=GitHub&dataType=branch`;
     const response = yield node_fetch_1.default(url);
     const data = (yield response.json());
     const ids = data.detail
         .map((detail) => detail.pullRequests
-        .filter((pr) => pr.status === 'OPEN')
+        .filter((pr) => pr.url.startsWith(`https://github.com/${Inputs_1.organizationName()}/${repo}/`) && pr.status === 'OPEN')
         .map((pr) => pr.id))
         .flat()
         .map((id) => parseInt(id.replace(/[^\d]/, ''), 10));
@@ -47550,7 +47551,7 @@ exports.createPullRequestForJiraIssue = (email, issueKey) => __awaiter(void 0, v
     core_1.info('Checking if there is an open pull request for this issue...');
     let pullRequestNumber;
     const repo = yield Github_1.getRepository(issue.fields.repository);
-    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(issue.id);
+    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(issue.id, repo.name);
     if (pullRequestNumbers.length > 0) {
         ;
         [pullRequestNumber] = pullRequestNumbers;
@@ -57780,7 +57781,7 @@ exports.createEpicPullRequest = (epic, repositoryName) => __awaiter(void 0, void
     core_1.info('Checking if there is an open pull request for this epic...');
     let pullRequestNumber;
     const repo = yield Repository_1.getRepository(repositoryName);
-    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id);
+    const pullRequestNumbers = yield Jira_1.getIssuePullRequestNumbers(epic.id, repo.name);
     if (pullRequestNumbers.length > 0) {
         ;
         [pullRequestNumber] = pullRequestNumbers;

--- a/src/services/Github/Epic.ts
+++ b/src/services/Github/Epic.ts
@@ -38,7 +38,10 @@ export const createEpicPullRequest = async (
   info('Checking if there is an open pull request for this epic...')
   let pullRequestNumber
   const repo = await getRepository(repositoryName)
-  const pullRequestNumbers = await getIssuePullRequestNumbers(epic.id)
+  const pullRequestNumbers = await getIssuePullRequestNumbers(
+    epic.id,
+    repo.name
+  )
 
   if (pullRequestNumbers.length > 0) {
     ;[pullRequestNumber] = pullRequestNumbers

--- a/src/services/Github/__tests__/Epic.test.ts
+++ b/src/services/Github/__tests__/Epic.test.ts
@@ -76,7 +76,9 @@ describe('Epic', () => {
         )
       jiraPrsSpy = jest
         .spyOn(Jira, 'getIssuePullRequestNumbers')
-        .mockImplementation((_issueId: string) => Promise.resolve([]))
+        .mockImplementation((_issueId: string, _repo: Git.Repository) =>
+          Promise.resolve([])
+        )
       repoSpy = jest
         .spyOn(Repository, 'getRepository')
         .mockImplementation((_name: string) =>

--- a/src/services/Jira/__tests__/Issue.test.ts
+++ b/src/services/Jira/__tests__/Issue.test.ts
@@ -124,8 +124,8 @@ describe('Issue', () => {
       ;(fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
         new Response(JSON.stringify(mockJiraPullRequests))
       )
-      const numbers = await getIssuePullRequestNumbers('ISSUE-236')
-      expect(numbers).toEqual([65])
+      const numbers = await getIssuePullRequestNumbers('ISSUE-236', 'actions')
+      expect(numbers).toEqual([64])
     })
   })
 

--- a/src/tests/fixtures/jira-pull-requests.json
+++ b/src/tests/fixtures/jira-pull-requests.json
@@ -45,16 +45,16 @@
           "commentCount":0,
           "source":{
             "branch":"issue-236-create-a-release",
-            "url":"https://github.com/octokit/actions/tree/issue-236-create-a-release"
+            "url":"https://github.com/octokit/webhooks/tree/issue-236-create-a-release"
           },
           "destination":{
-            "branch":"https://github.com/octokit/actions/tree/develop"
+            "branch":"https://github.com/octokit/webhooks/tree/develop"
           },
           "reviewers":[
 
           ],
           "status":"OPEN",
-          "url":"https://github.com/octokit/actions/pull/65",
+          "url":"https://github.com/octokit/webhooks/pull/65",
           "lastUpdate":"2020-10-09T04:53:34.000+0000"
         },
         {
@@ -76,7 +76,7 @@
           "reviewers":[
 
           ],
-          "status":"DECLINED",
+          "status":"OPEN",
           "url":"https://github.com/octokit/actions/pull/64",
           "lastUpdate":"2020-10-09T04:53:20.000+0000"
         },

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -91,7 +91,10 @@ export const createPullRequestForJiraIssue = async (
   info('Checking if there is an open pull request for this issue...')
   let pullRequestNumber
   const repo = await getRepository(issue.fields.repository)
-  const pullRequestNumbers = await getIssuePullRequestNumbers(issue.id)
+  const pullRequestNumbers = await getIssuePullRequestNumbers(
+    issue.id,
+    repo.name
+  )
 
   if (pullRequestNumbers.length > 0) {
     ;[pullRequestNumber] = pullRequestNumbers


### PR DESCRIPTION
## Fix missing filtering of pull requests by repository when creating PRs

[Jira Bug](https://shuttlerock.atlassian.net/browse/STUDIO-610)

## How to test the PR

Trigger PR creation for an issue whose Epic has PRs in multiple repositories (eg. [STUDIO-606](https://shuttlerock.atlassian.net/browse/STUDIO-606)). It shouldn't explode when it hits the wrong repo.

**Note: This is tested and working**

## Deployment Notes

None