### PR TITLE
[STUDIO-652] Allow a label to be added to Jira issues to skip PR creation

### DIFF
--- a/.meta/STUDIO-652.md
+++ b/.meta/STUDIO-652.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-652
+
+Created at 2020-11-10T06:53:25.905Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -17534,7 +17534,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
+exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
 const isNil_1 = __importDefault(__webpack_require__(977));
 const node_fetch_1 = __importDefault(__webpack_require__(467));
 const Inputs_1 = __webpack_require__(968);
@@ -17546,6 +17546,8 @@ exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
 // Jira issue types.
 exports.JiraIssueTypeEpic = 'Epic';
+// Jira labels.
+exports.JiraLabelSkipPR = 'Skip_PR';
 /**
  * Fetches the issue with the given key from Jira.
  *
@@ -17590,7 +17592,7 @@ exports.getEpic = (key) => __awaiter(void 0, void 0, void 0, function* () {
     }
     if (issue.fields.parent) {
         if (issue.fields.parent.fields.issuetype.name === exports.JiraIssueTypeEpic) {
-            return issue.fields.parent;
+            return exports.getIssue(issue.fields.parent.key);
         }
         // eslint-disable-next-line no-use-before-define
         return exports.recursiveGetEpic(issue.fields.parent.key);

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -16043,7 +16043,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
+exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
 const isNil_1 = __importDefault(__webpack_require__(977));
 const node_fetch_1 = __importDefault(__webpack_require__(467));
 const Inputs_1 = __webpack_require__(968);
@@ -16055,6 +16055,8 @@ exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
 // Jira issue types.
 exports.JiraIssueTypeEpic = 'Epic';
+// Jira labels.
+exports.JiraLabelSkipPR = 'Skip_PR';
 /**
  * Fetches the issue with the given key from Jira.
  *
@@ -16099,7 +16101,7 @@ exports.getEpic = (key) => __awaiter(void 0, void 0, void 0, function* () {
     }
     if (issue.fields.parent) {
         if (issue.fields.parent.fields.issuetype.name === exports.JiraIssueTypeEpic) {
-            return issue.fields.parent;
+            return exports.getIssue(issue.fields.parent.key);
         }
         // eslint-disable-next-line no-use-before-define
         return exports.recursiveGetEpic(issue.fields.parent.key);

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -16043,7 +16043,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
+exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
 const isNil_1 = __importDefault(__webpack_require__(977));
 const node_fetch_1 = __importDefault(__webpack_require__(467));
 const Inputs_1 = __webpack_require__(968);
@@ -16055,6 +16055,8 @@ exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
 // Jira issue types.
 exports.JiraIssueTypeEpic = 'Epic';
+// Jira labels.
+exports.JiraLabelSkipPR = 'Skip_PR';
 /**
  * Fetches the issue with the given key from Jira.
  *
@@ -16099,7 +16101,7 @@ exports.getEpic = (key) => __awaiter(void 0, void 0, void 0, function* () {
     }
     if (issue.fields.parent) {
         if (issue.fields.parent.fields.issuetype.name === exports.JiraIssueTypeEpic) {
-            return issue.fields.parent;
+            return exports.getIssue(issue.fields.parent.key);
         }
         // eslint-disable-next-line no-use-before-define
         return exports.recursiveGetEpic(issue.fields.parent.key);

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -16081,7 +16081,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
+exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
 const isNil_1 = __importDefault(__webpack_require__(977));
 const node_fetch_1 = __importDefault(__webpack_require__(467));
 const Inputs_1 = __webpack_require__(968);
@@ -16093,6 +16093,8 @@ exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
 // Jira issue types.
 exports.JiraIssueTypeEpic = 'Epic';
+// Jira labels.
+exports.JiraLabelSkipPR = 'Skip_PR';
 /**
  * Fetches the issue with the given key from Jira.
  *
@@ -16137,7 +16139,7 @@ exports.getEpic = (key) => __awaiter(void 0, void 0, void 0, function* () {
     }
     if (issue.fields.parent) {
         if (issue.fields.parent.fields.issuetype.name === exports.JiraIssueTypeEpic) {
-            return issue.fields.parent;
+            return exports.getIssue(issue.fields.parent.key);
         }
         // eslint-disable-next-line no-use-before-define
         return exports.recursiveGetEpic(issue.fields.parent.key);

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -16099,7 +16099,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
+exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
 const isNil_1 = __importDefault(__webpack_require__(977));
 const node_fetch_1 = __importDefault(__webpack_require__(467));
 const Inputs_1 = __webpack_require__(968);
@@ -16111,6 +16111,8 @@ exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
 // Jira issue types.
 exports.JiraIssueTypeEpic = 'Epic';
+// Jira labels.
+exports.JiraLabelSkipPR = 'Skip_PR';
 /**
  * Fetches the issue with the given key from Jira.
  *
@@ -16155,7 +16157,7 @@ exports.getEpic = (key) => __awaiter(void 0, void 0, void 0, function* () {
     }
     if (issue.fields.parent) {
         if (issue.fields.parent.fields.issuetype.name === exports.JiraIssueTypeEpic) {
-            return issue.fields.parent;
+            return exports.getIssue(issue.fields.parent.key);
         }
         // eslint-disable-next-line no-use-before-define
         return exports.recursiveGetEpic(issue.fields.parent.key);

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -16651,7 +16651,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
+exports.setIssueStatus = exports.issueUrl = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = void 0;
 const isNil_1 = __importDefault(__webpack_require__(977));
 const node_fetch_1 = __importDefault(__webpack_require__(467));
 const Inputs_1 = __webpack_require__(968);
@@ -16663,6 +16663,8 @@ exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
 // Jira issue types.
 exports.JiraIssueTypeEpic = 'Epic';
+// Jira labels.
+exports.JiraLabelSkipPR = 'Skip_PR';
 /**
  * Fetches the issue with the given key from Jira.
  *
@@ -16707,7 +16709,7 @@ exports.getEpic = (key) => __awaiter(void 0, void 0, void 0, function* () {
     }
     if (issue.fields.parent) {
         if (issue.fields.parent.fields.issuetype.name === exports.JiraIssueTypeEpic) {
-            return issue.fields.parent;
+            return exports.getIssue(issue.fields.parent.key);
         }
         // eslint-disable-next-line no-use-before-define
         return exports.recursiveGetEpic(issue.fields.parent.key);
@@ -48076,6 +48078,7 @@ const Template_1 = __webpack_require__(920);
  * @param {string} issueKey The key of the Jira issue we will base the pull request on.
  */
 exports.createPullRequestForJiraIssue = (email, issueKey) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a, _b;
     core_1.info('Fetching the Jira issue details...');
     const issue = yield Jira_1.getIssue(issueKey);
     if (isNil_1.default(issue)) {
@@ -48131,7 +48134,9 @@ exports.createPullRequestForJiraIssue = (email, issueKey) => __awaiter(void 0, v
         const branch = yield Github_1.getBranch(repo.name, newBranchName);
         // Decide if this is an epic.
         const epic = yield Jira_1.getEpic(issue.key);
-        if (epic) {
+        if (epic &&
+            !((_a = epic.fields.labels) === null || _a === void 0 ? void 0 : _a.includes(Jira_1.JiraLabelSkipPR)) &&
+            !((_b = issue.fields.labels) === null || _b === void 0 ? void 0 : _b.includes(Jira_1.JiraLabelSkipPR))) {
             core_1.info(`Issue ${issue.key} belongs to epic ${epic.key} - creating an Epic pull request.`);
             const epicPr = yield Github_1.createEpicPullRequest(epic, issue.fields.repository);
             baseBranchName = epicPr.head.ref;

--- a/src/actions/pull-request-labeled-action/__tests__/pullRequestLabeled.test.ts
+++ b/src/actions/pull-request-labeled-action/__tests__/pullRequestLabeled.test.ts
@@ -45,7 +45,7 @@ describe('pull-request-labeled-action', () => {
         },
       } as unknown) as EventPayloads.WebhookPayloadPullRequest
       await pullRequestLabeled(automatedPayload)
-      expect(addLabelsSpy.mock.calls.length).toBe(0)
+      expect(addLabelsSpy).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/src/services/Github/__tests__/Epic.test.ts
+++ b/src/services/Github/__tests__/Epic.test.ts
@@ -102,7 +102,7 @@ describe('Epic', () => {
       )
       const pr = await createEpicPullRequest(mockJiraIssue, repo)
       expect(pr.number).toEqual(123)
-      expect(githubCreatePullRequestSpy.mock.calls.length).toBe(0)
+      expect(githubCreatePullRequestSpy).toHaveBeenCalledTimes(0)
     })
 
     it('creates a new PR', async () => {

--- a/src/services/Github/__tests__/Label.test.ts
+++ b/src/services/Github/__tests__/Label.test.ts
@@ -75,7 +75,7 @@ describe('PullRequest', () => {
 
     it('does nothing if the labels will not change', async () => {
       await addLabels(repo, 23, [InProgressLabel])
-      expect(githubSetLabelsSpy.mock.calls.length).toBe(0)
+      expect(githubSetLabelsSpy).toHaveBeenCalledTimes(0)
     })
   })
 

--- a/src/services/Jira/Issue.ts
+++ b/src/services/Jira/Issue.ts
@@ -25,6 +25,7 @@ export interface Issue {
       name: string
       subtask: boolean
     }
+    labels?: any
     parent?: Issue
     subtasks?: Issue[]
     summary: string
@@ -64,6 +65,9 @@ export const JiraStatusValidated = 'Validated'
 
 // Jira issue types.
 export const JiraIssueTypeEpic = 'Epic'
+
+// Jira labels.
+export const JiraLabelSkipPR = 'Skip_PR'
 
 /**
  * Fetches the issue with the given key from Jira.
@@ -115,7 +119,7 @@ export const getEpic = async (key: string): Promise<Issue | undefined> => {
   }
   if (issue.fields.parent) {
     if (issue.fields.parent.fields.issuetype.name === JiraIssueTypeEpic) {
-      return issue.fields.parent
+      return getIssue(issue.fields.parent.key)
     }
     // eslint-disable-next-line no-use-before-define
     return recursiveGetEpic(issue.fields.parent.key)

--- a/src/services/Jira/__tests__/Issue.test.ts
+++ b/src/services/Jira/__tests__/Issue.test.ts
@@ -82,7 +82,7 @@ describe('Issue', () => {
       )
       const result = await getEpic(issueKey)
       expect(result).toBeUndefined()
-      expect(recursiveGetEpicSpy.mock.calls.length).toBe(0)
+      expect(recursiveGetEpicSpy).toHaveBeenCalledTimes(0)
     })
 
     it('returns the issue if it is an epic', async () => {
@@ -90,7 +90,7 @@ describe('Issue', () => {
       const result = await getEpic(issueKey)
       expect(result?.key).toEqual(epicKey)
       expect(getIssueSpy).toHaveBeenCalledWith(issueKey)
-      expect(recursiveGetEpicSpy.mock.calls.length).toBe(0)
+      expect(recursiveGetEpicSpy).toHaveBeenCalledTimes(0)
     })
 
     it('returns the parent issue if it is an epic', async () => {
@@ -98,11 +98,13 @@ describe('Issue', () => {
         ...mockJiraIssue,
         fields: { ...mockJiraIssue.fields, parent: epic },
       }
-      getIssueSpy.mockImplementation((_key: string) => Promise.resolve(issue))
+      getIssueSpy
+        .mockImplementationOnce((_key: string) => Promise.resolve(issue))
+        .mockImplementationOnce((_key: string) => Promise.resolve(epic))
       const result = await getEpic(issueKey)
       expect(result?.key).toEqual(epicKey)
       expect(getIssueSpy).toHaveBeenCalledWith(issueKey)
-      expect(recursiveGetEpicSpy.mock.calls.length).toBe(0)
+      expect(recursiveGetEpicSpy).toHaveBeenCalledTimes(0)
     })
 
     it('recurses if the parent is not an epic', async () => {
@@ -113,7 +115,9 @@ describe('Issue', () => {
           parent: { ...mockJiraIssue, key: 'ISSUE-234' },
         },
       }
-      getIssueSpy.mockImplementation((_key: string) => Promise.resolve(issue))
+      getIssueSpy.mockImplementationOnce((_key: string) =>
+        Promise.resolve(issue)
+      )
       await getEpic(issueKey)
       expect(recursiveGetEpicSpy).toHaveBeenCalledWith('ISSUE-234')
     })

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -18,6 +18,7 @@ import {
   getIssue,
   getIssuePullRequestNumbers,
   issueUrl,
+  JiraLabelSkipPR,
 } from '@sr-services/Jira'
 import { sendUserMessage } from '@sr-services/Slack'
 import { parameterize } from '@sr-services/String'
@@ -110,7 +111,11 @@ export const createPullRequestForJiraIssue = async (
 
     // Decide if this is an epic.
     const epic = await getEpic(issue.key)
-    if (epic) {
+    if (
+      epic &&
+      !epic.fields.labels?.includes(JiraLabelSkipPR) &&
+      !issue.fields.labels?.includes(JiraLabelSkipPR)
+    ) {
       info(
         `Issue ${issue.key} belongs to epic ${epic.key} - creating an Epic pull request.`
       )


### PR DESCRIPTION
## Allow a label to be added to Jira issues to skip PR creation

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-652)

Eg. [https:&#x2F;&#x2F;shuttlerock.atlassian.net&#x2F;browse&#x2F;STUDIO-643|https:&#x2F;&#x2F;shuttlerock.atlassian.net&#x2F;browse&#x2F;STUDIO-643|smart-link]  - we didn’t need to make a PR here. Maybe we can have some kind of label that will allow it to be skipped? Alternatively we could not-fill-in-the-repository-field

## How to test the PR

Add the `Skip_PR` label to an epic, and then create a PR for one of its children.  The Epic PR should not be created.

## Deployment Notes

None