### PR TITLE
[STUDIO-961] Fix issue triggering pull request creation when issues are moved by Shuttlebot

### DIFF
--- a/.meta/STUDIO-961.md
+++ b/.meta/STUDIO-961.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-961
+
+Created at 2020-11-26T05:44:01.362Z

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -48757,10 +48757,13 @@ exports.createPullRequestForJiraIssue = (email, issueKey) => __awaiter(void 0, v
     core_1.info(`The Jira URL is ${jiraUrl}`);
     core_1.info('Finding out who the pull request should belong to...');
     if (isNil_1.default(issue.fields.assignee)) {
-        const credentials = yield Credentials_1.fetchCredentials(email);
-        const message = `Issue <${jiraUrl}|${issue.key}> is not assigned to anyone, so no pull request was created`;
-        yield Slack_1.sendUserMessage(credentials.slack_id, message);
-        core_1.error(message);
+        // If this issue was transitioned via automation, we won't have anyone to send messages to.
+        if (!isNil_1.default(email)) {
+            const credentials = yield Credentials_1.fetchCredentials(email);
+            const message = `Issue <${jiraUrl}|${issue.key}> is not assigned to anyone, so no pull request was created`;
+            yield Slack_1.sendUserMessage(credentials.slack_id, message);
+            core_1.error(message);
+        }
         return;
     }
     const credentialLookup = issue.fields.assignee.emailAddress || issue.fields.assignee.displayName;

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -59,10 +59,13 @@ export const createPullRequestForJiraIssue = async (
 
   info('Finding out who the pull request should belong to...')
   if (isNil(issue.fields.assignee)) {
-    const credentials = await fetchCredentials(email)
-    const message = `Issue <${jiraUrl}|${issue.key}> is not assigned to anyone, so no pull request was created`
-    await sendUserMessage(credentials.slack_id, message)
-    error(message)
+    // If this issue was transitioned via automation, we won't have anyone to send messages to.
+    if (!isNil(email)) {
+      const credentials = await fetchCredentials(email)
+      const message = `Issue <${jiraUrl}|${issue.key}> is not assigned to anyone, so no pull request was created`
+      await sendUserMessage(credentials.slack_id, message)
+      error(message)
+    }
     return
   }
   const credentialLookup =


### PR DESCRIPTION
## Fix issue triggering pull request creation when issues are moved by Shuttlebot

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-961)
[Jira Epic](https://shuttlerock.atlassian.net/browse/STUDIO-231)

See https://github.com/Shuttlerock/spielberg-ui/runs/1456190355?check_suite_focus=true

<img width="1372" alt="Screen Shot 2020-11-26 at 14 41 42" src="https://user-images.githubusercontent.com/71472294/100312624-2b4f2700-2ff6-11eb-8a10-6e42954f6bd2.png">

## How to test the PR

Trigger automation to move an unassigned PR to `In Development`, and make sure no error occurs in the action.

## Deployment Notes

None