### PR TITLE
[STUDIO-1081] Catch errors when sending messages to invalid Slack accounts

### DIFF
--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -15248,8 +15248,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.sendUserMessage = exports.sendErrorMessage = void 0;
+const isNil_1 = __importDefault(__webpack_require__(977));
 const Inputs_1 = __webpack_require__(968);
 const Client_1 = __webpack_require__(589);
 /**
@@ -15260,6 +15264,9 @@ const Client_1 = __webpack_require__(589);
  * @returns {void}
  */
 exports.sendErrorMessage = (message) => __awaiter(void 0, void 0, void 0, function* () {
+    if (isNil_1.default(message)) {
+        return;
+    }
     yield Client_1.client.chat.postMessage({
         channel: Inputs_1.slackErrorChannelId(),
         text: message,
@@ -15274,8 +15281,19 @@ exports.sendErrorMessage = (message) => __awaiter(void 0, void 0, void 0, functi
  * @returns {void}
  */
 exports.sendUserMessage = (userId, message) => __awaiter(void 0, void 0, void 0, function* () {
-    // See: https://api.slack.com/methods/chat.postMessage
-    yield Client_1.client.chat.postMessage({ channel: userId, text: message });
+    if (isNil_1.default(userId) || isNil_1.default(message)) {
+        return;
+    }
+    try {
+        // See: https://api.slack.com/methods/chat.postMessage
+        yield Client_1.client.chat.postMessage({ channel: userId, text: message });
+    }
+    catch (err) {
+        if (err.message.match(/channel_not_found/)) {
+            return;
+        }
+        throw err;
+    }
 });
 
 

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -14547,8 +14547,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.sendUserMessage = exports.sendErrorMessage = void 0;
+const isNil_1 = __importDefault(__webpack_require__(977));
 const Inputs_1 = __webpack_require__(968);
 const Client_1 = __webpack_require__(589);
 /**
@@ -14559,6 +14563,9 @@ const Client_1 = __webpack_require__(589);
  * @returns {void}
  */
 exports.sendErrorMessage = (message) => __awaiter(void 0, void 0, void 0, function* () {
+    if (isNil_1.default(message)) {
+        return;
+    }
     yield Client_1.client.chat.postMessage({
         channel: Inputs_1.slackErrorChannelId(),
         text: message,
@@ -14573,8 +14580,19 @@ exports.sendErrorMessage = (message) => __awaiter(void 0, void 0, void 0, functi
  * @returns {void}
  */
 exports.sendUserMessage = (userId, message) => __awaiter(void 0, void 0, void 0, function* () {
-    // See: https://api.slack.com/methods/chat.postMessage
-    yield Client_1.client.chat.postMessage({ channel: userId, text: message });
+    if (isNil_1.default(userId) || isNil_1.default(message)) {
+        return;
+    }
+    try {
+        // See: https://api.slack.com/methods/chat.postMessage
+        yield Client_1.client.chat.postMessage({ channel: userId, text: message });
+    }
+    catch (err) {
+        if (err.message.match(/channel_not_found/)) {
+            return;
+        }
+        throw err;
+    }
 });
 
 

--- a/src/services/Slack/Message.ts
+++ b/src/services/Slack/Message.ts
@@ -1,3 +1,5 @@
+import isNil from 'lodash/isNil'
+
 import { slackErrorChannelId } from '@sr-services/Inputs'
 import { client } from '@sr-services/Slack/Client'
 
@@ -9,6 +11,10 @@ import { client } from '@sr-services/Slack/Client'
  * @returns {void}
  */
 export const sendErrorMessage = async (message: string): Promise<void> => {
+  if (isNil(message)) {
+    return
+  }
+
   await client.chat.postMessage({
     channel: slackErrorChannelId(),
     text: message,
@@ -27,6 +33,18 @@ export const sendUserMessage = async (
   userId: string,
   message: string
 ): Promise<void> => {
-  // See: https://api.slack.com/methods/chat.postMessage
-  await client.chat.postMessage({ channel: userId, text: message })
+  if (isNil(userId) || isNil(message)) {
+    return
+  }
+
+  try {
+    // See: https://api.slack.com/methods/chat.postMessage
+    await client.chat.postMessage({ channel: userId, text: message })
+  } catch (err) {
+    if (err.message.match(/channel_not_found/)) {
+      return
+    }
+
+    throw err
+  }
 }


### PR DESCRIPTION
## Catch errors when sending messages to invalid Slack accounts

[Jira Bug](https://shuttlerock.atlassian.net/browse/STUDIO-1081)

Eg. https:&#x2F;&#x2F;github.com&#x2F;Shuttlerock&#x2F;spielberg-ui&#x2F;runs&#x2F;1507730511?check_suite_focus&#x3D;true

## How to test the PR

If tests pass, it should be fine - it just improves error handling.

## Deployment Notes

None.