### PR TITLE
[STUDIO-1083] Only send the 'Has Issues' Slack message when the issue is moved, to avoid duplicates

### DIFF
--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -42533,10 +42533,12 @@ exports.checkRunCompleted = (payload) => __awaiter(void 0, void 0, void 0, funct
     }
     core_1.info(`Adding the '${Constants_1.HasIssuesLabel}' label...`);
     yield Github_1.addLabels(repository.name, pullRequest.number, [Constants_1.HasIssuesLabel]);
-    if (issue.fields.status.name !== Jira_1.JiraStatusHasIssues) {
-        core_1.info(`Moving Jira issue ${issueKey} to '${Jira_1.JiraStatusHasIssues}'...`);
-        yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusHasIssues);
+    if (issue.fields.status.name === Jira_1.JiraStatusHasIssues) {
+        core_1.info(`Issue ${issueKey} is already in '${Jira_1.JiraStatusHasIssues}' - giving up`);
+        return;
     }
+    core_1.info(`Moving Jira issue ${issueKey} to '${Jira_1.JiraStatusHasIssues}'...`);
+    yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusHasIssues);
     if (issue.fields.assignee) {
         core_1.info('Sending a Slack message to the Jira assignee...');
         const credentialLookup = issue.fields.assignee.emailAddress || issue.fields.assignee.displayName;

--- a/src/actions/check-run-completed-action/checkRunCompleted.ts
+++ b/src/actions/check-run-completed-action/checkRunCompleted.ts
@@ -62,10 +62,13 @@ export const checkRunCompleted = async (
   info(`Adding the '${HasIssuesLabel}' label...`)
   await addLabels(repository.name, pullRequest.number, [HasIssuesLabel])
 
-  if (issue.fields.status.name !== JiraStatusHasIssues) {
-    info(`Moving Jira issue ${issueKey} to '${JiraStatusHasIssues}'...`)
-    await setIssueStatus(issue.id, JiraStatusHasIssues)
+  if (issue.fields.status.name === JiraStatusHasIssues) {
+    info(`Issue ${issueKey} is already in '${JiraStatusHasIssues}' - giving up`)
+    return
   }
+
+  info(`Moving Jira issue ${issueKey} to '${JiraStatusHasIssues}'...`)
+  await setIssueStatus(issue.id, JiraStatusHasIssues)
 
   if (issue.fields.assignee) {
     info('Sending a Slack message to the Jira assignee...')


### PR DESCRIPTION
## Only send the 'Has Issues' Slack message when the issue is moved, to avoid duplicates

[Jira Bug](https://shuttlerock.atlassian.net/browse/STUDIO-1083)



## How to test the PR

This should stop the stream of repeated `Has Issues` slack messages, but I'm not sure how to trigger it...

## Deployment Notes

None