### PR TITLE
[STUDIO-1291] Don't include the Git hash in dependabot summary in release PRs

### DIFF
--- a/.meta/STUDIO-1291.md
+++ b/.meta/STUDIO-1291.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1291
+
+Created at 2021-01-13T06:57:20.963Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61124,7 +61124,11 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
     if (dependencies.length > 0) {
         description += '### Dependency updates\n\n';
         dependencies.forEach((commit) => {
-            description += `- ${commit.sha.substring(0, 7)} ${commit.commit.message.split('\n')[0]}\n`;
+            // Linkify the last word to point to the commit (the new version, for bumps).
+            const message = commit.commit.message
+                .split('\n')[0]
+                .replace(/ (\S*$)/, ` [$1](https://github.com/${Inputs_1.organizationName()}/${repoName}/commit/${commit.sha})`);
+            description += `- ${message}\n`;
         });
     }
     return description;

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61113,7 +61113,11 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
     if (dependencies.length > 0) {
         description += '### Dependency updates\n\n';
         dependencies.forEach((commit) => {
-            description += `- ${commit.sha.substring(0, 7)} ${commit.commit.message.split('\n')[0]}\n`;
+            // Linkify the last word to point to the commit (the new version, for bumps).
+            const message = commit.commit.message
+                .split('\n')[0]
+                .replace(/ (\S*$)/, ` [$1](https://github.com/${Inputs_1.organizationName()}/${repoName}/commit/${commit.sha})`);
+            description += `- ${message}\n`;
         });
     }
     return description;

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61094,7 +61094,11 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
     if (dependencies.length > 0) {
         description += '### Dependency updates\n\n';
         dependencies.forEach((commit) => {
-            description += `- ${commit.sha.substring(0, 7)} ${commit.commit.message.split('\n')[0]}\n`;
+            // Linkify the last word to point to the commit (the new version, for bumps).
+            const message = commit.commit.message
+                .split('\n')[0]
+                .replace(/ (\S*$)/, ` [$1](https://github.com/${Inputs_1.organizationName()}/${repoName}/commit/${commit.sha})`);
+            description += `- ${message}\n`;
         });
     }
     return description;

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61088,7 +61088,11 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
     if (dependencies.length > 0) {
         description += '### Dependency updates\n\n';
         dependencies.forEach((commit) => {
-            description += `- ${commit.sha.substring(0, 7)} ${commit.commit.message.split('\n')[0]}\n`;
+            // Linkify the last word to point to the commit (the new version, for bumps).
+            const message = commit.commit.message
+                .split('\n')[0]
+                .replace(/ (\S*$)/, ` [$1](https://github.com/${Inputs_1.organizationName()}/${repoName}/commit/${commit.sha})`);
+            description += `- ${message}\n`;
         });
     }
     return description;

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61102,7 +61102,11 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
     if (dependencies.length > 0) {
         description += '### Dependency updates\n\n';
         dependencies.forEach((commit) => {
-            description += `- ${commit.sha.substring(0, 7)} ${commit.commit.message.split('\n')[0]}\n`;
+            // Linkify the last word to point to the commit (the new version, for bumps).
+            const message = commit.commit.message
+                .split('\n')[0]
+                .replace(/ (\S*$)/, ` [$1](https://github.com/${Inputs_1.organizationName()}/${repoName}/commit/${commit.sha})`);
+            description += `- ${message}\n`;
         });
     }
     return description;

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -62370,7 +62370,11 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
     if (dependencies.length > 0) {
         description += '### Dependency updates\n\n';
         dependencies.forEach((commit) => {
-            description += `- ${commit.sha.substring(0, 7)} ${commit.commit.message.split('\n')[0]}\n`;
+            // Linkify the last word to point to the commit (the new version, for bumps).
+            const message = commit.commit.message
+                .split('\n')[0]
+                .replace(/ (\S*$)/, ` [$1](https://github.com/${Inputs_1.organizationName()}/${repoName}/commit/${commit.sha})`);
+            description += `- ${message}\n`;
         });
     }
     return description;

--- a/src/services/Github/Release.ts
+++ b/src/services/Github/Release.ts
@@ -102,9 +102,16 @@ const getReleaseNotes = async (
   if (dependencies.length > 0) {
     description += '### Dependency updates\n\n'
     dependencies.forEach((commit: Commit) => {
-      description += `- ${commit.sha.substring(0, 7)} ${
-        commit.commit.message.split('\n')[0]
-      }\n`
+      // Linkify the last word to point to the commit (the new version, for bumps).
+      const message = commit.commit.message
+        .split('\n')[0]
+        .replace(
+          / (\S*$)/,
+          ` [$1](https://github.com/${organizationName()}/${repoName}/commit/${
+            commit.sha
+          })`
+        )
+      description += `- ${message}\n`
     })
   }
 


### PR DESCRIPTION
## Don't include the Git hash in dependabot summary in release PRs

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-1291)
[Jira Epic](https://shuttlerock.atlassian.net/browse/STUDIO-231)



## How to test the PR

Make a release PR, and check that dependabot links don't display the git SHA.

## Deployment Notes

None