### PR TITLE
[SECURITY-177] Auto-assign dependabot and security PRs to the project tech lead

### DIFF
--- a/.meta/SECURITY-177.md
+++ b/.meta/SECURITY-177.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-177
+
+Created at 2021-03-24T01:33:04.115Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -60465,7 +60465,7 @@ exports.checkSuiteCompleted = checkSuiteCompleted;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.SecurityLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
 // Labels.
 exports.DependenciesLabel = 'dependencies';
 exports.EpicLabel = 'epic';
@@ -60476,6 +60476,7 @@ exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
 exports.ReleaseLabel = 'release';
+exports.SecurityLabel = 'security';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -60463,7 +60463,7 @@ exports.run().catch(err => {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.SecurityLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
 // Labels.
 exports.DependenciesLabel = 'dependencies';
 exports.EpicLabel = 'epic';
@@ -60474,6 +60474,7 @@ exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
 exports.ReleaseLabel = 'release';
+exports.SecurityLabel = 'security';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -60398,7 +60398,7 @@ exports.pullRequestClosed = pullRequestClosed;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.SecurityLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
 // Labels.
 exports.DependenciesLabel = 'dependencies';
 exports.EpicLabel = 'epic';
@@ -60409,6 +60409,7 @@ exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
 exports.ReleaseLabel = 'release';
+exports.SecurityLabel = 'security';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -60379,7 +60379,7 @@ exports.pullRequestConvertedToDraft = pullRequestConvertedToDraft;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.SecurityLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
 // Labels.
 exports.DependenciesLabel = 'dependencies';
 exports.EpicLabel = 'epic';
@@ -60390,6 +60390,7 @@ exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
 exports.ReleaseLabel = 'release';
+exports.SecurityLabel = 'security';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60343,9 +60343,14 @@ const pullRequestReadyForReview = (payload) => __awaiter(void 0, void 0, void 0,
     core_1.info('Fetching repository details...');
     const repo = yield Credentials_1.fetchRepository(repository.name);
     const reviewers = repo.reviewers.map((user) => user.github_username);
-    core_1.info(`Assigning reviewers (${reviewers.join(', ')})...`);
     if (reviewers.length > 0) {
+        core_1.info(`Assigning reviewers (${reviewers.join(', ')})...`);
         yield Github_1.assignReviewers(repository.name, pullRequest.number, reviewers);
+    }
+    const owners = repo.leads.map((user) => user.github_username);
+    if (owners.length > 0) {
+        core_1.info(`Assigning owners (${owners.join(', ')})...`);
+        yield Github_1.assignOwners(repository.name, pullRequest.number, owners);
     }
     core_1.info(`Adding the '${Constants_1.PleaseReviewLabel}' label...`);
     yield Github_1.addLabels(repository.name, pullRequest.number, [Constants_1.PleaseReviewLabel]);
@@ -60387,7 +60392,7 @@ exports.pullRequestReadyForReview = pullRequestReadyForReview;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.SecurityLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
 // Labels.
 exports.DependenciesLabel = 'dependencies';
 exports.EpicLabel = 'epic';
@@ -60398,6 +60403,7 @@ exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
 exports.ReleaseLabel = 'release';
+exports.SecurityLabel = 'security';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61702,7 +61702,7 @@ exports.run().catch((err) => __awaiter(void 0, void 0, void 0, function* () {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
+exports.ReleaseBranchName = exports.MasterBranchName = exports.DevelopBranchName = exports.GithubWriteUser = exports.UnderDiscussionLabel = exports.SecurityLabel = exports.ReleaseLabel = exports.PleaseReviewLabel = exports.PassedReviewLabel = exports.InProgressLabel = exports.HasIssuesLabel = exports.HasFailuresLabel = exports.HasConflictsLabel = exports.EpicLabel = exports.DependenciesLabel = void 0;
 // Labels.
 exports.DependenciesLabel = 'dependencies';
 exports.EpicLabel = 'epic';
@@ -61713,6 +61713,7 @@ exports.InProgressLabel = 'in-progress';
 exports.PassedReviewLabel = 'passed-review';
 exports.PleaseReviewLabel = 'please-review';
 exports.ReleaseLabel = 'release';
+exports.SecurityLabel = 'security';
 exports.UnderDiscussionLabel = 'under-discussion';
 // The Github user our actions use.
 exports.GithubWriteUser = 'sr-devops';

--- a/src/actions/pull-request-ready-for-review-action/pullRequestReadyForReview.ts
+++ b/src/actions/pull-request-ready-for-review-action/pullRequestReadyForReview.ts
@@ -4,7 +4,12 @@ import isNil from 'lodash/isNil'
 
 import { PleaseReviewLabel } from '@sr-services/Constants'
 import { fetchRepository, User } from '@sr-services/Credentials'
-import { addLabels, assignReviewers, getIssueKey } from '@sr-services/Github'
+import {
+  addLabels,
+  assignOwners,
+  assignReviewers,
+  getIssueKey,
+} from '@sr-services/Github'
 import { getReviewColumn, getIssue, setIssueStatus } from '@sr-services/Jira'
 
 /**
@@ -19,11 +24,17 @@ export const pullRequestReadyForReview = async (
 
   info('Fetching repository details...')
   const repo = await fetchRepository(repository.name)
-  const reviewers = repo.reviewers.map((user: User) => user.github_username)
 
-  info(`Assigning reviewers (${reviewers.join(', ')})...`)
+  const reviewers = repo.reviewers.map((user: User) => user.github_username)
   if (reviewers.length > 0) {
+    info(`Assigning reviewers (${reviewers.join(', ')})...`)
     await assignReviewers(repository.name, pullRequest.number, reviewers)
+  }
+
+  const owners = repo.leads.map((user: User) => user.github_username)
+  if (owners.length > 0) {
+    info(`Assigning owners (${owners.join(', ')})...`)
+    await assignOwners(repository.name, pullRequest.number, owners)
   }
 
   info(`Adding the '${PleaseReviewLabel}' label...`)

--- a/src/services/Constants.ts
+++ b/src/services/Constants.ts
@@ -8,6 +8,7 @@ export const InProgressLabel = 'in-progress'
 export const PassedReviewLabel = 'passed-review'
 export const PleaseReviewLabel = 'please-review'
 export const ReleaseLabel = 'release'
+export const SecurityLabel = 'security'
 export const UnderDiscussionLabel = 'under-discussion'
 
 // The Github user our actions use.


### PR DESCRIPTION
## Auto-assign dependabot and security PRs to the project tech lead

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-177)

This will address the Vanta _“Records of security issues being assigned to owners”_ control.

## How to test the PR

Edit `pull-request-labeled.json` so that it adds the `security` label, and then run:

`act --job pull_request_labeled_action --eventpath src/actions/pull-request-labeled-action/__tests__/fixtures/pull-request-labeled.json`

## Deployment Notes

None