### PR TITLE
[STUDIO-1267] Fix ready-for-review action for release PRs

### DIFF
--- a/.meta/STUDIO-1267.md
+++ b/.meta/STUDIO-1267.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1267
+
+Created at 2021-01-12T03:26:00.168Z

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60294,6 +60294,13 @@ const Jira_1 = __nccwpck_require__(404);
  */
 const pullRequestReadyForReview = (payload) => __awaiter(void 0, void 0, void 0, function* () {
     const { pull_request: pullRequest, repository } = payload;
+    core_1.info('Fetching repository details...');
+    const repo = yield Credentials_1.fetchRepository(repository.name);
+    const reviewers = repo.reviewers.map((user) => user.github_username);
+    core_1.info(`Assigning reviewers (${reviewers.join(', ')})...`);
+    if (reviewers.length > 0) {
+        yield Github_1.assignReviewers(repository.name, pullRequest.number, reviewers);
+    }
     // Used for log messages.
     const prName = `${repository.name}#${pullRequest.number}`;
     core_1.info(`Getting the Jira key from the pull request ${prName}...`);
@@ -60307,13 +60314,6 @@ const pullRequestReadyForReview = (payload) => __awaiter(void 0, void 0, void 0,
     if (isNil_1.default(issue)) {
         core_1.info(`Couldn't find a Jira issue for ${prName} - ignoring`);
         return;
-    }
-    core_1.info('Fetching repository details...');
-    const repo = yield Credentials_1.fetchRepository(repository.name);
-    const reviewers = repo.reviewers.map((user) => user.github_username);
-    core_1.info(`Assigning reviewers (${reviewers.join(', ')})...`);
-    if (reviewers.length > 0) {
-        yield Github_1.assignReviewers(repository.name, pullRequest.number, reviewers);
     }
     if (issue.fields.status.name === Jira_1.JiraStatusTechReview) {
         core_1.info(`Jira issue ${issueKey} is already in '${Jira_1.JiraStatusTechReview}' - ignoring`);


### PR DESCRIPTION
## Fix ready-for-review action for release PRs

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-1267)
[Jira Epic](https://shuttlerock.atlassian.net/browse/STUDIO-231)

See [https:&#x2F;&#x2F;github.com&#x2F;Shuttlerock&#x2F;pitch-deck&#x2F;pull&#x2F;37&#x2F;checks?check_run_id&#x3D;1667144484|https:&#x2F;&#x2F;github.com&#x2F;Shuttlerock&#x2F;pitch-deck&#x2F;pull&#x2F;37&#x2F;checks?check_run_id&#x3D;1667144484]

{noformat}Getting the Jira key from the pull request pitch-deck#37...

14Couldn&#39;t extract a Jira issue key from pitch-deck#37 - ignoring{noformat}

Since there is no Jira issue attached to a release, the {{please-review}} label never gets added. We shouldn’t give up in this case.

## How to test the PR

Set a release to `ready for review` - reviewers should be added correctly.

## Deployment Notes

None