### PR TITLE
[SECURITY-207] Handle 'Review' column during Jira automation

### DIFF
--- a/.meta/SECURITY-207.md
+++ b/.meta/SECURITY-207.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-207
+
+Created at 2021-03-16T06:27:54.353Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61688,7 +61688,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReview = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61700,6 +61700,7 @@ exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
 exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
+exports.JiraStatusReview = 'Review'; // Alternative to 'Tech review' in some boards.
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
@@ -61967,7 +61968,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -62032,6 +62033,28 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     return inProgressColumn;
 });
 exports.getInProgressColumn = getInProgressColumn;
+/**
+ * Some boards use 'Review' rather than 'Tech review' to mark issues as ready-for-review.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as ready-for-review.
+ */
+const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _b;
+    core_1.info(`Finding the 'Review' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    if (isNil_1.default(reviewColumn)) {
+        throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
+    }
+    return reviewColumn;
+});
+exports.getReviewColumn = getReviewColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -61686,7 +61686,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReview = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61698,6 +61698,7 @@ exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
 exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
+exports.JiraStatusReview = 'Review'; // Alternative to 'Tech review' in some boards.
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
@@ -61965,7 +61966,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -62030,6 +62031,28 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     return inProgressColumn;
 });
 exports.getInProgressColumn = getInProgressColumn;
+/**
+ * Some boards use 'Review' rather than 'Tech review' to mark issues as ready-for-review.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as ready-for-review.
+ */
+const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _b;
+    core_1.info(`Finding the 'Review' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    if (isNil_1.default(reviewColumn)) {
+        throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
+    }
+    return reviewColumn;
+});
+exports.getReviewColumn = getReviewColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61621,7 +61621,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReview = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61633,6 +61633,7 @@ exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
 exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
+exports.JiraStatusReview = 'Review'; // Alternative to 'Tech review' in some boards.
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
@@ -61900,7 +61901,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61965,6 +61966,28 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     return inProgressColumn;
 });
 exports.getInProgressColumn = getInProgressColumn;
+/**
+ * Some boards use 'Review' rather than 'Tech review' to mark issues as ready-for-review.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as ready-for-review.
+ */
+const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _b;
+    core_1.info(`Finding the 'Review' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    if (isNil_1.default(reviewColumn)) {
+        throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
+    }
+    return reviewColumn;
+});
+exports.getReviewColumn = getReviewColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61602,7 +61602,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReview = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61614,6 +61614,7 @@ exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
 exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
+exports.JiraStatusReview = 'Review'; // Alternative to 'Tech review' in some boards.
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
@@ -61881,7 +61882,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61946,6 +61947,28 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     return inProgressColumn;
 });
 exports.getInProgressColumn = getInProgressColumn;
+/**
+ * Some boards use 'Review' rather than 'Tech review' to mark issues as ready-for-review.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as ready-for-review.
+ */
+const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _b;
+    core_1.info(`Finding the 'Review' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    if (isNil_1.default(reviewColumn)) {
+        throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
+    }
+    return reviewColumn;
+});
+exports.getReviewColumn = getReviewColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61590,7 +61590,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReview = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61602,6 +61602,7 @@ exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
 exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
+exports.JiraStatusReview = 'Review'; // Alternative to 'Tech review' in some boards.
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
@@ -61869,7 +61870,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61934,6 +61935,28 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     return inProgressColumn;
 });
 exports.getInProgressColumn = getInProgressColumn;
+/**
+ * Some boards use 'Review' rather than 'Tech review' to mark issues as ready-for-review.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as ready-for-review.
+ */
+const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _b;
+    core_1.info(`Finding the 'Review' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    if (isNil_1.default(reviewColumn)) {
+        throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
+    }
+    return reviewColumn;
+});
+exports.getReviewColumn = getReviewColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60363,12 +60363,18 @@ const pullRequestReadyForReview = (payload) => __awaiter(void 0, void 0, void 0,
         core_1.info(`Couldn't find a Jira issue for ${prName} - ignoring`);
         return;
     }
-    if (issue.fields.status.name === Jira_1.JiraStatusTechReview) {
-        core_1.info(`Jira issue ${issueKey} is already in '${Jira_1.JiraStatusTechReview}' - ignoring`);
+    if (isNil_1.default(issue.fields.project)) {
+        core_1.info(`Couldn't find a project for Jira issue ${issueKey} - ignoring`);
         return;
     }
-    core_1.info(`Moving Jira issue ${issueKey} to '${Jira_1.JiraStatusTechReview}'...`);
-    yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusTechReview);
+    // Some boards use 'Review' rather than 'Tech review'.
+    const reviewColumn = yield Jira_1.getReviewColumn(issue.fields.project.id);
+    if (issue.fields.status.name === reviewColumn) {
+        core_1.info(`Jira issue ${issueKey} is already in '${reviewColumn}' - ignoring`);
+        return;
+    }
+    core_1.info(`Moving Jira issue ${issueKey} to '${reviewColumn}'...`);
+    yield Jira_1.setIssueStatus(issue.id, reviewColumn);
 });
 exports.pullRequestReadyForReview = pullRequestReadyForReview;
 
@@ -61604,7 +61610,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReview = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61616,6 +61622,7 @@ exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
 exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
+exports.JiraStatusReview = 'Review'; // Alternative to 'Tech review' in some boards.
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
@@ -61883,7 +61890,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61948,6 +61955,28 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     return inProgressColumn;
 });
 exports.getInProgressColumn = getInProgressColumn;
+/**
+ * Some boards use 'Review' rather than 'Tech review' to mark issues as ready-for-review.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as ready-for-review.
+ */
+const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _b;
+    core_1.info(`Finding the 'Review' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    if (isNil_1.default(reviewColumn)) {
+        throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
+    }
+    return reviewColumn;
+});
+exports.getReviewColumn = getReviewColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -62925,7 +62925,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
+exports.updateCustomField = exports.setVersion = exports.setIssueStatus = exports.moveIssueToBoard = exports.issueUrl = exports.isIssueOnBoard = exports.getIssuePullRequestNumbers = exports.recursiveGetEpic = exports.getEpic = exports.getIssue = exports.getChildIssues = exports.JiraFieldStoryPointEstimate = exports.JiraFieldRepository = exports.JiraLabelSkipPR = exports.JiraIssueTypeEpic = exports.JiraStatusValidated = exports.JiraStatusTechReview = exports.JiraStatusTechnicalPlanning = exports.JiraStatusReview = exports.JiraStatusReadyForPlanning = exports.JiraStatusInProgress = exports.JiraStatusInDevelopment = exports.JiraStatusHasIssues = exports.JiraStatusDone = void 0;
 const core_1 = __nccwpck_require__(42186);
 const isNil_1 = __importDefault(__nccwpck_require__(84977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(80467));
@@ -62937,6 +62937,7 @@ exports.JiraStatusHasIssues = 'Has issues';
 exports.JiraStatusInDevelopment = 'In development';
 exports.JiraStatusInProgress = 'In progress'; // Alternative to 'In development' in some boards.
 exports.JiraStatusReadyForPlanning = 'Ready for planning';
+exports.JiraStatusReview = 'Review'; // Alternative to 'Tech review' in some boards.
 exports.JiraStatusTechnicalPlanning = 'Technical Planning';
 exports.JiraStatusTechReview = 'Tech review';
 exports.JiraStatusValidated = 'Validated';
@@ -63204,7 +63205,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(42186);
 const isNil_1 = __importDefault(__nccwpck_require__(84977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(80467));
@@ -63269,6 +63270,28 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     return inProgressColumn;
 });
 exports.getInProgressColumn = getInProgressColumn;
+/**
+ * Some boards use 'Review' rather than 'Tech review' to mark issues as ready-for-review.
+ * This fetches the column names for the project and decides which one is appropriate.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as ready-for-review.
+ */
+const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _b;
+    core_1.info(`Finding the 'Review' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    if (isNil_1.default(reviewColumn)) {
+        throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
+    }
+    return reviewColumn;
+});
+exports.getReviewColumn = getReviewColumn;
 /**
  * Fetches the project with the given ID.
  *
@@ -63921,7 +63944,7 @@ const createPullRequestForJiraIssue = (email, issueKey) => __awaiter(void 0, voi
     const issue = yield Jira_1.getIssue(issueKey);
     if (isNil_1.default(issue)) {
         const credentials = yield Credentials_1.fetchCredentials(email);
-        const message = `Issue ${issueKey}> could not be found, so no pull request was created`;
+        const message = `Issue ${issueKey} could not be found, so no pull request was created`;
         yield Slack_1.sendUserMessage(credentials.slack_id, message);
         core_1.error(message);
         return;

--- a/src/actions/pull-request-ready-for-review-action/__tests__/pullRequestReadyForReview.test.ts
+++ b/src/actions/pull-request-ready-for-review-action/__tests__/pullRequestReadyForReview.test.ts
@@ -15,7 +15,9 @@ import {
 } from '@sr-tests/Mocks'
 
 jest.mock('@sr-services/Jira', () => ({
+  getReviewColumn: jest.fn(),
   getIssue: jest.fn(),
+  JiraStatusTechReview: 'Tech review',
   setIssueStatus: jest.fn(),
 }))
 jest.mock('@sr-services/Github', () => ({
@@ -34,8 +36,9 @@ describe('pull-request-ready-for-review-action', () => {
     let addLabelsSpy: jest.SpyInstance
     let assignReviewersSpy: jest.SpyInstance
     let fetchRepositorySpy: jest.SpyInstance
-    let getIssueSpy: jest.SpyInstance
     let getIssueKeySpy: jest.SpyInstance
+    let getIssueSpy: jest.SpyInstance
+    let getReviewColumnSpy: jest.SpyInstance
     let infoSpy: jest.SpyInstance
     let setIssueStatusSpy: jest.SpyInstance
 
@@ -63,6 +66,9 @@ describe('pull-request-ready-for-review-action', () => {
       getIssueKeySpy = jest
         .spyOn(Github, 'getIssueKey')
         .mockImplementation((_pr: Github.PullRequestContent) => 'ISSUE-236')
+      getReviewColumnSpy = jest
+        .spyOn(Jira, 'getReviewColumn')
+        .mockReturnValue(Promise.resolve(Jira.JiraStatusTechReview))
       infoSpy = jest
         .spyOn(core, 'info')
         .mockImplementation((_message: string) => undefined)
@@ -79,6 +85,7 @@ describe('pull-request-ready-for-review-action', () => {
       fetchRepositorySpy.mockRestore()
       getIssueSpy.mockRestore()
       getIssueKeySpy.mockRestore()
+      getReviewColumnSpy.mockRestore()
       infoSpy.mockRestore()
       setIssueStatusSpy.mockRestore()
     })

--- a/src/services/Jira/Issue.ts
+++ b/src/services/Jira/Issue.ts
@@ -71,6 +71,7 @@ export const JiraStatusHasIssues = 'Has issues'
 export const JiraStatusInDevelopment = 'In development'
 export const JiraStatusInProgress = 'In progress' // Alternative to 'In development' in some boards.
 export const JiraStatusReadyForPlanning = 'Ready for planning'
+export const JiraStatusReview = 'Review' // Alternative to 'Tech review' in some boards.
 export const JiraStatusTechnicalPlanning = 'Technical Planning'
 export const JiraStatusTechReview = 'Tech review'
 export const JiraStatusValidated = 'Validated'

--- a/src/services/Jira/__tests__/Project.test.ts
+++ b/src/services/Jira/__tests__/Project.test.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch'
 
 import { client } from '@sr-services/Jira/Client'
-import { JiraStatusInProgress } from '@sr-services/Jira/Issue'
+import { JiraStatusInProgress, JiraStatusReview } from '@sr-services/Jira/Issue'
 import * as Project from '@sr-services/Jira/Project'
 import {
   mockJiraBoard,
@@ -50,6 +50,19 @@ describe('Project', () => {
         )
       const columnName = await Project.getInProgressColumn('10003')
       expect(columnName).toEqual(JiraStatusInProgress)
+      spy.mockRestore()
+    })
+  })
+
+  describe('getReviewColumn', () => {
+    it('returns the correct column name', async () => {
+      const spy = jest
+        .spyOn(Project, 'getColumns')
+        .mockReturnValue(
+          Promise.resolve([mockJiraBoardColumn, { name: JiraStatusReview }])
+        )
+      const columnName = await Project.getReviewColumn('10003')
+      expect(columnName).toEqual(JiraStatusReview)
       spy.mockRestore()
     })
   })

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -50,7 +50,7 @@ export const createPullRequestForJiraIssue = async (
   const issue = await getIssue(issueKey)
   if (isNil(issue)) {
     const credentials = await fetchCredentials(email)
-    const message = `Issue ${issueKey}> could not be found, so no pull request was created`
+    const message = `Issue ${issueKey} could not be found, so no pull request was created`
     await sendUserMessage(credentials.slack_id, message)
     error(message)
     return


### PR DESCRIPTION
## Handle 'Review' column during Jira automation

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-207)

Some boards call it &#x60;Tech review&#x60;, others just &#x60;Review&#x60;.

## How to test the PR

Mark a security issue as `Ready for review`

## Deployment Notes

None