### PR TITLE
[STUDIO-1183] Block PR creation if no points estimate has been entered for the issue

### DIFF
--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61679,6 +61679,12 @@ const createPullRequestForJiraIssue = (email, issueKey) => __awaiter(void 0, voi
         yield Slack_1.sendUserMessage(credentials.slack_id, message);
         return;
     }
+    if (isNil_1.default(issue.fields.storyPointEstimate)) {
+        const message = `No point estimate is set for issue <${jiraUrl}|${issue.key}>, so no pull request was created`;
+        core_1.error(message);
+        yield Slack_1.sendUserMessage(credentials.slack_id, message);
+        return;
+    }
     core_1.info('Checking if there is an open pull request for this issue...');
     let pullRequestNumber;
     const repo = yield Github_1.getRepository(issue.fields.repository);

--- a/src/tests/fixtures/jira-issue.json
+++ b/src/tests/fixtures/jira-issue.json
@@ -343,6 +343,7 @@
       "total": 0,
       "worklogs": []
     },
-    "repository": "actions"
+    "repository": "actions",
+    "storyPointEstimate": 11
   }
 }

--- a/src/triggers/__tests__/createPullRequestForJiraIssue.test.ts
+++ b/src/triggers/__tests__/createPullRequestForJiraIssue.test.ts
@@ -151,6 +151,19 @@ describe('createPullRequestForJiraIssue', () => {
     expect(slackSpy).toHaveBeenCalledWith(mockCredentials.slack_id, message)
   })
 
+  it('sends an error message if no Story  is set for the issue', async () => {
+    const noEstimate = {
+      ...mockJiraIssue,
+      fields: { ...mockJiraIssue.fields, storyPointEstimate: undefined },
+    }
+    jiraIssueSpy.mockImplementation((_key: string) =>
+      Promise.resolve(noEstimate)
+    )
+    await createPullRequestForJiraIssue(email, issueKey)
+    const message = `No point estimate is set for issue <https://${jiraHost()}/browse/${issueKey}|${issueKey}>, so no pull request was created`
+    expect(slackSpy).toHaveBeenCalledWith(mockCredentials.slack_id, message)
+  })
+
   it('returns an existing PR if there is one', async () => {
     jiraPrsSpy.mockImplementation((_issueId: string) => Promise.resolve([123]))
     await createPullRequestForJiraIssue(email, issueKey)

--- a/src/triggers/__tests__/jiraStoryPointsUpdated.test.ts
+++ b/src/triggers/__tests__/jiraStoryPointsUpdated.test.ts
@@ -13,11 +13,7 @@ jest.mock('@sr-services/Jira', () => ({
   JiraFieldStoryPointEstimate: 'Story point estimate',
 }))
 
-const childIssue = {
-  ...mockJiraIssue,
-  id: '20000',
-  fields: { ...mockJiraIssue.fields, storyPointEstimate: 11 },
-}
+const childIssue = { ...mockJiraIssue, id: '20000' }
 const parentIssue = {
   ...mockJiraIssue,
   fields: { ...mockJiraIssue.fields, parent: undefined },

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -93,6 +93,13 @@ export const createPullRequestForJiraIssue = async (
     return
   }
 
+  if (isNil(issue.fields.storyPointEstimate)) {
+    const message = `No point estimate is set for issue <${jiraUrl}|${issue.key}>, so no pull request was created`
+    error(message)
+    await sendUserMessage(credentials.slack_id, message)
+    return
+  }
+
   info('Checking if there is an open pull request for this issue...')
   let pullRequestNumber
   const repo = await getRepository(issue.fields.repository)


### PR DESCRIPTION
## Block PR creation if no points estimate has been entered for the issue

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-1183)
[Jira Epic](https://shuttlerock.atlassian.net/browse/STUDIO-231)



## How to test the PR

Move a Jira issue *with no point estimate* to `In Development`. You should get a slack message warning you that the PR could not be created.

## Deployment Notes

None