### PR TITLE
[STUDIO-1201] If the status of a parent issue changes, move all of the subtasks to the board

### DIFF
--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61880,6 +61880,17 @@ const jiraIssueTransitioned = (_email, issueKey) => __awaiter(void 0, void 0, vo
         else {
             yield Jira_1.moveIssueToBoard(board.id, issue.id);
         }
+        core_1.info(`Checking if the direct children of issue ${issueKey} need to be moved to the board...`);
+        const children = yield Jira_1.getChildIssues(issueKey);
+        let moved = 0;
+        yield Promise.all(children.map((child) => __awaiter(void 0, void 0, void 0, function* () {
+            const childIsOnBoard = yield Jira_1.isIssueOnBoard(board.id, child.id);
+            if (!childIsOnBoard) {
+                yield Jira_1.moveIssueToBoard(board.id, child.id);
+                moved += 1;
+            }
+        })));
+        core_1.info(`Moved ${moved} children of issue ${issueKey} to the board`);
     }
     if (isNil_1.default(issue.fields.parent)) {
         core_1.info(`Issue ${issueKey} has no parent issue - nothing to do`);

--- a/src/triggers/jiraIssueTransitioned.ts
+++ b/src/triggers/jiraIssueTransitioned.ts
@@ -62,6 +62,22 @@ export const jiraIssueTransitioned = async (
     } else {
       await moveIssueToBoard(board.id, issue.id)
     }
+
+    info(
+      `Checking if the direct children of issue ${issueKey} need to be moved to the board...`
+    )
+    const children = await getChildIssues(issueKey)
+    let moved = 0
+    await Promise.all(
+      children.map(async (child: Issue) => {
+        const childIsOnBoard = await isIssueOnBoard(board.id, child.id)
+        if (!childIsOnBoard) {
+          await moveIssueToBoard(board.id, child.id)
+          moved += 1
+        }
+      })
+    )
+    info(`Moved ${moved} children of issue ${issueKey} to the board`)
   }
 
   if (isNil(issue.fields.parent)) {


### PR DESCRIPTION
## If the status of a parent issue changes, move all of the subtasks to the board

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-1201)
[Jira Epic](https://shuttlerock.atlassian.net/browse/STUDIO-231)



## How to test the PR

Move an issue with children that are in the backlog to any status except `Ready for planning`. The children should be moved to the board (if they weren't there already).

## Deployment Notes

None