### PR TITLE
Release Candidate 2021-02-05-0624 (Universal Urial)

### DIFF
--- a/.meta/STUDIO-1463.md
+++ b/.meta/STUDIO-1463.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1463
+
+Created at 2021-02-05T03:32:41.076Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -62254,13 +62254,38 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = void 0;
+exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = exports.negativeEmoji = void 0;
 const escapeRegExp_1 = __importDefault(__nccwpck_require__(8415));
 const isFunction_1 = __importDefault(__nccwpck_require__(7799));
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Inputs_1 = __nccwpck_require__(5968);
 const Inputs = __importStar(__nccwpck_require__(5968));
 const Client_1 = __nccwpck_require__(7589);
+/**
+ * Returns a random 'negative' emoji.
+ *
+ * @returns {string} A slack emoji.
+ */
+const negativeEmoji = () => {
+    const emoji = [
+        'bomb',
+        'cry',
+        'crying_cat_face',
+        'disappointed',
+        'dizzy_face',
+        'man-facepalming',
+        'man-shrugging',
+        'sadpanda',
+        'scream_cat',
+        'thumbsdown',
+        'unamused',
+        'woman-facepalming',
+        'woman-shrugging',
+        'worried',
+    ];
+    return `:${emoji[Math.floor(Math.random() * emoji.length)]}:`;
+};
+exports.negativeEmoji = negativeEmoji;
 /**
  * Returns a random 'positive' emoji.
  *

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61024,7 +61024,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
+exports.updatePullRequest = exports.reviewPullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Client_1 = __nccwpck_require__(2818);
 const Inputs_1 = __nccwpck_require__(5968);
@@ -61183,6 +61183,27 @@ exports.listPullRequestCommits = listPullRequestCommits;
  */
 const pullRequestUrl = (repo, number) => `https://github.com/${Inputs_1.organizationName()}/${repo}/pull/${number}`;
 exports.pullRequestUrl = pullRequestUrl;
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+const reviewPullRequest = (repo, number, event, body) => __awaiter(void 0, void 0, void 0, function* () {
+    const response = yield Client_1.client.pulls.createReview({
+        body,
+        event,
+        owner: Inputs_1.organizationName(),
+        pull_number: number,
+        repo,
+    });
+    return response.data;
+});
+exports.reviewPullRequest = reviewPullRequest;
 /**
  * Update the pull request with the given number, and assigns the given param hash.
  *

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -62254,13 +62254,38 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = void 0;
+exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = exports.negativeEmoji = void 0;
 const escapeRegExp_1 = __importDefault(__nccwpck_require__(8415));
 const isFunction_1 = __importDefault(__nccwpck_require__(7799));
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Inputs_1 = __nccwpck_require__(5968);
 const Inputs = __importStar(__nccwpck_require__(5968));
 const Client_1 = __nccwpck_require__(7589);
+/**
+ * Returns a random 'negative' emoji.
+ *
+ * @returns {string} A slack emoji.
+ */
+const negativeEmoji = () => {
+    const emoji = [
+        'bomb',
+        'cry',
+        'crying_cat_face',
+        'disappointed',
+        'dizzy_face',
+        'man-facepalming',
+        'man-shrugging',
+        'sadpanda',
+        'scream_cat',
+        'thumbsdown',
+        'unamused',
+        'woman-facepalming',
+        'woman-shrugging',
+        'worried',
+    ];
+    return `:${emoji[Math.floor(Math.random() * emoji.length)]}:`;
+};
+exports.negativeEmoji = negativeEmoji;
 /**
  * Returns a random 'positive' emoji.
  *

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -61024,7 +61024,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
+exports.updatePullRequest = exports.reviewPullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Client_1 = __nccwpck_require__(2818);
 const Inputs_1 = __nccwpck_require__(5968);
@@ -61183,6 +61183,27 @@ exports.listPullRequestCommits = listPullRequestCommits;
  */
 const pullRequestUrl = (repo, number) => `https://github.com/${Inputs_1.organizationName()}/${repo}/pull/${number}`;
 exports.pullRequestUrl = pullRequestUrl;
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+const reviewPullRequest = (repo, number, event, body) => __awaiter(void 0, void 0, void 0, function* () {
+    const response = yield Client_1.client.pulls.createReview({
+        body,
+        event,
+        owner: Inputs_1.organizationName(),
+        pull_number: number,
+        repo,
+    });
+    return response.data;
+});
+exports.reviewPullRequest = reviewPullRequest;
 /**
  * Update the pull request with the given number, and assigns the given param hash.
  *

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -62189,13 +62189,38 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = void 0;
+exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = exports.negativeEmoji = void 0;
 const escapeRegExp_1 = __importDefault(__nccwpck_require__(8415));
 const isFunction_1 = __importDefault(__nccwpck_require__(7799));
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Inputs_1 = __nccwpck_require__(5968);
 const Inputs = __importStar(__nccwpck_require__(5968));
 const Client_1 = __nccwpck_require__(7589);
+/**
+ * Returns a random 'negative' emoji.
+ *
+ * @returns {string} A slack emoji.
+ */
+const negativeEmoji = () => {
+    const emoji = [
+        'bomb',
+        'cry',
+        'crying_cat_face',
+        'disappointed',
+        'dizzy_face',
+        'man-facepalming',
+        'man-shrugging',
+        'sadpanda',
+        'scream_cat',
+        'thumbsdown',
+        'unamused',
+        'woman-facepalming',
+        'woman-shrugging',
+        'worried',
+    ];
+    return `:${emoji[Math.floor(Math.random() * emoji.length)]}:`;
+};
+exports.negativeEmoji = negativeEmoji;
 /**
  * Returns a random 'positive' emoji.
  *

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -60959,7 +60959,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
+exports.updatePullRequest = exports.reviewPullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Client_1 = __nccwpck_require__(2818);
 const Inputs_1 = __nccwpck_require__(5968);
@@ -61118,6 +61118,27 @@ exports.listPullRequestCommits = listPullRequestCommits;
  */
 const pullRequestUrl = (repo, number) => `https://github.com/${Inputs_1.organizationName()}/${repo}/pull/${number}`;
 exports.pullRequestUrl = pullRequestUrl;
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+const reviewPullRequest = (repo, number, event, body) => __awaiter(void 0, void 0, void 0, function* () {
+    const response = yield Client_1.client.pulls.createReview({
+        body,
+        event,
+        owner: Inputs_1.organizationName(),
+        pull_number: number,
+        repo,
+    });
+    return response.data;
+});
+exports.reviewPullRequest = reviewPullRequest;
 /**
  * Update the pull request with the given number, and assigns the given param hash.
  *

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -60935,7 +60935,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
+exports.updatePullRequest = exports.reviewPullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Client_1 = __nccwpck_require__(2818);
 const Inputs_1 = __nccwpck_require__(5968);
@@ -61094,6 +61094,27 @@ exports.listPullRequestCommits = listPullRequestCommits;
  */
 const pullRequestUrl = (repo, number) => `https://github.com/${Inputs_1.organizationName()}/${repo}/pull/${number}`;
 exports.pullRequestUrl = pullRequestUrl;
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+const reviewPullRequest = (repo, number, event, body) => __awaiter(void 0, void 0, void 0, function* () {
+    const response = yield Client_1.client.pulls.createReview({
+        body,
+        event,
+        owner: Inputs_1.organizationName(),
+        pull_number: number,
+        repo,
+    });
+    return response.data;
+});
+exports.reviewPullRequest = reviewPullRequest;
 /**
  * Update the pull request with the given number, and assigns the given param hash.
  *

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -62165,13 +62165,38 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = void 0;
+exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = exports.negativeEmoji = void 0;
 const escapeRegExp_1 = __importDefault(__nccwpck_require__(8415));
 const isFunction_1 = __importDefault(__nccwpck_require__(7799));
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Inputs_1 = __nccwpck_require__(5968);
 const Inputs = __importStar(__nccwpck_require__(5968));
 const Client_1 = __nccwpck_require__(7589);
+/**
+ * Returns a random 'negative' emoji.
+ *
+ * @returns {string} A slack emoji.
+ */
+const negativeEmoji = () => {
+    const emoji = [
+        'bomb',
+        'cry',
+        'crying_cat_face',
+        'disappointed',
+        'dizzy_face',
+        'man-facepalming',
+        'man-shrugging',
+        'sadpanda',
+        'scream_cat',
+        'thumbsdown',
+        'unamused',
+        'woman-facepalming',
+        'woman-shrugging',
+        'worried',
+    ];
+    return `:${emoji[Math.floor(Math.random() * emoji.length)]}:`;
+};
+exports.negativeEmoji = negativeEmoji;
 /**
  * Returns a random 'positive' emoji.
  *

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -62159,13 +62159,38 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = void 0;
+exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = exports.negativeEmoji = void 0;
 const escapeRegExp_1 = __importDefault(__nccwpck_require__(8415));
 const isFunction_1 = __importDefault(__nccwpck_require__(7799));
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Inputs_1 = __nccwpck_require__(5968);
 const Inputs = __importStar(__nccwpck_require__(5968));
 const Client_1 = __nccwpck_require__(7589);
+/**
+ * Returns a random 'negative' emoji.
+ *
+ * @returns {string} A slack emoji.
+ */
+const negativeEmoji = () => {
+    const emoji = [
+        'bomb',
+        'cry',
+        'crying_cat_face',
+        'disappointed',
+        'dizzy_face',
+        'man-facepalming',
+        'man-shrugging',
+        'sadpanda',
+        'scream_cat',
+        'thumbsdown',
+        'unamused',
+        'woman-facepalming',
+        'woman-shrugging',
+        'worried',
+    ];
+    return `:${emoji[Math.floor(Math.random() * emoji.length)]}:`;
+};
+exports.negativeEmoji = negativeEmoji;
 /**
  * Returns a random 'positive' emoji.
  *

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -60929,7 +60929,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
+exports.updatePullRequest = exports.reviewPullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Client_1 = __nccwpck_require__(2818);
 const Inputs_1 = __nccwpck_require__(5968);
@@ -61088,6 +61088,27 @@ exports.listPullRequestCommits = listPullRequestCommits;
  */
 const pullRequestUrl = (repo, number) => `https://github.com/${Inputs_1.organizationName()}/${repo}/pull/${number}`;
 exports.pullRequestUrl = pullRequestUrl;
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+const reviewPullRequest = (repo, number, event, body) => __awaiter(void 0, void 0, void 0, function* () {
+    const response = yield Client_1.client.pulls.createReview({
+        body,
+        event,
+        owner: Inputs_1.organizationName(),
+        pull_number: number,
+        repo,
+    });
+    return response.data;
+});
+exports.reviewPullRequest = reviewPullRequest;
 /**
  * Update the pull request with the given number, and assigns the given param hash.
  *

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60943,7 +60943,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
+exports.updatePullRequest = exports.reviewPullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Client_1 = __nccwpck_require__(2818);
 const Inputs_1 = __nccwpck_require__(5968);
@@ -61102,6 +61102,27 @@ exports.listPullRequestCommits = listPullRequestCommits;
  */
 const pullRequestUrl = (repo, number) => `https://github.com/${Inputs_1.organizationName()}/${repo}/pull/${number}`;
 exports.pullRequestUrl = pullRequestUrl;
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+const reviewPullRequest = (repo, number, event, body) => __awaiter(void 0, void 0, void 0, function* () {
+    const response = yield Client_1.client.pulls.createReview({
+        body,
+        event,
+        owner: Inputs_1.organizationName(),
+        pull_number: number,
+        repo,
+    });
+    return response.data;
+});
+exports.reviewPullRequest = reviewPullRequest;
 /**
  * Update the pull request with the given number, and assigns the given param hash.
  *

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -62173,13 +62173,38 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = void 0;
+exports.sendUserMessage = exports.sendErrorMessage = exports.scrubMessage = exports.positiveEmoji = exports.negativeEmoji = void 0;
 const escapeRegExp_1 = __importDefault(__nccwpck_require__(8415));
 const isFunction_1 = __importDefault(__nccwpck_require__(7799));
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const Inputs_1 = __nccwpck_require__(5968);
 const Inputs = __importStar(__nccwpck_require__(5968));
 const Client_1 = __nccwpck_require__(7589);
+/**
+ * Returns a random 'negative' emoji.
+ *
+ * @returns {string} A slack emoji.
+ */
+const negativeEmoji = () => {
+    const emoji = [
+        'bomb',
+        'cry',
+        'crying_cat_face',
+        'disappointed',
+        'dizzy_face',
+        'man-facepalming',
+        'man-shrugging',
+        'sadpanda',
+        'scream_cat',
+        'thumbsdown',
+        'unamused',
+        'woman-facepalming',
+        'woman-shrugging',
+        'worried',
+    ];
+    return `:${emoji[Math.floor(Math.random() * emoji.length)]}:`;
+};
+exports.negativeEmoji = negativeEmoji;
 /**
  * Returns a random 'positive' emoji.
  *

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61615,6 +61615,9 @@ const index_1 = __nccwpck_require__(64464);
 const run = () => __awaiter(void 0, void 0, void 0, function* () {
     const { payload: { inputs: { email, event, param }, }, } = (yield github_1.context);
     switch (event) {
+        case 'approvePullRequest':
+            yield index_1.approvePullRequest(email, param);
+            break;
         case 'createPullRequestForJiraIssue':
             yield index_1.createPullRequestForJiraIssue(email, param);
             break;
@@ -62211,7 +62214,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
+exports.updatePullRequest = exports.reviewPullRequest = exports.pullRequestUrl = exports.listPullRequestCommits = exports.extractPullRequestNumber = exports.assignReviewers = exports.getPullRequest = exports.getIssueKey = exports.createPullRequest = exports.assignOwners = void 0;
 const isNil_1 = __importDefault(__nccwpck_require__(84977));
 const Client_1 = __nccwpck_require__(32818);
 const Inputs_1 = __nccwpck_require__(25968);
@@ -62370,6 +62373,27 @@ exports.listPullRequestCommits = listPullRequestCommits;
  */
 const pullRequestUrl = (repo, number) => `https://github.com/${Inputs_1.organizationName()}/${repo}/pull/${number}`;
 exports.pullRequestUrl = pullRequestUrl;
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+const reviewPullRequest = (repo, number, event, body) => __awaiter(void 0, void 0, void 0, function* () {
+    const response = yield Client_1.client.pulls.createReview({
+        body,
+        event,
+        owner: Inputs_1.organizationName(),
+        pull_number: number,
+        repo,
+    });
+    return response.data;
+});
+exports.reviewPullRequest = reviewPullRequest;
 /**
  * Update the pull request with the given number, and assigns the given param hash.
  *
@@ -63672,6 +63696,60 @@ It requires new Environmental variables:
 
 /***/ }),
 
+/***/ 85520:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.approvePullRequest = void 0;
+const core_1 = __nccwpck_require__(42186);
+const isNil_1 = __importDefault(__nccwpck_require__(84977));
+const Github_1 = __nccwpck_require__(24390);
+/**
+ * To trigger this event manually:
+ *
+ * $ act --job trigger_action --eventpath src/actions/trigger-action/__tests__/fixtures/approvePullRequest.json
+ *
+ * or to trigger it via the Github API:
+ *
+ * $ curl --header "Accept: application/vnd.github.v3+json" \
+ * --header  "Authorization: token YOUR_TOKEN" \
+ * --request POST \
+ * --data    '{"ref": "develop", "inputs": { "email": "dave@shuttlerock.com", "event": "approvePullRequest", "param": "actions#344" }}' \
+ * https://api.github.com/repos/Shuttlerock/actions/actions/workflows/trigger-action.yml/dispatches
+ *
+ * @param {string} email     The email address of the user who requested the release be created.
+ * @param {string} repoAndPr The name of the repository and the pull request number together (eg. 'actions#344').
+ */
+const approvePullRequest = (email, repoAndPr) => __awaiter(void 0, void 0, void 0, function* () {
+    const [repositoryName, prStr] = repoAndPr.trim().split(/[\s#]+/);
+    const prNumber = parseInt(prStr, 10);
+    if (isNil_1.default(repositoryName) || isNil_1.default(prNumber)) {
+        core_1.error(`Repository name and pull request number could not be extracted from '${repoAndPr}' - giving up`);
+        return;
+    }
+    core_1.info(`User ${email} requested approval of ${repositoryName}#${prNumber}...`);
+    yield Github_1.reviewPullRequest(repositoryName, prNumber, 'APPROVE', ':thumbsup:');
+    core_1.info(`Approved ${repositoryName}#${prNumber}`);
+});
+exports.approvePullRequest = approvePullRequest;
+
+
+/***/ }),
+
 /***/ 88749:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -63896,6 +63974,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+__exportStar(__nccwpck_require__(85520), exports);
 __exportStar(__nccwpck_require__(88749), exports);
 __exportStar(__nccwpck_require__(33982), exports);
 __exportStar(__nccwpck_require__(39973), exports);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-github": "^4.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
-    "eslint-plugin-jsdoc": "^31.4.0",
+    "eslint-plugin-jsdoc": "^31.6.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-unused-imports": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@actions/github": "^4.0.0",
     "@octokit/rest": "^18.0.9",
     "@slack/web-api": "^6.0.0",
-    "dateformat": "^4.5.0",
+    "dateformat": "^4.5.1",
     "jira-client": "^6.21.0",
     "lodash": "^4.17.20",
     "mustache": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "unique-names-generator": "^4.3.1"
   },
   "devDependencies": {
-    "@octokit/webhooks": "^7.21.0",
+    "@octokit/webhooks": "^7.24.2",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.20",
     "@types/jira-client": "^6.13.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/parser": "^4.14.1",
     "@vercel/ncc": "0.27.0",
-    "eslint": "^7.18.0",
+    "eslint": "^7.19.0",
     "eslint-config-airbnb-typescript": "^12.0.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/mustache": "^4.1.1",
     "@types/node": "^14.14.25",
     "@types/node-fetch": "^2.5.8",
-    "@typescript-eslint/parser": "^4.14.1",
+    "@typescript-eslint/parser": "^4.14.2",
     "@vercel/ncc": "0.27.0",
     "eslint": "^7.19.0",
     "eslint-config-airbnb-typescript": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "js-yaml": "^4.0.0",
     "lint-staged": "^10.5.3",
     "prettier": "2.2.1",
-    "ts-jest": "^26.4.4",
+    "ts-jest": "^26.5.0",
     "tscpaths": "^0.0.9",
     "typescript": "^4.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.168",
     "@types/mustache": "^4.1.1",
-    "@types/node": "^14.14.22",
+    "@types/node": "^14.14.25",
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/parser": "^4.14.1",
     "@vercel/ncc": "0.27.0",

--- a/src/actions/trigger-action/__tests__/fixtures/approvePullRequest.json
+++ b/src/actions/trigger-action/__tests__/fixtures/approvePullRequest.json
@@ -1,0 +1,8 @@
+{
+  "ref": "develop",
+  "inputs": {
+    "email": "dave@shuttlerock.com",
+    "event": "approvePullRequest",
+    "param": "actions#344"
+  }
+}

--- a/src/actions/trigger-action/index.ts
+++ b/src/actions/trigger-action/index.ts
@@ -3,6 +3,7 @@ import { context } from '@actions/github'
 
 import { sendErrorMessage } from '@sr-services/Slack'
 import {
+  approvePullRequest,
   createPullRequestForJiraIssue,
   createRelease,
   jiraIssueTransitioned,
@@ -30,6 +31,9 @@ export const run = async (): Promise<void> => {
   } = ((await context) as unknown) as Context
 
   switch (event) {
+    case 'approvePullRequest':
+      await approvePullRequest(email, param)
+      break
     case 'createPullRequestForJiraIssue':
       await createPullRequestForJiraIssue(email, param)
       break

--- a/src/services/Credentials.ts
+++ b/src/services/Credentials.ts
@@ -19,6 +19,7 @@ export interface Credentials extends User {
 }
 
 export interface Repository {
+  allow_auto_review: boolean
   jira_project_id?: number
   leads: User[]
   reviewers: User[]

--- a/src/services/Github/PullRequest.ts
+++ b/src/services/Github/PullRequest.ts
@@ -1,5 +1,6 @@
 import {
   IssuesAddAssigneesResponseData,
+  PullsCreateReviewResponseData,
   PullsGetResponseData,
   PullsListCommitsResponseData,
   PullsRequestReviewersResponseData,
@@ -208,6 +209,33 @@ export const listPullRequestCommits = async (
  */
 export const pullRequestUrl = (repo: Repository, number: number): string =>
   `https://github.com/${organizationName()}/${repo}/pull/${number}`
+
+/**
+ * Reviews the given PR using the system Github user.
+ *
+ * @param {Repository} repo      The name of the repository that the PR belongs to.
+ * @param {number}     number    The PR number.
+ * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
+ * @param {string}     body      The review body.
+ *
+ * @returns {PullsCreateReviewResponseData} The review data.
+ */
+export const reviewPullRequest = async (
+  repo: Repository,
+  number: number,
+  event: 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES',
+  body: string
+): Promise<PullsCreateReviewResponseData> => {
+  const response = await client.pulls.createReview({
+    body,
+    event,
+    owner: organizationName(),
+    pull_number: number,
+    repo,
+  })
+
+  return response.data
+}
 
 /**
  * Update the pull request with the given number, and assigns the given param hash.

--- a/src/services/Github/__tests__/PullRequest.test.ts
+++ b/src/services/Github/__tests__/PullRequest.test.ts
@@ -2,6 +2,7 @@ import {
   IssuesAddAssigneesResponseData,
   OctokitResponse,
   PullsCreateResponseData,
+  PullsCreateReviewResponseData,
   PullsGetResponseData,
   PullsListCommitsResponseData,
   PullsRequestReviewersResponseData,
@@ -20,6 +21,7 @@ import {
   getPullRequest,
   listPullRequestCommits,
   pullRequestUrl,
+  reviewPullRequest,
   updatePullRequest,
 } from '@sr-services/Github/PullRequest'
 import { organizationName } from '@sr-services/Inputs'
@@ -27,6 +29,7 @@ import {
   mockGitCommit,
   mockGithubPullRequest,
   mockGithubPullRequestCreateResponse,
+  mockGithubPullRequestReviewResponse,
   mockGithubPullRequestUpdateResponse,
   mockIssuesAddAssigneesResponseData,
   mockPullsRequestReviewersResponseData,
@@ -73,6 +76,7 @@ describe('PullRequest', () => {
       spy.mockRestore()
     })
   })
+
   describe('assignReviewers', () => {
     it('calls the Github API', async () => {
       const getPullRequestSpy = jest
@@ -248,6 +252,28 @@ describe('PullRequest', () => {
     it('returns the URL', () => {
       const expected = 'https://github.com/octokit/actions/pull/123'
       expect(pullRequestUrl('actions', 123)).toEqual(expected)
+    })
+  })
+
+  describe('reviewPullRequest', () => {
+    it('calls the Github API', async () => {
+      const spy = jest
+        .spyOn(Client.client.pulls, 'createReview')
+        .mockReturnValue(
+          Promise.resolve({
+            data: mockGithubPullRequestReviewResponse,
+          } as OctokitResponse<PullsCreateReviewResponseData>)
+        )
+      const result = await reviewPullRequest(repo, 23, 'APPROVE', ':thumbsup:')
+      expect(spy).toHaveBeenCalledWith({
+        body: ':thumbsup:',
+        event: 'APPROVE',
+        pull_number: 23,
+        owner: organizationName(),
+        repo,
+      })
+      expect(result.id).toEqual(1234)
+      spy.mockRestore()
     })
   })
 

--- a/src/services/Slack/Message.ts
+++ b/src/services/Slack/Message.ts
@@ -7,6 +7,31 @@ import * as Inputs from '@sr-services/Inputs'
 import { client } from '@sr-services/Slack/Client'
 
 /**
+ * Returns a random 'negative' emoji.
+ *
+ * @returns {string} A slack emoji.
+ */
+export const negativeEmoji = (): string => {
+  const emoji = [
+    'bomb',
+    'cry',
+    'crying_cat_face',
+    'disappointed',
+    'dizzy_face',
+    'man-facepalming',
+    'man-shrugging',
+    'sadpanda',
+    'scream_cat',
+    'thumbsdown',
+    'unamused',
+    'woman-facepalming',
+    'woman-shrugging',
+    'worried',
+  ]
+  return `:${emoji[Math.floor(Math.random() * emoji.length)]}:`
+}
+
+/**
  * Returns a random 'positive' emoji.
  *
  * @returns {string} A slack emoji.

--- a/src/tests/Mocks.ts
+++ b/src/tests/Mocks.ts
@@ -3,6 +3,7 @@ import {
   IssuesAddLabelsResponseData,
   IssuesSetLabelsResponseData,
   PullsCreateResponseData,
+  PullsCreateReviewResponseData,
   PullsGetResponseData,
   PullsRequestReviewersResponseData,
   PullsUpdateResponseData,
@@ -69,6 +70,11 @@ export const mockGithubPullRequestCreateResponse = ({
   number: 123,
   title: 'Add a Widget',
 } as unknown) as PullsCreateResponseData
+
+export const mockGithubPullRequestReviewResponse = ({
+  id: 1234,
+  body: ':thumbsup:',
+} as unknown) as PullsCreateReviewResponseData
 
 export const mockGithubPullRequestUpdateResponse = ({
   id: 1234,

--- a/src/tests/Mocks.ts
+++ b/src/tests/Mocks.ts
@@ -148,6 +148,7 @@ export const mockJiraRelease = {
 }
 
 export const mockRepository = {
+  allow_auto_review: true,
   leads: [{ github_username: 'dhh' }],
   reviewers: [{ github_username: 'wycats' }],
   status: 'ok',

--- a/src/triggers/__tests__/approvePullRequest.test.ts
+++ b/src/triggers/__tests__/approvePullRequest.test.ts
@@ -1,0 +1,45 @@
+import * as Github from '@sr-services/Github'
+import { mockGithubPullRequestReviewResponse } from '@sr-tests/Mocks'
+import { approvePullRequest } from '@sr-triggers/approvePullRequest'
+
+jest.mock('@sr-services/Github', () => ({
+  reviewPullRequest: jest.fn(),
+}))
+
+const email = 'user@example.com'
+const repoName = 'actions'
+const prNumber = 123
+
+describe('approvePullRequest', () => {
+  let reviewPullRequest: jest.SpyInstance
+
+  beforeEach(() => {
+    reviewPullRequest = jest
+      .spyOn(Github, 'reviewPullRequest')
+      .mockReturnValue(Promise.resolve(mockGithubPullRequestReviewResponse))
+  })
+
+  afterEach(() => {
+    reviewPullRequest.mockRestore()
+  })
+
+  it('calls the review service', async () => {
+    await approvePullRequest(email, `${repoName}#${prNumber}`)
+    expect(reviewPullRequest).toHaveBeenCalledWith(
+      repoName,
+      prNumber,
+      'APPROVE',
+      ':thumbsup:'
+    )
+  })
+
+  it('handles badly formed inputs', async () => {
+    await approvePullRequest(email, `  ${repoName}   #   ${prNumber}     `)
+    expect(reviewPullRequest).toHaveBeenCalledWith(
+      repoName,
+      prNumber,
+      'APPROVE',
+      ':thumbsup:'
+    )
+  })
+})

--- a/src/triggers/approvePullRequest.ts
+++ b/src/triggers/approvePullRequest.ts
@@ -1,0 +1,38 @@
+import { error, info } from '@actions/core'
+import isNil from 'lodash/isNil'
+
+import { reviewPullRequest } from '@sr-services/Github'
+
+/**
+ * To trigger this event manually:
+ *
+ * $ act --job trigger_action --eventpath src/actions/trigger-action/__tests__/fixtures/approvePullRequest.json
+ *
+ * or to trigger it via the Github API:
+ *
+ * $ curl --header "Accept: application/vnd.github.v3+json" \
+ * --header  "Authorization: token YOUR_TOKEN" \
+ * --request POST \
+ * --data    '{"ref": "develop", "inputs": { "email": "dave@shuttlerock.com", "event": "approvePullRequest", "param": "actions#344" }}' \
+ * https://api.github.com/repos/Shuttlerock/actions/actions/workflows/trigger-action.yml/dispatches
+ *
+ * @param {string} email     The email address of the user who requested the release be created.
+ * @param {string} repoAndPr The name of the repository and the pull request number together (eg. 'actions#344').
+ */
+export const approvePullRequest = async (
+  email: string,
+  repoAndPr: string
+): Promise<void> => {
+  const [repositoryName, prStr] = repoAndPr.trim().split(/[\s#]+/)
+  const prNumber = parseInt(prStr, 10)
+  if (isNil(repositoryName) || isNil(prNumber)) {
+    error(
+      `Repository name and pull request number could not be extracted from '${repoAndPr}' - giving up`
+    )
+    return
+  }
+
+  info(`User ${email} requested approval of ${repositoryName}#${prNumber}...`)
+  await reviewPullRequest(repositoryName, prNumber, 'APPROVE', ':thumbsup:')
+  info(`Approved ${repositoryName}#${prNumber}`)
+}

--- a/src/triggers/index.ts
+++ b/src/triggers/index.ts
@@ -1,3 +1,4 @@
+export * from './approvePullRequest'
 export * from './createPullRequestForJiraIssue'
 export * from './createRelease'
 export * from './jiraIssueTransitioned'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1743,10 +1743,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dateformat@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.5.0.tgz#2b5fbae50d9f30dd0c82bf85344878cbc41b08cc"
-  integrity sha512-YkS64mgmj9At0Ua9p3qyqoHqjqkOTV/FGCluRIcrFNbhFmltQGl2x/DFBgpbRRPTNPoyxfzjqgNaGYjMbfnsdg==
+dateformat@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.5.1.tgz#c20e7a9ca77d147906b6dc2261a8be0a5bd2173c"
+  integrity sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==
 
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,10 +2172,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.11.0, eslint@^7.18.0:
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.18.0.tgz#7fdcd2f3715a41fe6295a16234bd69aed2c75e67"
-  integrity sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==
+eslint@^7.11.0, eslint@^7.19.0:
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.19.0.tgz#6719621b196b5fad72e43387981314e5d0dc3f41"
+  integrity sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@eslint/eslintrc" "^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,10 +850,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^14.14.22":
-  version "14.14.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
-  integrity sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^14.14.25":
+  version "14.14.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.25.tgz#15967a7b577ff81383f9b888aa6705d43fbbae93"
+  integrity sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,23 +942,23 @@
     "@typescript-eslint/typescript-estree" "4.4.1"
     debug "^4.1.1"
 
-"@typescript-eslint/parser@>=2.25.0", "@typescript-eslint/parser@^4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.1.tgz#3bd6c24710cd557d8446625284bcc9c6d52817c6"
-  integrity sha512-mL3+gU18g9JPsHZuKMZ8Z0Ss9YP1S5xYZ7n68Z98GnPq02pYNQuRXL85b9GYhl6jpdvUc45Km7hAl71vybjUmw==
+"@typescript-eslint/parser@>=2.25.0", "@typescript-eslint/parser@^4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.2.tgz#31e216e4baab678a56e539f9db9862e2542c98d0"
+  integrity sha512-ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.14.1"
-    "@typescript-eslint/types" "4.14.1"
-    "@typescript-eslint/typescript-estree" "4.14.1"
+    "@typescript-eslint/scope-manager" "4.14.2"
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/typescript-estree" "4.14.2"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.1.tgz#8444534254c6f370e9aa974f035ced7fe713ce02"
-  integrity sha512-F4bjJcSqXqHnC9JGUlnqSa3fC2YH5zTtmACS1Hk+WX/nFB0guuynVK5ev35D4XZbdKjulXBAQMyRr216kmxghw==
+"@typescript-eslint/scope-manager@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz#64cbc9ca64b60069aae0c060b2bf81163243b266"
+  integrity sha512-cuV9wMrzKm6yIuV48aTPfIeqErt5xceTheAgk70N1V4/2Ecj+fhl34iro/vIssJlb7XtzcaD07hWk7Jk0nKghg==
   dependencies:
-    "@typescript-eslint/types" "4.14.1"
-    "@typescript-eslint/visitor-keys" "4.14.1"
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/visitor-keys" "4.14.2"
 
 "@typescript-eslint/scope-manager@4.4.1":
   version "4.4.1"
@@ -976,10 +976,10 @@
     "@typescript-eslint/types" "4.5.0"
     "@typescript-eslint/visitor-keys" "4.5.0"
 
-"@typescript-eslint/types@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.1.tgz#b3d2eb91dafd0fd8b3fce7c61512ac66bd0364aa"
-  integrity sha512-SkhzHdI/AllAgQSxXM89XwS1Tkic7csPdndUuTKabEwRcEfR8uQ/iPA3Dgio1rqsV3jtqZhY0QQni8rLswJM2w==
+"@typescript-eslint/types@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.2.tgz#d96da62be22dc9dc6a06647f3633815350fb3174"
+  integrity sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==
 
 "@typescript-eslint/types@4.4.1":
   version "4.4.1"
@@ -991,13 +991,13 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.5.0.tgz#98256e07bad1c8d15d0c9627ebec82fd971bb3c3"
   integrity sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g==
 
-"@typescript-eslint/typescript-estree@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.1.tgz#20d3b8c8e3cdc8f764bdd5e5b0606dd83da6075b"
-  integrity sha512-M8+7MbzKC1PvJIA8kR2sSBnex8bsR5auatLCnVlNTJczmJgqRn8M+sAlQfkEq7M4IY3WmaNJ+LJjPVRrREVSHQ==
+"@typescript-eslint/typescript-estree@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.2.tgz#9c5ebd8cae4d7b014f890acd81e8e17f309c9df9"
+  integrity sha512-ESiFl8afXxt1dNj8ENEZT12p+jl9PqRur+Y19m0Z/SPikGL6rqq4e7Me60SU9a2M28uz48/8yct97VQYaGl0Vg==
   dependencies:
-    "@typescript-eslint/types" "4.14.1"
-    "@typescript-eslint/visitor-keys" "4.14.1"
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/visitor-keys" "4.14.2"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -1033,12 +1033,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.1.tgz#e93c2ff27f47ee477a929b970ca89d60a117da91"
-  integrity sha512-TAblbDXOI7bd0C/9PE1G+AFo7R5uc+ty1ArDoxmrC1ah61Hn6shURKy7gLdRb1qKJmjHkqu5Oq+e4Kt0jwf1IA==
+"@typescript-eslint/visitor-keys@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz#997cbe2cb0690e1f384a833f64794e98727c70c6"
+  integrity sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==
   dependencies:
-    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/types" "4.14.2"
     eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.4.1":

--- a/yarn.lock
+++ b/yarn.lock
@@ -3832,17 +3832,12 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.memoize@4.x:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -5268,10 +5263,10 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-ts-jest@^26.4.4:
-  version "26.4.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
-  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+ts-jest@^26.5.0:
+  version "26.5.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.0.tgz#3e3417d91bc40178a6716d7dacc5b0505835aa21"
+  integrity sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==
   dependencies:
     "@types/jest" "26.x"
     bs-logger "0.x"
@@ -5279,7 +5274,7 @@ ts-jest@^26.4.4:
     fast-json-stable-stringify "2.x"
     jest-util "^26.1.0"
     json5 "2.x"
-    lodash.memoize "4.x"
+    lodash "4.x"
     make-error "1.x"
     mkdirp "1.x"
     semver "7.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,10 +661,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/webhooks@^7.21.0":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-7.21.0.tgz#2aee3404aa311740a5f4ea37b070268752e21b02"
-  integrity sha512-Mj7Pa6JZgSjfzQfYF3Bf5KpyhzEBv4kHbj2EjCB/vMQiZCiiW30j5rS6t/d0ZN0FBrlSOuJIT+YU8IJt30VyWA==
+"@octokit/webhooks@^7.24.2":
+  version "7.24.2"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-7.24.2.tgz#9de37f187d8be34735598d265633bff3af1a8943"
+  integrity sha512-Bz1VS6I7EPUiUVs5kW0OtnDB6LDiufR7pzOQvGRgxK9d8fjtEJsXKCWe1kZuMCJoSfdcTW3GVRALw3Qdpry4Pg==
   dependencies:
     "@octokit/request-error" "^2.0.2"
     aggregate-error "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@ eslint-plugin-jest@^24.1.3:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-jsdoc@^31.4.0:
-  version "31.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-31.4.0.tgz#70e00f5f8f7cc695de36319d0e761e1a784ae10e"
-  integrity sha512-NX387IVQrA/ZE9F1tpeEFzZDsXb/BJS4HdT1ZH0RME3O/4DJF8GNQnjMSia8O3gFx/kjfASsdmK5LglVs+xGLA==
+eslint-plugin-jsdoc@^31.6.0:
+  version "31.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-31.6.0.tgz#c91f8cb4e4f8a94a27aafdc41c58eb8c35c9ce9a"
+  integrity sha512-kYhdW+BXHij9n12oHvAC27oDHKEFITz1YJP/C0NPtb+gsGJWxejh5B6dEmmj6oLYOsmNvuCVkdIcqYOyabP2QA==
   dependencies:
     comment-parser "1.1.1"
     debug "^4.3.1"


### PR DESCRIPTION
## Release Candidate 2021-02-05-0624 (Universal Urial)

### Pull Requests

- #344 Allow selected repositories to be auto-approved via Slack ([STUDIO-1463](https://shuttlerock.atlassian.net/browse/STUDIO-1463))

### Dependency updates

- Bump dateformat from 4.5.0 to [4.5.1](https://github.com/Shuttlerock/actions/commit/f5a9df1bed6c29284cc27b7df143ddb25af7a17c)
- Bump eslint from 7.18.0 to [7.19.0](https://github.com/Shuttlerock/actions/commit/c67752e4393cc5fce5802fddfc36a7c87b8890bb)
- Bump ts-jest from 26.4.4 to [26.5.0](https://github.com/Shuttlerock/actions/commit/c22a9221e439749c35bdba35287a044722a56f9b)
- Bump eslint-plugin-jsdoc from 31.4.0 to [31.6.0](https://github.com/Shuttlerock/actions/commit/9706be0dff309542280f634c66d868101d5d05cb)
- Bump @octokit/webhooks from 7.21.0 to [7.24.2](https://github.com/Shuttlerock/actions/commit/b79bd21051a8fee1fbad531ced5ef199815f01c2)
- Bump @types/node from 14.14.22 to [14.14.25](https://github.com/Shuttlerock/actions/commit/d37f34ef12f2a8b7adf0817e561d8ed67f140066)
- Bump @typescript-eslint/parser from 4.14.1 to [4.14.2](https://github.com/Shuttlerock/actions/commit/af35c098d5dd256384dd7162f0690aef650bdf0c)
