### PR TITLE
Release Candidate 2021-01-05-0321 (Quickest Quelea)

### DIFF
--- a/.github/workflows/pull-request-closed-action.yml
+++ b/.github/workflows/pull-request-closed-action.yml
@@ -14,4 +14,5 @@ jobs:
           jira-host:   ${{ secrets.JIRA_HOST }}
           jira-token:  ${{ secrets.JIRA_TOKEN }}
           repo-token:  ${{ secrets.GITHUB_TOKEN }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
           write-token: ${{ secrets.ACTIONS_WRITE_TOKEN }}

--- a/.github/workflows/pull-request-converted-to-draft-action.yml
+++ b/.github/workflows/pull-request-converted-to-draft-action.yml
@@ -15,4 +15,5 @@ jobs:
           jira-token:        ${{ secrets.JIRA_TOKEN }}
           organization-name: ${{ secrets.ORGANIZATION_NAME }}
           repo-token:        ${{ secrets.GITHUB_TOKEN }}
+          slack-token:       ${{ secrets.SLACK_TOKEN }}
           write-token:       ${{ secrets.ACTIONS_WRITE_TOKEN }}

--- a/.github/workflows/pull-request-labeled-action.yml
+++ b/.github/workflows/pull-request-labeled-action.yml
@@ -12,4 +12,5 @@ jobs:
         with:
           organization-name: ${{ secrets.ORGANIZATION_NAME }}
           repo-token:        ${{ secrets.GITHUB_TOKEN }}
+          slack-token:       ${{ secrets.SLACK_TOKEN }}
           write-token:       ${{ secrets.ACTIONS_WRITE_TOKEN }}

--- a/.github/workflows/rebase-epic.yml
+++ b/.github/workflows/rebase-epic.yml
@@ -10,5 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Shuttlerock/actions/actions/rebase-epic-action@master
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           actions-write-token: ${{ secrets.ACTIONS_WRITE_TOKEN }}
+          repo-token:          ${{ secrets.GITHUB_TOKEN }}
+          slack-token:         ${{ secrets.SLACK_TOKEN }}

--- a/.meta/STUDIO-1232.md
+++ b/.meta/STUDIO-1232.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1232
+
+Created at 2021-01-04T23:27:39.720Z

--- a/.meta/STUDIO-1235.md
+++ b/.meta/STUDIO-1235.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1235
+
+Created at 2021-01-05T01:16:02.437Z

--- a/.meta/STUDIO-1237.md
+++ b/.meta/STUDIO-1237.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1237
+
+Created at 2021-01-05T02:40:13.159Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61373,6 +61373,10 @@ const generateReleaseName = () => {
     const letter = getRandomLetter();
     const filteredAdjectives = unique_names_generator_1.adjectives.filter((word) => word.startsWith(letter));
     const filteredAnimals = unique_names_generator_1.animals.filter((word) => word.startsWith(letter));
+    // If either of the candidate dictionaries are empty, try again with (hopefully) a different letter.
+    if (filteredAdjectives.length === 0 || filteredAnimals.length === 0) {
+        return exports.generateReleaseName();
+    }
     const releaseName = unique_names_generator_1.uniqueNamesGenerator({
         dictionaries: [filteredAdjectives, filteredAnimals],
         separator: ' ',

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -34683,6 +34683,90 @@ module.exports = isBuffer;
 
 /***/ }),
 
+/***/ 2384:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var baseKeys = __webpack_require__(7164),
+    getTag = __webpack_require__(941),
+    isArguments = __webpack_require__(8495),
+    isArray = __webpack_require__(4869),
+    isArrayLike = __webpack_require__(8017),
+    isBuffer = __webpack_require__(4190),
+    isPrototype = __webpack_require__(10),
+    isTypedArray = __webpack_require__(2496);
+
+/** `Object#toString` result references. */
+var mapTag = '[object Map]',
+    setTag = '[object Set]';
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Checks if `value` is an empty object, collection, map, or set.
+ *
+ * Objects are considered empty if they have no own enumerable string keyed
+ * properties.
+ *
+ * Array-like values such as `arguments` objects, arrays, buffers, strings, or
+ * jQuery-like collections are considered empty if they have a `length` of `0`.
+ * Similarly, maps and sets are considered empty if they have a `size` of `0`.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is empty, else `false`.
+ * @example
+ *
+ * _.isEmpty(null);
+ * // => true
+ *
+ * _.isEmpty(true);
+ * // => true
+ *
+ * _.isEmpty(1);
+ * // => true
+ *
+ * _.isEmpty([1, 2, 3]);
+ * // => false
+ *
+ * _.isEmpty({ 'a': 1 });
+ * // => false
+ */
+function isEmpty(value) {
+  if (value == null) {
+    return true;
+  }
+  if (isArrayLike(value) &&
+      (isArray(value) || typeof value == 'string' || typeof value.splice == 'function' ||
+        isBuffer(value) || isTypedArray(value) || isArguments(value))) {
+    return !value.length;
+  }
+  var tag = getTag(value);
+  if (tag == mapTag || tag == setTag) {
+    return !value.size;
+  }
+  if (isPrototype(value)) {
+    return !baseKeys(value).length;
+  }
+  for (var key in value) {
+    if (hasOwnProperty.call(value, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = isEmpty;
+
+
+/***/ }),
+
 /***/ 52:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -59800,7 +59884,7 @@ exports.run().catch(err => {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
 // Labels.
 exports.EpicLabel = 'epic';
 exports.HasConflictsLabel = 'has-conflicts';
@@ -59809,6 +59893,7 @@ exports.HasIssuesLabel = 'has-issues';
 exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
+exports.ReleaseLabel = 'release';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';
@@ -60515,12 +60600,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createReleasePullRequest = void 0;
 const core_1 = __webpack_require__(2186);
 const dateformat_1 = __importDefault(__webpack_require__(1512));
+const isEmpty_1 = __importDefault(__webpack_require__(2384));
 const isNil_1 = __importDefault(__webpack_require__(4977));
 const Constants_1 = __webpack_require__(7682);
 const Credentials_1 = __webpack_require__(3543);
 const Branch_1 = __webpack_require__(7866);
 const Client_1 = __webpack_require__(2818);
 const Git_1 = __webpack_require__(8433);
+const Label_1 = __webpack_require__(3146);
 const PullRequest_1 = __webpack_require__(8028);
 const Repository_1 = __webpack_require__(5015);
 const Inputs_1 = __webpack_require__(5968);
@@ -60689,6 +60776,26 @@ const createReleasePullRequest = (email, repo) => __awaiter(void 0, void 0, void
     if (isNil_1.default(pullRequest)) {
         const message = `An unknown error occurred while creating a release pull request for repository '${repo.name}'`;
         return reportError(credentials.slack_id, message);
+    }
+    // Assign someone, if no-one has been assigned yet.
+    if (isEmpty_1.default(pullRequest.assignees)) {
+        if (isNil_1.default(credentials.github_username)) {
+            core_1.info(`Credentials for ${email} don't have a Github account linked, so we can't assign an owner`);
+        }
+        else {
+            core_1.info(`Assigning @${credentials.github_username} as the owner...`);
+            yield PullRequest_1.assignOwners(repo.name, pullRequest.number, [
+                credentials.github_username,
+            ]);
+        }
+    }
+    // Add labels, if the PR has not been labeled yet.
+    if (isEmpty_1.default(pullRequest.labels)) {
+        core_1.info(`Adding labels '${Constants_1.InProgressLabel}' and '${Constants_1.ReleaseLabel}'...`);
+        yield Label_1.setLabels(repo.name, pullRequest.number, [
+            Constants_1.InProgressLabel,
+            Constants_1.ReleaseLabel,
+        ]);
     }
     return reportInfo(credentials.slack_id, `Here's your release PR: ${PullRequest_1.pullRequestUrl(repo.name, pullRequest.number)}`);
 });

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61361,7 +61361,7 @@ exports.parameterize = parameterize;
  * @returns {string} A letter.
  */
 const getRandomLetter = () => {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    const alphabet = 'abcdefghijklmnopqrstuvwyz';
     return alphabet[Math.floor(Math.random() * alphabet.length)];
 };
 /**

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61344,6 +61344,10 @@ const generateReleaseName = () => {
     const letter = getRandomLetter();
     const filteredAdjectives = unique_names_generator_1.adjectives.filter((word) => word.startsWith(letter));
     const filteredAnimals = unique_names_generator_1.animals.filter((word) => word.startsWith(letter));
+    // If either of the candidate dictionaries are empty, try again with (hopefully) a different letter.
+    if (filteredAdjectives.length === 0 || filteredAnimals.length === 0) {
+        return exports.generateReleaseName();
+    }
     const releaseName = unique_names_generator_1.uniqueNamesGenerator({
         dictionaries: [filteredAdjectives, filteredAnimals],
         separator: ' ',

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61332,7 +61332,7 @@ exports.parameterize = parameterize;
  * @returns {string} A letter.
  */
 const getRandomLetter = () => {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    const alphabet = 'abcdefghijklmnopqrstuvwyz';
     return alphabet[Math.floor(Math.random() * alphabet.length)];
 };
 /**

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61343,6 +61343,10 @@ const generateReleaseName = () => {
     const letter = getRandomLetter();
     const filteredAdjectives = unique_names_generator_1.adjectives.filter((word) => word.startsWith(letter));
     const filteredAnimals = unique_names_generator_1.animals.filter((word) => word.startsWith(letter));
+    // If either of the candidate dictionaries are empty, try again with (hopefully) a different letter.
+    if (filteredAdjectives.length === 0 || filteredAnimals.length === 0) {
+        return exports.generateReleaseName();
+    }
     const releaseName = unique_names_generator_1.uniqueNamesGenerator({
         dictionaries: [filteredAdjectives, filteredAnimals],
         separator: ' ',

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -34683,6 +34683,90 @@ module.exports = isBuffer;
 
 /***/ }),
 
+/***/ 2384:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var baseKeys = __webpack_require__(7164),
+    getTag = __webpack_require__(941),
+    isArguments = __webpack_require__(8495),
+    isArray = __webpack_require__(4869),
+    isArrayLike = __webpack_require__(8017),
+    isBuffer = __webpack_require__(4190),
+    isPrototype = __webpack_require__(10),
+    isTypedArray = __webpack_require__(2496);
+
+/** `Object#toString` result references. */
+var mapTag = '[object Map]',
+    setTag = '[object Set]';
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Checks if `value` is an empty object, collection, map, or set.
+ *
+ * Objects are considered empty if they have no own enumerable string keyed
+ * properties.
+ *
+ * Array-like values such as `arguments` objects, arrays, buffers, strings, or
+ * jQuery-like collections are considered empty if they have a `length` of `0`.
+ * Similarly, maps and sets are considered empty if they have a `size` of `0`.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is empty, else `false`.
+ * @example
+ *
+ * _.isEmpty(null);
+ * // => true
+ *
+ * _.isEmpty(true);
+ * // => true
+ *
+ * _.isEmpty(1);
+ * // => true
+ *
+ * _.isEmpty([1, 2, 3]);
+ * // => false
+ *
+ * _.isEmpty({ 'a': 1 });
+ * // => false
+ */
+function isEmpty(value) {
+  if (value == null) {
+    return true;
+  }
+  if (isArrayLike(value) &&
+      (isArray(value) || typeof value == 'string' || typeof value.splice == 'function' ||
+        isBuffer(value) || isTypedArray(value) || isArguments(value))) {
+    return !value.length;
+  }
+  var tag = getTag(value);
+  if (tag == mapTag || tag == setTag) {
+    return !value.size;
+  }
+  if (isPrototype(value)) {
+    return !baseKeys(value).length;
+  }
+  for (var key in value) {
+    if (hasOwnProperty.call(value, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = isEmpty;
+
+
+/***/ }),
+
 /***/ 52:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -59770,7 +59854,7 @@ exports.pullRequestConvertedToDraft = pullRequestConvertedToDraft;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
 // Labels.
 exports.EpicLabel = 'epic';
 exports.HasConflictsLabel = 'has-conflicts';
@@ -59779,6 +59863,7 @@ exports.HasIssuesLabel = 'has-issues';
 exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
+exports.ReleaseLabel = 'release';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';
@@ -60485,12 +60570,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createReleasePullRequest = void 0;
 const core_1 = __webpack_require__(2186);
 const dateformat_1 = __importDefault(__webpack_require__(1512));
+const isEmpty_1 = __importDefault(__webpack_require__(2384));
 const isNil_1 = __importDefault(__webpack_require__(4977));
 const Constants_1 = __webpack_require__(7682);
 const Credentials_1 = __webpack_require__(3543);
 const Branch_1 = __webpack_require__(7866);
 const Client_1 = __webpack_require__(2818);
 const Git_1 = __webpack_require__(8433);
+const Label_1 = __webpack_require__(3146);
 const PullRequest_1 = __webpack_require__(8028);
 const Repository_1 = __webpack_require__(5015);
 const Inputs_1 = __webpack_require__(5968);
@@ -60659,6 +60746,26 @@ const createReleasePullRequest = (email, repo) => __awaiter(void 0, void 0, void
     if (isNil_1.default(pullRequest)) {
         const message = `An unknown error occurred while creating a release pull request for repository '${repo.name}'`;
         return reportError(credentials.slack_id, message);
+    }
+    // Assign someone, if no-one has been assigned yet.
+    if (isEmpty_1.default(pullRequest.assignees)) {
+        if (isNil_1.default(credentials.github_username)) {
+            core_1.info(`Credentials for ${email} don't have a Github account linked, so we can't assign an owner`);
+        }
+        else {
+            core_1.info(`Assigning @${credentials.github_username} as the owner...`);
+            yield PullRequest_1.assignOwners(repo.name, pullRequest.number, [
+                credentials.github_username,
+            ]);
+        }
+    }
+    // Add labels, if the PR has not been labeled yet.
+    if (isEmpty_1.default(pullRequest.labels)) {
+        core_1.info(`Adding labels '${Constants_1.InProgressLabel}' and '${Constants_1.ReleaseLabel}'...`);
+        yield Label_1.setLabels(repo.name, pullRequest.number, [
+            Constants_1.InProgressLabel,
+            Constants_1.ReleaseLabel,
+        ]);
     }
     return reportInfo(credentials.slack_id, `Here's your release PR: ${PullRequest_1.pullRequestUrl(repo.name, pullRequest.number)}`);
 });

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61331,7 +61331,7 @@ exports.parameterize = parameterize;
  * @returns {string} A letter.
  */
 const getRandomLetter = () => {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    const alphabet = 'abcdefghijklmnopqrstuvwyz';
     return alphabet[Math.floor(Math.random() * alphabet.length)];
 };
 /**

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61322,6 +61322,10 @@ const generateReleaseName = () => {
     const letter = getRandomLetter();
     const filteredAdjectives = unique_names_generator_1.adjectives.filter((word) => word.startsWith(letter));
     const filteredAnimals = unique_names_generator_1.animals.filter((word) => word.startsWith(letter));
+    // If either of the candidate dictionaries are empty, try again with (hopefully) a different letter.
+    if (filteredAdjectives.length === 0 || filteredAnimals.length === 0) {
+        return exports.generateReleaseName();
+    }
     const releaseName = unique_names_generator_1.uniqueNamesGenerator({
         dictionaries: [filteredAdjectives, filteredAnimals],
         separator: ' ',

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61310,7 +61310,7 @@ exports.parameterize = parameterize;
  * @returns {string} A letter.
  */
 const getRandomLetter = () => {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    const alphabet = 'abcdefghijklmnopqrstuvwyz';
     return alphabet[Math.floor(Math.random() * alphabet.length)];
 };
 /**

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -34683,6 +34683,90 @@ module.exports = isBuffer;
 
 /***/ }),
 
+/***/ 2384:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var baseKeys = __webpack_require__(7164),
+    getTag = __webpack_require__(941),
+    isArguments = __webpack_require__(8495),
+    isArray = __webpack_require__(4869),
+    isArrayLike = __webpack_require__(8017),
+    isBuffer = __webpack_require__(4190),
+    isPrototype = __webpack_require__(10),
+    isTypedArray = __webpack_require__(2496);
+
+/** `Object#toString` result references. */
+var mapTag = '[object Map]',
+    setTag = '[object Set]';
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Checks if `value` is an empty object, collection, map, or set.
+ *
+ * Objects are considered empty if they have no own enumerable string keyed
+ * properties.
+ *
+ * Array-like values such as `arguments` objects, arrays, buffers, strings, or
+ * jQuery-like collections are considered empty if they have a `length` of `0`.
+ * Similarly, maps and sets are considered empty if they have a `size` of `0`.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is empty, else `false`.
+ * @example
+ *
+ * _.isEmpty(null);
+ * // => true
+ *
+ * _.isEmpty(true);
+ * // => true
+ *
+ * _.isEmpty(1);
+ * // => true
+ *
+ * _.isEmpty([1, 2, 3]);
+ * // => false
+ *
+ * _.isEmpty({ 'a': 1 });
+ * // => false
+ */
+function isEmpty(value) {
+  if (value == null) {
+    return true;
+  }
+  if (isArrayLike(value) &&
+      (isArray(value) || typeof value == 'string' || typeof value.splice == 'function' ||
+        isBuffer(value) || isTypedArray(value) || isArguments(value))) {
+    return !value.length;
+  }
+  var tag = getTag(value);
+  if (tag == mapTag || tag == setTag) {
+    return !value.size;
+  }
+  if (isPrototype(value)) {
+    return !baseKeys(value).length;
+  }
+  for (var key in value) {
+    if (hasOwnProperty.call(value, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = isEmpty;
+
+
+/***/ }),
+
 /***/ 52:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -59749,7 +59833,7 @@ exports.pullRequestLabeled = pullRequestLabeled;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
 // Labels.
 exports.EpicLabel = 'epic';
 exports.HasConflictsLabel = 'has-conflicts';
@@ -59758,6 +59842,7 @@ exports.HasIssuesLabel = 'has-issues';
 exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
+exports.ReleaseLabel = 'release';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';
@@ -60464,12 +60549,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createReleasePullRequest = void 0;
 const core_1 = __webpack_require__(2186);
 const dateformat_1 = __importDefault(__webpack_require__(1512));
+const isEmpty_1 = __importDefault(__webpack_require__(2384));
 const isNil_1 = __importDefault(__webpack_require__(4977));
 const Constants_1 = __webpack_require__(7682);
 const Credentials_1 = __webpack_require__(3543);
 const Branch_1 = __webpack_require__(7866);
 const Client_1 = __webpack_require__(2818);
 const Git_1 = __webpack_require__(8433);
+const Label_1 = __webpack_require__(3146);
 const PullRequest_1 = __webpack_require__(8028);
 const Repository_1 = __webpack_require__(5015);
 const Inputs_1 = __webpack_require__(5968);
@@ -60638,6 +60725,26 @@ const createReleasePullRequest = (email, repo) => __awaiter(void 0, void 0, void
     if (isNil_1.default(pullRequest)) {
         const message = `An unknown error occurred while creating a release pull request for repository '${repo.name}'`;
         return reportError(credentials.slack_id, message);
+    }
+    // Assign someone, if no-one has been assigned yet.
+    if (isEmpty_1.default(pullRequest.assignees)) {
+        if (isNil_1.default(credentials.github_username)) {
+            core_1.info(`Credentials for ${email} don't have a Github account linked, so we can't assign an owner`);
+        }
+        else {
+            core_1.info(`Assigning @${credentials.github_username} as the owner...`);
+            yield PullRequest_1.assignOwners(repo.name, pullRequest.number, [
+                credentials.github_username,
+            ]);
+        }
+    }
+    // Add labels, if the PR has not been labeled yet.
+    if (isEmpty_1.default(pullRequest.labels)) {
+        core_1.info(`Adding labels '${Constants_1.InProgressLabel}' and '${Constants_1.ReleaseLabel}'...`);
+        yield Label_1.setLabels(repo.name, pullRequest.number, [
+            Constants_1.InProgressLabel,
+            Constants_1.ReleaseLabel,
+        ]);
     }
     return reportInfo(credentials.slack_id, `Here's your release PR: ${PullRequest_1.pullRequestUrl(repo.name, pullRequest.number)}`);
 });

--- a/actions/pull-request-ready-for-review-action/action.yml
+++ b/actions/pull-request-ready-for-review-action/action.yml
@@ -19,7 +19,5 @@ inputs:
     description: 'The name of the Github organization'
   repo-token:
     description: 'Github access token'
-  slack-token:
-    description: 'Slack access token with write access'
   write-token:
     description: 'Github access token with write access'

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61351,6 +61351,10 @@ const generateReleaseName = () => {
     const letter = getRandomLetter();
     const filteredAdjectives = unique_names_generator_1.adjectives.filter((word) => word.startsWith(letter));
     const filteredAnimals = unique_names_generator_1.animals.filter((word) => word.startsWith(letter));
+    // If either of the candidate dictionaries are empty, try again with (hopefully) a different letter.
+    if (filteredAdjectives.length === 0 || filteredAnimals.length === 0) {
+        return exports.generateReleaseName();
+    }
     const releaseName = unique_names_generator_1.uniqueNamesGenerator({
         dictionaries: [filteredAdjectives, filteredAnimals],
         separator: ' ',

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -34683,6 +34683,90 @@ module.exports = isBuffer;
 
 /***/ }),
 
+/***/ 2384:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var baseKeys = __webpack_require__(7164),
+    getTag = __webpack_require__(941),
+    isArguments = __webpack_require__(8495),
+    isArray = __webpack_require__(4869),
+    isArrayLike = __webpack_require__(8017),
+    isBuffer = __webpack_require__(4190),
+    isPrototype = __webpack_require__(10),
+    isTypedArray = __webpack_require__(2496);
+
+/** `Object#toString` result references. */
+var mapTag = '[object Map]',
+    setTag = '[object Set]';
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Checks if `value` is an empty object, collection, map, or set.
+ *
+ * Objects are considered empty if they have no own enumerable string keyed
+ * properties.
+ *
+ * Array-like values such as `arguments` objects, arrays, buffers, strings, or
+ * jQuery-like collections are considered empty if they have a `length` of `0`.
+ * Similarly, maps and sets are considered empty if they have a `size` of `0`.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is empty, else `false`.
+ * @example
+ *
+ * _.isEmpty(null);
+ * // => true
+ *
+ * _.isEmpty(true);
+ * // => true
+ *
+ * _.isEmpty(1);
+ * // => true
+ *
+ * _.isEmpty([1, 2, 3]);
+ * // => false
+ *
+ * _.isEmpty({ 'a': 1 });
+ * // => false
+ */
+function isEmpty(value) {
+  if (value == null) {
+    return true;
+  }
+  if (isArrayLike(value) &&
+      (isArray(value) || typeof value == 'string' || typeof value.splice == 'function' ||
+        isBuffer(value) || isTypedArray(value) || isArguments(value))) {
+    return !value.length;
+  }
+  var tag = getTag(value);
+  if (tag == mapTag || tag == setTag) {
+    return !value.size;
+  }
+  if (isPrototype(value)) {
+    return !baseKeys(value).length;
+  }
+  for (var key in value) {
+    if (hasOwnProperty.call(value, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = isEmpty;
+
+
+/***/ }),
+
 /***/ 52:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -59778,7 +59862,7 @@ exports.pullRequestReadyForReview = pullRequestReadyForReview;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
 // Labels.
 exports.EpicLabel = 'epic';
 exports.HasConflictsLabel = 'has-conflicts';
@@ -59787,6 +59871,7 @@ exports.HasIssuesLabel = 'has-issues';
 exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
+exports.ReleaseLabel = 'release';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';
@@ -60493,12 +60578,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createReleasePullRequest = void 0;
 const core_1 = __webpack_require__(2186);
 const dateformat_1 = __importDefault(__webpack_require__(1512));
+const isEmpty_1 = __importDefault(__webpack_require__(2384));
 const isNil_1 = __importDefault(__webpack_require__(4977));
 const Constants_1 = __webpack_require__(7682);
 const Credentials_1 = __webpack_require__(3543);
 const Branch_1 = __webpack_require__(7866);
 const Client_1 = __webpack_require__(2818);
 const Git_1 = __webpack_require__(8433);
+const Label_1 = __webpack_require__(3146);
 const PullRequest_1 = __webpack_require__(8028);
 const Repository_1 = __webpack_require__(5015);
 const Inputs_1 = __webpack_require__(5968);
@@ -60667,6 +60754,26 @@ const createReleasePullRequest = (email, repo) => __awaiter(void 0, void 0, void
     if (isNil_1.default(pullRequest)) {
         const message = `An unknown error occurred while creating a release pull request for repository '${repo.name}'`;
         return reportError(credentials.slack_id, message);
+    }
+    // Assign someone, if no-one has been assigned yet.
+    if (isEmpty_1.default(pullRequest.assignees)) {
+        if (isNil_1.default(credentials.github_username)) {
+            core_1.info(`Credentials for ${email} don't have a Github account linked, so we can't assign an owner`);
+        }
+        else {
+            core_1.info(`Assigning @${credentials.github_username} as the owner...`);
+            yield PullRequest_1.assignOwners(repo.name, pullRequest.number, [
+                credentials.github_username,
+            ]);
+        }
+    }
+    // Add labels, if the PR has not been labeled yet.
+    if (isEmpty_1.default(pullRequest.labels)) {
+        core_1.info(`Adding labels '${Constants_1.InProgressLabel}' and '${Constants_1.ReleaseLabel}'...`);
+        yield Label_1.setLabels(repo.name, pullRequest.number, [
+            Constants_1.InProgressLabel,
+            Constants_1.ReleaseLabel,
+        ]);
     }
     return reportInfo(credentials.slack_id, `Here's your release PR: ${PullRequest_1.pullRequestUrl(repo.name, pullRequest.number)}`);
 });

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61339,7 +61339,7 @@ exports.parameterize = parameterize;
  * @returns {string} A letter.
  */
 const getRandomLetter = () => {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    const alphabet = 'abcdefghijklmnopqrstuvwyz';
     return alphabet[Math.floor(Math.random() * alphabet.length)];
 };
 /**

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -62182,6 +62182,10 @@ const generateReleaseName = () => {
     const letter = getRandomLetter();
     const filteredAdjectives = unique_names_generator_1.adjectives.filter((word) => word.startsWith(letter));
     const filteredAnimals = unique_names_generator_1.animals.filter((word) => word.startsWith(letter));
+    // If either of the candidate dictionaries are empty, try again with (hopefully) a different letter.
+    if (filteredAdjectives.length === 0 || filteredAnimals.length === 0) {
+        return exports.generateReleaseName();
+    }
     const releaseName = unique_names_generator_1.uniqueNamesGenerator({
         dictionaries: [filteredAdjectives, filteredAnimals],
         separator: ' ',

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -60597,7 +60597,6 @@ exports.run().catch((err) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.error(err);
     core_1.error(err.stack);
     yield Slack_1.sendErrorMessage(err.message);
-    //
     core_1.setFailed(err.message);
 }));
 
@@ -62171,7 +62170,7 @@ exports.parameterize = parameterize;
  * @returns {string} A letter.
  */
 const getRandomLetter = () => {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    const alphabet = 'abcdefghijklmnopqrstuvwyz';
     return alphabet[Math.floor(Math.random() * alphabet.length)];
 };
 /**

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -35408,6 +35408,90 @@ module.exports = isBuffer;
 
 /***/ }),
 
+/***/ 53912:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+var baseKeys = __webpack_require__(67164),
+    getTag = __webpack_require__(50941),
+    isArguments = __webpack_require__(78495),
+    isArray = __webpack_require__(44869),
+    isArrayLike = __webpack_require__(18017),
+    isBuffer = __webpack_require__(74190),
+    isPrototype = __webpack_require__(60010),
+    isTypedArray = __webpack_require__(2496);
+
+/** `Object#toString` result references. */
+var mapTag = '[object Map]',
+    setTag = '[object Set]';
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Checks if `value` is an empty object, collection, map, or set.
+ *
+ * Objects are considered empty if they have no own enumerable string keyed
+ * properties.
+ *
+ * Array-like values such as `arguments` objects, arrays, buffers, strings, or
+ * jQuery-like collections are considered empty if they have a `length` of `0`.
+ * Similarly, maps and sets are considered empty if they have a `size` of `0`.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is empty, else `false`.
+ * @example
+ *
+ * _.isEmpty(null);
+ * // => true
+ *
+ * _.isEmpty(true);
+ * // => true
+ *
+ * _.isEmpty(1);
+ * // => true
+ *
+ * _.isEmpty([1, 2, 3]);
+ * // => false
+ *
+ * _.isEmpty({ 'a': 1 });
+ * // => false
+ */
+function isEmpty(value) {
+  if (value == null) {
+    return true;
+  }
+  if (isArrayLike(value) &&
+      (isArray(value) || typeof value == 'string' || typeof value.splice == 'function' ||
+        isBuffer(value) || isTypedArray(value) || isArguments(value))) {
+    return !value.length;
+  }
+  var tag = getTag(value);
+  if (tag == mapTag || tag == setTag) {
+    return !value.size;
+  }
+  if (isPrototype(value)) {
+    return !baseKeys(value).length;
+  }
+  for (var key in value) {
+    if (hasOwnProperty.call(value, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = isEmpty;
+
+
+/***/ }),
+
 /***/ 20052:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -60609,7 +60693,7 @@ exports.run().catch((err) => __awaiter(void 0, void 0, void 0, function* () {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = void 0;
 // Labels.
 exports.EpicLabel = 'epic';
 exports.HasConflictsLabel = 'has-conflicts';
@@ -60618,6 +60702,7 @@ exports.HasIssuesLabel = 'has-issues';
 exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
+exports.ReleaseLabel = 'release';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';
@@ -61324,12 +61409,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createReleasePullRequest = void 0;
 const core_1 = __webpack_require__(42186);
 const dateformat_1 = __importDefault(__webpack_require__(51512));
+const isEmpty_1 = __importDefault(__webpack_require__(53912));
 const isNil_1 = __importDefault(__webpack_require__(84977));
 const Constants_1 = __webpack_require__(17682);
 const Credentials_1 = __webpack_require__(43543);
 const Branch_1 = __webpack_require__(37866);
 const Client_1 = __webpack_require__(32818);
 const Git_1 = __webpack_require__(8433);
+const Label_1 = __webpack_require__(13146);
 const PullRequest_1 = __webpack_require__(88028);
 const Repository_1 = __webpack_require__(35015);
 const Inputs_1 = __webpack_require__(25968);
@@ -61498,6 +61585,26 @@ const createReleasePullRequest = (email, repo) => __awaiter(void 0, void 0, void
     if (isNil_1.default(pullRequest)) {
         const message = `An unknown error occurred while creating a release pull request for repository '${repo.name}'`;
         return reportError(credentials.slack_id, message);
+    }
+    // Assign someone, if no-one has been assigned yet.
+    if (isEmpty_1.default(pullRequest.assignees)) {
+        if (isNil_1.default(credentials.github_username)) {
+            core_1.info(`Credentials for ${email} don't have a Github account linked, so we can't assign an owner`);
+        }
+        else {
+            core_1.info(`Assigning @${credentials.github_username} as the owner...`);
+            yield PullRequest_1.assignOwners(repo.name, pullRequest.number, [
+                credentials.github_username,
+            ]);
+        }
+    }
+    // Add labels, if the PR has not been labeled yet.
+    if (isEmpty_1.default(pullRequest.labels)) {
+        core_1.info(`Adding labels '${Constants_1.InProgressLabel}' and '${Constants_1.ReleaseLabel}'...`);
+        yield Label_1.setLabels(repo.name, pullRequest.number, [
+            Constants_1.InProgressLabel,
+            Constants_1.ReleaseLabel,
+        ]);
     }
     return reportInfo(credentials.slack_id, `Here's your release PR: ${PullRequest_1.pullRequestUrl(repo.name, pullRequest.number)}`);
 });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.167",
     "@types/mustache": "^4.1.0",
-    "@types/node": "^14.14.17",
+    "@types/node": "^14.14.19",
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/parser": "^4.11.1",
     "@vercel/ncc": "0.26.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-github": "^4.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
-    "eslint-plugin-jsdoc": "^30.7.9",
+    "eslint-plugin-jsdoc": "^30.7.13",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.0",
     "eslint-plugin-unused-imports": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "husky": "^4.3.6",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^4.0.0",
     "lint-staged": "^10.5.3",
     "prettier": "2.2.1",
     "ts-jest": "^26.4.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.19",
     "@types/jira-client": "^6.13.1",
-    "@types/lodash": "^4.14.166",
+    "@types/lodash": "^4.14.167",
     "@types/mustache": "^4.1.0",
     "@types/node": "^14.14.17",
     "@types/node-fetch": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/parser": "^4.11.1",
     "@vercel/ncc": "0.26.1",
-    "eslint": "^7.16.0",
+    "eslint": "^7.17.0",
     "eslint-config-airbnb-typescript": "^12.0.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/src/actions/trigger-action/__tests__/fixtures/createRelease.json
+++ b/src/actions/trigger-action/__tests__/fixtures/createRelease.json
@@ -3,6 +3,6 @@
   "inputs": {
     "email": "dave@shuttlerock.com",
     "event": "createRelease",
-    "param": "nolan"
+    "param": "gatekeeper"
   }
 }

--- a/src/services/Constants.ts
+++ b/src/services/Constants.ts
@@ -6,6 +6,7 @@ export const HasIssuesLabel = 'has-issues'
 export const InProgressLabel = 'in-progress'
 export const PassedReviewLabel = 'passed-review'
 export const PleaseReviewLabel = 'please-review'
+export const ReleaseLabel = 'release'
 export const UnderDiscussionLabel = 'under-discussion'
 
 // The Github user our actions use.

--- a/src/services/String.ts
+++ b/src/services/String.ts
@@ -41,6 +41,12 @@ export const generateReleaseName = (): string => {
   const filteredAnimals = animals.filter((word: string) =>
     word.startsWith(letter)
   )
+
+  // If either of the candidate dictionaries are empty, try again with (hopefully) a different letter.
+  if (filteredAdjectives.length === 0 || filteredAnimals.length === 0) {
+    return generateReleaseName()
+  }
+
   const releaseName = uniqueNamesGenerator({
     dictionaries: [filteredAdjectives, filteredAnimals],
     separator: ' ',

--- a/src/services/String.ts
+++ b/src/services/String.ts
@@ -24,7 +24,7 @@ export const parameterize = (str: string): string =>
  * @returns {string} A letter.
  */
 const getRandomLetter = (): string => {
-  const alphabet = 'abcdefghijklmnopqrstuvwxyz'
+  const alphabet = 'abcdefghijklmnopqrstuvwyz'
   return alphabet[Math.floor(Math.random() * alphabet.length)]
 }
 

--- a/src/tests/fixtures/github-pull-request-payload.json
+++ b/src/tests/fixtures/github-pull-request-payload.json
@@ -1,6 +1,7 @@
 {
   "action": "closed",
   "pull_request": {
+    "assignees": [],
     "body": "## When a PR is merged, move to `Validated`\n\n[Jira Tech task](https://example.atlassian.net/browse/ISSUE-123)\n\n## How to test the PR",
     "head": {
       "ref": "feature/create-epic-prs"

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,10 +827,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.166":
-  version "4.14.166"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.166.tgz#07e7f2699a149219dbc3c35574f126ec8737688f"
-  integrity sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA==
+"@types/lodash@^4.14.167":
+  version "4.14.167"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
+  integrity sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==
 
 "@types/minimatch@*":
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,6 +1163,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -3575,13 +3580,20 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.14.1:
+js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,10 +2174,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.11.0, eslint@^7.16.0:
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.16.0.tgz#a761605bf9a7b32d24bb7cde59aeb0fd76f06092"
-  integrity sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==
+eslint@^7.11.0, eslint@^7.17.0:
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.17.0.tgz#4ccda5bf12572ad3bf760e6f195886f50569adb0"
+  integrity sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@eslint/eslintrc" "^0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@ eslint-plugin-jest@^24.1.3:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-jsdoc@^30.7.9:
-  version "30.7.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.9.tgz#b0a9881990edc1bc8a635467bad9edfae9ecbaaf"
-  integrity sha512-qMM0fNx7/6OCnIh3jRpIrEBAhTG1THNXXbr3yfJ8yqLrDbzJR98xsstX25xt9GCPlrjNc/bBpTHfJQOvn7nVMA==
+eslint-plugin-jsdoc@^30.7.13:
+  version "30.7.13"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz#52e5c74fb806d3bbeb51d04a0c829508c3c6b563"
+  integrity sha512-YM4WIsmurrp0rHX6XiXQppqKB8Ne5ATiZLJe2+/fkp9l9ExXFr43BbAbjZaVrpCT+tuPYOZ8k1MICARHnURUNQ==
   dependencies:
     comment-parser "^0.7.6"
     debug "^4.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,10 +850,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=8.9.0", "@types/node@^14.14.17":
-  version "14.14.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.17.tgz#29fab92f3986c0e379968ad3c2043683d8020dbb"
-  integrity sha512-G0lD1/7qD60TJ/mZmhog76k7NcpLWkPVGgzkRy3CTlnFu4LUQh5v2Wa661z6vnXmD8EQrnALUyf0VRtrACYztw==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=8.9.0", "@types/node@^14.14.19":
+  version "14.14.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.19.tgz#5135176a8330b88ece4e9ab1fdcfc0a545b4bab4"
+  integrity sha512-4nhBPStMK04rruRVtVc6cDqhu7S9GZai0fpXgPXrFpcPX6Xul8xnrjSdGB4KPBVYG/R5+fXWdCM8qBoiULWGPQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
## Release Candidate 2021-01-05-0321 (Quickest Quelea)

### Pull Requests

- #252 Always include the slack-token in workflows, for reporting errors
- #254 Don't use release names that start with X - there's no adjectives
- #256 Add an owner and labels when creating a release PR

### Dependency updates

- a7a9503 Bump eslint from 7.16.0 to 7.17.0
- b733ff6 Bump @types/lodash from 4.14.166 to 4.14.167
- fc9317c Bump eslint-plugin-jsdoc from 30.7.9 to 30.7.13
- e3eeb10 Bump js-yaml from 3.14.1 to 4.0.0
- d0720b7 Bump @types/node from 14.14.17 to 14.14.19
