### PR TITLE
Release Candidate 2021-01-22-1247 (Juicy Jay)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@actions/github": "^4.0.0",
     "@octokit/rest": "^18.0.9",
     "@slack/web-api": "^6.0.0",
-    "dateformat": "^4.4.1",
+    "dateformat": "^4.4.2",
     "jira-client": "^6.21.0",
     "lodash": "^4.17.20",
     "mustache": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1743,10 +1743,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dateformat@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.4.1.tgz#c6b3b821588f36826735c346148424d7a39007c3"
-  integrity sha512-3V9b/50QBYmFtd2c3cPOmdr2xNfnDphoBLxh/UVBoPIsylWkbUYGq3f4EQYuEaK7Mq4vcIpQCmOyJ37pqW/Uug==
+dateformat@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.4.2.tgz#893758f83397ab5d366f841f4fb5f1d6f17e4d1f"
+  integrity sha512-GdplOQjYDNWJ1DxVFgTn9x9gHqigo8a5GS8oceQurS8RtTIG2v/T2GLke1ry9Le+M5gatDWMDsanaiT646WzDQ==
 
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
## Release Candidate 2021-01-22-1247 (Juicy Jay)

### Dependency updates

- Bump dateformat from 4.4.1 to [4.4.2](https://github.com/Shuttlerock/actions/commit/cfe2dc86ce11e9be1f7b9e9d0f6051308f8a77a5)
