### PR TITLE
Release Candidate 2021-02-24-0258 (Zealous Zebra)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
   jest:
     <<: *defaults
-    resource_class: large # Work around out-of-memory errors.
+    resource_class: xlarge # Work around out-of-memory errors.
     steps:
       - restore_cache:
           name: "Restore checkout cache"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,6 @@ module.exports = {
     'plugin:jsdoc/recommended',
     'plugin:prettier/recommended',
     'prettier',
-    'prettier/@typescript-eslint',
   ],
   rules: {
     camelcase: 'off',

--- a/.meta/STUDIO-1567.md
+++ b/.meta/STUDIO-1567.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1567
+
+Created at 2021-02-24T01:37:26.138Z

--- a/.meta/STUDIO-1568.md
+++ b/.meta/STUDIO-1568.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1568
+
+Created at 2021-02-24T01:57:28.730Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61270,8 +61270,8 @@ const String_1 = __nccwpck_require__(5058);
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Making release notes from ${commits.length} commits...`);
     const dependencies = commits.filter((commit) => {
-        var _a;
-        return ((_a = commit.author.login) === null || _a === void 0 ? void 0 : _a.startsWith('dependabot')) &&
+        var _a, _b;
+        return ((_b = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login) === null || _b === void 0 ? void 0 : _b.startsWith('dependabot')) &&
             commit.commit.message.includes('Bump ');
     });
     const prNumbers = [

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -61270,8 +61270,8 @@ const String_1 = __nccwpck_require__(5058);
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Making release notes from ${commits.length} commits...`);
     const dependencies = commits.filter((commit) => {
-        var _a;
-        return ((_a = commit.author.login) === null || _a === void 0 ? void 0 : _a.startsWith('dependabot')) &&
+        var _a, _b;
+        return ((_b = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login) === null || _b === void 0 ? void 0 : _b.startsWith('dependabot')) &&
             commit.commit.message.includes('Bump ');
     });
     const prNumbers = [

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61206,8 +61206,8 @@ const String_1 = __nccwpck_require__(5058);
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Making release notes from ${commits.length} commits...`);
     const dependencies = commits.filter((commit) => {
-        var _a;
-        return ((_a = commit.author.login) === null || _a === void 0 ? void 0 : _a.startsWith('dependabot')) &&
+        var _a, _b;
+        return ((_b = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login) === null || _b === void 0 ? void 0 : _b.startsWith('dependabot')) &&
             commit.commit.message.includes('Bump ');
     });
     const prNumbers = [

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61181,8 +61181,8 @@ const String_1 = __nccwpck_require__(5058);
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Making release notes from ${commits.length} commits...`);
     const dependencies = commits.filter((commit) => {
-        var _a;
-        return ((_a = commit.author.login) === null || _a === void 0 ? void 0 : _a.startsWith('dependabot')) &&
+        var _a, _b;
+        return ((_b = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login) === null || _b === void 0 ? void 0 : _b.startsWith('dependabot')) &&
             commit.commit.message.includes('Bump ');
     });
     const prNumbers = [

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61175,8 +61175,8 @@ const String_1 = __nccwpck_require__(5058);
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Making release notes from ${commits.length} commits...`);
     const dependencies = commits.filter((commit) => {
-        var _a;
-        return ((_a = commit.author.login) === null || _a === void 0 ? void 0 : _a.startsWith('dependabot')) &&
+        var _a, _b;
+        return ((_b = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login) === null || _b === void 0 ? void 0 : _b.startsWith('dependabot')) &&
             commit.commit.message.includes('Bump ');
     });
     const prNumbers = [

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61189,8 +61189,8 @@ const String_1 = __nccwpck_require__(5058);
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Making release notes from ${commits.length} commits...`);
     const dependencies = commits.filter((commit) => {
-        var _a;
-        return ((_a = commit.author.login) === null || _a === void 0 ? void 0 : _a.startsWith('dependabot')) &&
+        var _a, _b;
+        return ((_b = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login) === null || _b === void 0 ? void 0 : _b.startsWith('dependabot')) &&
             commit.commit.message.includes('Bump ');
     });
     const prNumbers = [

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -62460,8 +62460,8 @@ const String_1 = __nccwpck_require__(55058);
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Making release notes from ${commits.length} commits...`);
     const dependencies = commits.filter((commit) => {
-        var _a;
-        return ((_a = commit.author.login) === null || _a === void 0 ? void 0 : _a.startsWith('dependabot')) &&
+        var _a, _b;
+        return ((_b = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login) === null || _b === void 0 ? void 0 : _b.startsWith('dependabot')) &&
             commit.commit.message.includes('Bump ');
     });
     const prNumbers = [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-github": "^4.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
-    "eslint-plugin-jsdoc": "^31.6.1",
+    "eslint-plugin-jsdoc": "^32.2.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-unused-imports": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.20",
     "mustache": "^4.1.0",
     "node-fetch": "^2.6.1",
-    "unique-names-generator": "^4.3.1"
+    "unique-names-generator": "^4.4.0"
   },
   "devDependencies": {
     "@octokit/webhooks": "^7.24.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/parser": "^4.15.2",
     "@vercel/ncc": "0.27.0",
-    "eslint": "^7.19.0",
+    "eslint": "^7.20.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^7.2.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-jsdoc": "^31.6.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-unused-imports": "^1.0.3",
+    "eslint-plugin-unused-imports": "^1.1.0",
     "husky": "^5.1.1",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "js-yaml": "^4.0.0",
     "lint-staged": "^10.5.4",
     "prettier": "2.2.1",
-    "ts-jest": "^26.5.0",
+    "ts-jest": "^26.5.2",
     "tscpaths": "^0.0.9",
     "typescript": "^4.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@vercel/ncc": "0.27.0",
     "eslint": "^7.20.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
-    "eslint-config-prettier": "^7.2.0",
+    "eslint-config-prettier": "^8.0.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-github": "^4.1.1",
     "eslint-plugin-import": "^2.22.1",

--- a/src/services/Github/Release.ts
+++ b/src/services/Github/Release.ts
@@ -60,7 +60,7 @@ const getReleaseNotes = async (
   info(`Making release notes from ${commits.length} commits...`)
   const dependencies = commits.filter(
     (commit: Commit) =>
-      commit.author.login?.startsWith('dependabot') &&
+      commit.author?.login?.startsWith('dependabot') &&
       commit.commit.message.includes('Bump ')
   )
 

--- a/src/services/Github/__tests__/Release.test.ts
+++ b/src/services/Github/__tests__/Release.test.ts
@@ -235,7 +235,7 @@ describe('Release', () => {
     })
 
     it('handles commit authors with no Github login', async () => {
-      listPullsSpy = jest.spyOn(readClient.pulls, 'list').mockReturnValue(
+      listPullsSpy.mockReturnValue(
         Promise.resolve(({
           data: [],
         } as unknown) as OctokitResponse<PullsListResponseData>)
@@ -243,6 +243,22 @@ describe('Release', () => {
       compareCommitsSpy.mockReturnValue(
         Promise.resolve(({
           commits: [{ ...mockGitCommit, author: { login: null } }],
+          total_commits: 1,
+        } as unknown) as ReposCompareCommitsResponseData)
+      )
+      await createReleasePullRequest(email, mockGithubRepository)
+      expect(createPullRequestSpy).toHaveBeenCalled()
+    })
+
+    it('handles commits with no author', async () => {
+      listPullsSpy.mockReturnValue(
+        Promise.resolve(({
+          data: [],
+        } as unknown) as OctokitResponse<PullsListResponseData>)
+      )
+      compareCommitsSpy.mockReturnValue(
+        Promise.resolve(({
+          commits: [{ ...mockGitCommit, author: null }],
           total_commits: 1,
         } as unknown) as ReposCompareCommitsResponseData)
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,10 +1971,10 @@ eslint-config-airbnb@^18.2.0:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
-eslint-config-prettier@>=6.10.1, eslint-config-prettier@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
-  integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
+eslint-config-prettier@>=6.10.1, eslint-config-prettier@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.0.0.tgz#024d661444319686c588c8849c8da33815dbdb1c"
+  integrity sha512-5EaAVPsIHu+grmm5WKjxUia4yHgRrbkd8I0ffqUSwixCPMVBrbS97UnzlEY/Q7OWo584vgixefM0kJnUfo/VjA==
 
 eslint-import-resolver-alias@^1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,10 +36,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.0.2.tgz#2f614b6e69ce14d191180451eb38e6576a6e6b27"
   integrity sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg==
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
-  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+"@babel/code-frame@7.12.11", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   dependencies:
     "@babel/highlight" "^7.10.4"
 
@@ -2125,12 +2125,12 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.19.0:
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.19.0.tgz#6719621b196b5fad72e43387981314e5d0dc3f41"
-  integrity sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==
+eslint@^7.20.0:
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.20.0.tgz#db07c4ca4eda2e2316e7aa57ac7fc91ec550bdc7"
+  integrity sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
+    "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.3.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
@@ -2142,7 +2142,7 @@ eslint@^7.19.0:
     eslint-utils "^2.1.0"
     eslint-visitor-keys "^2.0.0"
     espree "^7.3.1"
-    esquery "^1.2.0"
+    esquery "^1.4.0"
     esutils "^2.0.2"
     file-entry-cache "^6.0.0"
     functional-red-black-tree "^1.0.1"
@@ -2182,10 +2182,10 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
-  integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,13 +2083,12 @@ eslint-plugin-prettier@>=3.1.2, eslint-plugin-prettier@^3.3.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-unused-imports@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.0.3.tgz#0be330ca0f4b502e3e7357ba8dce0a9532694fbb"
-  integrity sha512-TKVBPovo53zPeg1msczfX91bbPj0aBwk7o+vYi26JIcd5jTgO1C3elcpJVc0reB0cbrB1JukT/zhquX9Y8Lw/w==
+eslint-plugin-unused-imports@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.0.tgz#4236063175c83f99cef42ea339a66679d75be19a"
+  integrity sha512-4SLYlkCwAbudvKDKZqn/3KjHlKAoorTxnP7AkAMMXkz59pQCBUjKPEaDv5pQ7fOyfDvLPCJKLowCcTl6HXcCuA==
   dependencies:
     eslint-rule-composer "^0.3.0"
-    requireindex "~1.2.0"
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
@@ -4573,11 +4572,6 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-requireindex@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,10 +2046,10 @@ eslint-plugin-jest@^24.1.3:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-jsdoc@^31.6.1:
-  version "31.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-31.6.1.tgz#98040c801500572fff71c984a097d89946f1e450"
-  integrity sha512-5hCV3u+1VSEUMyfdTl+dpWsioD7tqQr2ILQw+KbXrF42AVxCLO8gnNLR6zDCDjqGGpt79V1sgY0RRchCWuCigg==
+eslint-plugin-jsdoc@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.2.0.tgz#d848ea8475a9be63d8d261bd7fa01cf2a2bb32d5"
+  integrity sha512-ikeVeF3JVmzjcmGd04OZK0rXjgiw46TWtNX+OhyF2jQlw3w1CAU1vyAyLv8PZcIjp7WxP4N20Vg1CI9bp/52dw==
   dependencies:
     comment-parser "1.1.2"
     debug "^4.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5166,10 +5166,10 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-ts-jest@^26.5.0:
-  version "26.5.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.0.tgz#3e3417d91bc40178a6716d7dacc5b0505835aa21"
-  integrity sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==
+ts-jest@^26.5.2:
+  version "26.5.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.2.tgz#5281d6b44c2f94f71205728a389edc3d7995b0c4"
+  integrity sha512-bwyJ2zJieSugf7RB+o8fgkMeoMVMM2KPDE0UklRLuACxjwJsOrZNo6chrcScmK33YavPSwhARffy8dZx5LJdUQ==
   dependencies:
     "@types/jest" "26.x"
     bs-logger "0.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5286,10 +5286,10 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
-unique-names-generator@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/unique-names-generator/-/unique-names-generator-4.3.1.tgz#f61ec2290b2f865894af01afb40f3e1043bb8fa2"
-  integrity sha512-oxkKrDXbwx6I5M963SdfmMH2t8n1OIfYyzoJ25BmDeETlyWAZjTbMXwIEMiQDex4lkD2pqe+9gxDJQAB2IOfDg==
+unique-names-generator@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/unique-names-generator/-/unique-names-generator-4.4.0.tgz#8adc33aaff899beaa36247965090bb154370df3f"
+  integrity sha512-0noP+m59TGwolNqnmXfiqMA5KiTudIk6D0VgzNkk2C1Jv3Lr+sY3T07nEWBg8Uq92/FjGca1klsRR6CXFriqFw==
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Release Candidate 2021-02-24-0258 (Zealous Zebra)

### Pull Requests

- #383 Don't assume that a commit author will have a Github login, take 2 ([STUDIO-1567](https://shuttlerock.atlassian.net/browse/STUDIO-1567))
- #385 Use a bigger CircleCI instance for selected tests ([STUDIO-1568](https://shuttlerock.atlassian.net/browse/STUDIO-1568))

### Dependency updates

- Bump eslint-plugin-unused-imports from 1.0.3 to [1.1.0](https://github.com/Shuttlerock/actions/commit/6671a04fda170064446f5ff436354c6e0220ac12)
- Bump ts-jest from 26.5.0 to [26.5.2](https://github.com/Shuttlerock/actions/commit/fc22587c398636d8b601a487a7bf1849eb2c0d36)
- Bump unique-names-generator from 4.3.1 to [4.4.0](https://github.com/Shuttlerock/actions/commit/9f0e9426c2d481cfa9944932455b2cf17fe8fafa)
- Bump eslint from 7.19.0 to [7.20.0](https://github.com/Shuttlerock/actions/commit/f4fdb7dcdf6982f844729e7db7f7c91270ee3554)
- Bump eslint-config-prettier from 7.2.0 to [8.0.0](https://github.com/Shuttlerock/actions/commit/2aacf421167f9fecfdb742575367e6e2c85cda6b)
- Bump eslint-plugin-jsdoc from 31.6.1 to [32.2.0](https://github.com/Shuttlerock/actions/commit/a3b642413d2c7469063abe009d5ab262a310f026)
