### PR TITLE
[STUDIO-1283] Fix adding labels to release PRs when they are made ready for review

### DIFF
--- a/.meta/STUDIO-1283.md
+++ b/.meta/STUDIO-1283.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1283
+
+Created at 2021-01-12T03:48:00.319Z

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60301,6 +60301,8 @@ const pullRequestReadyForReview = (payload) => __awaiter(void 0, void 0, void 0,
     if (reviewers.length > 0) {
         yield Github_1.assignReviewers(repository.name, pullRequest.number, reviewers);
     }
+    core_1.info(`Adding the '${Constants_1.PleaseReviewLabel}' label...`);
+    yield Github_1.addLabels(repository.name, pullRequest.number, [Constants_1.PleaseReviewLabel]);
     // Used for log messages.
     const prName = `${repository.name}#${pullRequest.number}`;
     core_1.info(`Getting the Jira key from the pull request ${prName}...`);
@@ -60321,8 +60323,6 @@ const pullRequestReadyForReview = (payload) => __awaiter(void 0, void 0, void 0,
     }
     core_1.info(`Moving Jira issue ${issueKey} to '${Jira_1.JiraStatusTechReview}'...`);
     yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusTechReview);
-    core_1.info(`Adding the '${Constants_1.PleaseReviewLabel}' label...`);
-    yield Github_1.addLabels(repository.name, pullRequest.number, [Constants_1.PleaseReviewLabel]);
 });
 exports.pullRequestReadyForReview = pullRequestReadyForReview;
 

--- a/src/actions/pull-request-ready-for-review-action/pullRequestReadyForReview.ts
+++ b/src/actions/pull-request-ready-for-review-action/pullRequestReadyForReview.ts
@@ -30,6 +30,9 @@ export const pullRequestReadyForReview = async (
     await assignReviewers(repository.name, pullRequest.number, reviewers)
   }
 
+  info(`Adding the '${PleaseReviewLabel}' label...`)
+  await addLabels(repository.name, pullRequest.number, [PleaseReviewLabel])
+
   // Used for log messages.
   const prName = `${repository.name}#${pullRequest.number}`
 
@@ -56,7 +59,4 @@ export const pullRequestReadyForReview = async (
 
   info(`Moving Jira issue ${issueKey} to '${JiraStatusTechReview}'...`)
   await setIssueStatus(issue.id, JiraStatusTechReview)
-
-  info(`Adding the '${PleaseReviewLabel}' label...`)
-  await addLabels(repository.name, pullRequest.number, [PleaseReviewLabel])
 }


### PR DESCRIPTION
## Fix adding labels to release PRs when they are made ready for review

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-1283)
[Jira Epic](https://shuttlerock.atlassian.net/browse/STUDIO-231)



## How to test the PR

Release, then make another release PR and set it to `Ready for review` - the `please-review` label should be added.

## Deployment Notes

None