### PR TITLE
[STUDIO-1198] Don't automatically move epics to 'Validated'

### DIFF
--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61857,6 +61857,10 @@ const jiraIssueTransitioned = (_email, issueKey) => __awaiter(void 0, void 0, vo
     if (parent.fields.status.name === leftmost) {
         core_1.info(`The parent issue ${parent.key} is already in '${leftmost}' - nothing to do`);
     }
+    else if (parent.fields.issuetype.name === Jira_1.JiraIssueTypeEpic &&
+        leftmost === Jira_1.JiraStatusValidated) {
+        core_1.info(`The parent issue ${parent.key} is an epic, so it can't be moved to '${leftmost}' automatically - nothing to do`);
+    }
     else {
         core_1.info(`Moved the parent issue ${parent.key} to '${leftmost}'`);
         yield Jira_1.setIssueStatus(parent.id, leftmost);

--- a/src/triggers/jiraIssueTransitioned.ts
+++ b/src/triggers/jiraIssueTransitioned.ts
@@ -3,11 +3,13 @@ import isNil from 'lodash/isNil'
 import minBy from 'lodash/minBy'
 
 import {
-  JiraBoardColumn,
   getChildIssues,
   getColumns,
   getIssue,
   Issue,
+  JiraBoardColumn,
+  JiraIssueTypeEpic,
+  JiraStatusValidated,
   setIssueStatus,
 } from '@sr-services/Jira'
 
@@ -86,6 +88,13 @@ export const jiraIssueTransitioned = async (
   if (parent.fields.status.name === leftmost) {
     info(
       `The parent issue ${parent.key} is already in '${leftmost}' - nothing to do`
+    )
+  } else if (
+    parent.fields.issuetype.name === JiraIssueTypeEpic &&
+    leftmost === JiraStatusValidated
+  ) {
+    info(
+      `The parent issue ${parent.key} is an epic, so it can't be moved to '${leftmost}' automatically - nothing to do`
     )
   } else {
     info(`Moved the parent issue ${parent.key} to '${leftmost}'`)


### PR DESCRIPTION
## Don't automatically move epics to 'Validated'

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-1198)
[Jira Epic](https://shuttlerock.atlassian.net/browse/STUDIO-231)



## How to test the PR

Make an Epic with one child issue,. and move the child issue to `Validated`. The Epic should not move.

## Deployment Notes

None