### PR TITLE
[SHARED-69] Support Jira state names from the Security project

### DIFF
--- a/.meta/SHARED-69.md
+++ b/.meta/SHARED-69.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SHARED-69
+
+Created at 2021-03-11T06:49:46.244Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61688,7 +61688,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61698,6 +61698,7 @@ const Client_1 = __nccwpck_require__(3861);
 exports.JiraStatusDone = 'Done';
 exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
+exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
@@ -61966,10 +61967,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
 const Client_1 = __nccwpck_require__(3861);
+const Issue_1 = __nccwpck_require__(8273);
 /**
  * Fetches the board definition for the given project ID.
  *
@@ -62007,6 +62010,28 @@ const getColumns = (projectId) => __awaiter(void 0, void 0, void 0, function* ()
     return data.columnConfig.columns;
 });
 exports.getColumns = getColumns;
+/**
+ * Some boards use 'In progress' rather than 'In development' to mark issues as in-progress.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as in-progress.
+ */
+const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
+    core_1.info(`Finding the 'In progress' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    if (isNil_1.default(inProgressColumn)) {
+        throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
+    }
+    return inProgressColumn;
+});
+exports.getInProgressColumn = getInProgressColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -61686,7 +61686,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61696,6 +61696,7 @@ const Client_1 = __nccwpck_require__(3861);
 exports.JiraStatusDone = 'Done';
 exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
+exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
@@ -61964,10 +61965,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
 const Client_1 = __nccwpck_require__(3861);
+const Issue_1 = __nccwpck_require__(8273);
 /**
  * Fetches the board definition for the given project ID.
  *
@@ -62005,6 +62008,28 @@ const getColumns = (projectId) => __awaiter(void 0, void 0, void 0, function* ()
     return data.columnConfig.columns;
 });
 exports.getColumns = getColumns;
+/**
+ * Some boards use 'In progress' rather than 'In development' to mark issues as in-progress.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as in-progress.
+ */
+const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
+    core_1.info(`Finding the 'In progress' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    if (isNil_1.default(inProgressColumn)) {
+        throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
+    }
+    return inProgressColumn;
+});
+exports.getInProgressColumn = getInProgressColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61621,7 +61621,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61631,6 +61631,7 @@ const Client_1 = __nccwpck_require__(3861);
 exports.JiraStatusDone = 'Done';
 exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
+exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
@@ -61899,10 +61900,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
 const Client_1 = __nccwpck_require__(3861);
+const Issue_1 = __nccwpck_require__(8273);
 /**
  * Fetches the board definition for the given project ID.
  *
@@ -61940,6 +61943,28 @@ const getColumns = (projectId) => __awaiter(void 0, void 0, void 0, function* ()
     return data.columnConfig.columns;
 });
 exports.getColumns = getColumns;
+/**
+ * Some boards use 'In progress' rather than 'In development' to mark issues as in-progress.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as in-progress.
+ */
+const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
+    core_1.info(`Finding the 'In progress' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    if (isNil_1.default(inProgressColumn)) {
+        throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
+    }
+    return inProgressColumn;
+});
+exports.getInProgressColumn = getInProgressColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -60353,12 +60353,18 @@ const pullRequestConvertedToDraft = (payload) => __awaiter(void 0, void 0, void 
         core_1.info(`Couldn't find a Jira issue for ${prName} - ignoring`);
         return;
     }
-    if (issue.fields.status.name === Jira_1.JiraStatusInDevelopment) {
-        core_1.info(`Jira issue ${issueKey} is already in '${Jira_1.JiraStatusInDevelopment}' - ignoring`);
+    if (isNil_1.default(issue.fields.project)) {
+        core_1.info(`Couldn't find a project for Jira issue ${issueKey} - ignoring`);
         return;
     }
-    core_1.info(`Moving Jira issue ${issueKey} to '${Jira_1.JiraStatusInDevelopment}'...`);
-    yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusInDevelopment);
+    // Some boards use 'In progress' rather than 'In development'.
+    const inProgressColumn = yield Jira_1.getInProgressColumn(issue.fields.project.id);
+    if (issue.fields.status.name === inProgressColumn) {
+        core_1.info(`Jira issue ${issueKey} is already in '${inProgressColumn}' - ignoring`);
+        return;
+    }
+    core_1.info(`Moving Jira issue ${issueKey} to '${inProgressColumn}'...`);
+    yield Jira_1.setIssueStatus(issue.id, inProgressColumn);
     core_1.info(`Adding the '${Constants_1.InProgressLabel}' label...`);
     yield Github_1.addLabels(repository.name, pullRequest.number, [Constants_1.InProgressLabel]);
 });
@@ -61596,7 +61602,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61606,6 +61612,7 @@ const Client_1 = __nccwpck_require__(3861);
 exports.JiraStatusDone = 'Done';
 exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
+exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
@@ -61874,10 +61881,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
 const Client_1 = __nccwpck_require__(3861);
+const Issue_1 = __nccwpck_require__(8273);
 /**
  * Fetches the board definition for the given project ID.
  *
@@ -61915,6 +61924,28 @@ const getColumns = (projectId) => __awaiter(void 0, void 0, void 0, function* ()
     return data.columnConfig.columns;
 });
 exports.getColumns = getColumns;
+/**
+ * Some boards use 'In progress' rather than 'In development' to mark issues as in-progress.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as in-progress.
+ */
+const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
+    core_1.info(`Finding the 'In progress' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    if (isNil_1.default(inProgressColumn)) {
+        throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
+    }
+    return inProgressColumn;
+});
+exports.getInProgressColumn = getInProgressColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61590,7 +61590,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61600,6 +61600,7 @@ const Client_1 = __nccwpck_require__(3861);
 exports.JiraStatusDone = 'Done';
 exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
+exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
@@ -61868,10 +61869,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
 const Client_1 = __nccwpck_require__(3861);
+const Issue_1 = __nccwpck_require__(8273);
 /**
  * Fetches the board definition for the given project ID.
  *
@@ -61909,6 +61912,28 @@ const getColumns = (projectId) => __awaiter(void 0, void 0, void 0, function* ()
     return data.columnConfig.columns;
 });
 exports.getColumns = getColumns;
+/**
+ * Some boards use 'In progress' rather than 'In development' to mark issues as in-progress.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as in-progress.
+ */
+const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
+    core_1.info(`Finding the 'In progress' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    if (isNil_1.default(inProgressColumn)) {
+        throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
+    }
+    return inProgressColumn;
+});
+exports.getInProgressColumn = getInProgressColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61604,7 +61604,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61614,6 +61614,7 @@ const Client_1 = __nccwpck_require__(3861);
 exports.JiraStatusDone = 'Done';
 exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
+exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
@@ -61882,10 +61883,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
 const Client_1 = __nccwpck_require__(3861);
+const Issue_1 = __nccwpck_require__(8273);
 /**
  * Fetches the board definition for the given project ID.
  *
@@ -61923,6 +61926,28 @@ const getColumns = (projectId) => __awaiter(void 0, void 0, void 0, function* ()
     return data.columnConfig.columns;
 });
 exports.getColumns = getColumns;
+/**
+ * Some boards use 'In progress' rather than 'In development' to mark issues as in-progress.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as in-progress.
+ */
+const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
+    core_1.info(`Finding the 'In progress' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    if (isNil_1.default(inProgressColumn)) {
+        throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
+    }
+    return inProgressColumn;
+});
+exports.getInProgressColumn = getInProgressColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/src/services/Jira/Issue.ts
+++ b/src/services/Jira/Issue.ts
@@ -69,6 +69,7 @@ interface IssueSearchResults {
 export const JiraStatusDone = 'Done'
 export const JiraStatusHasIssues = 'Has issues'
 export const JiraStatusInDevelopment = 'In development'
+export const JiraStatusInProgress = 'In progress' // Alternative to 'In development' in some boards.
 export const JiraStatusReadyForPlanning = 'Ready for planning'
 export const JiraStatusTechnicalPlanning = 'Technical Planning'
 export const JiraStatusTechReview = 'Tech review'

--- a/src/services/Jira/__tests__/Project.test.ts
+++ b/src/services/Jira/__tests__/Project.test.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch'
 
 import { client } from '@sr-services/Jira/Client'
+import { JiraStatusInProgress } from '@sr-services/Jira/Issue'
 import * as Project from '@sr-services/Jira/Project'
 import {
   mockJiraBoard,
@@ -36,6 +37,19 @@ describe('Project', () => {
       const columns = (await Project.getColumns('10003')) || []
       expect(columns.length).toEqual(1)
       expect(columns[0].name).toEqual(mockJiraBoardColumn.name)
+      spy.mockRestore()
+    })
+  })
+
+  describe('getInProgressColumn', () => {
+    it('returns the correct column name', async () => {
+      const spy = jest
+        .spyOn(Project, 'getColumns')
+        .mockReturnValue(
+          Promise.resolve([mockJiraBoardColumn, { name: JiraStatusInProgress }])
+        )
+      const columnName = await Project.getInProgressColumn('10003')
+      expect(columnName).toEqual(JiraStatusInProgress)
       spy.mockRestore()
     })
   })

--- a/src/triggers/__tests__/jiraIssueTransitioned.test.ts
+++ b/src/triggers/__tests__/jiraIssueTransitioned.test.ts
@@ -8,6 +8,7 @@ jest.mock('@sr-services/Jira', () => ({
   getBoard: jest.fn(),
   getChildIssues: jest.fn(),
   getColumns: jest.fn(),
+  getInProgressColumn: jest.fn(),
   getIssue: jest.fn(),
   isIssueOnBoard: jest.fn(),
   JiraIssueTypeEpic: 'Epic',
@@ -33,6 +34,7 @@ describe('jiraIssueTransitioned', () => {
   let getBoardSpy: jest.SpyInstance
   let getChildIssuesSpy: jest.SpyInstance
   let getColumnsSpy: jest.SpyInstance
+  let getInProgressColumnSpy: jest.SpyInstance
   let getIssueSpy: jest.SpyInstance
   let infoSpy: jest.SpyInstance
   let isIssueOnBoardSpy: jest.SpyInstance
@@ -45,6 +47,9 @@ describe('jiraIssueTransitioned', () => {
       .mockImplementation((_projectId: string) =>
         Promise.resolve(mockJiraBoard)
       )
+    getInProgressColumnSpy = jest
+      .spyOn(Jira, 'getInProgressColumn')
+      .mockReturnValue(Promise.resolve(Jira.JiraStatusInDevelopment))
     getChildIssuesSpy = jest
       .spyOn(Jira, 'getChildIssues')
       .mockImplementation((_key: string) => Promise.resolve([childIssue]))
@@ -78,6 +83,7 @@ describe('jiraIssueTransitioned', () => {
     getBoardSpy.mockRestore()
     getChildIssuesSpy.mockRestore()
     getColumnsSpy.mockRestore()
+    getInProgressColumnSpy.mockRestore()
     getIssueSpy.mockRestore()
     infoSpy.mockRestore()
     isIssueOnBoardSpy.mockRestore()


### PR DESCRIPTION
## Support Jira state names from the Security project

[Jira Chore](https://shuttlerock.atlassian.net/browse/SHARED-69)

Currently we use &#x60;In Progress&#x60; instead of &#x60;In Development&#x60; in the &#x60;Security&#x60; board. We want to make sure we can create PRs there without throwing errors.

## How to test the PR

Create a PR for `compliance` repo via the SECURITY project in Jira, by moving to the `In progress` column.

## Deployment Notes

None