### PR TITLE
[SECURITY-238] Handle 'Validated' column during Jira automation

### DIFF
--- a/.meta/SECURITY-238.md
+++ b/.meta/SECURITY-238.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-238
+
+Created at 2021-03-25T07:57:18.596Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61969,7 +61969,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getValidatedColumn = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -62027,7 +62027,10 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    const inProgressColumn = (_a = columns.find((col) => [
+        Issue_1.JiraStatusInDevelopment.toLowerCase(),
+        Issue_1.JiraStatusInProgress.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _a === void 0 ? void 0 : _a.name;
     if (isNil_1.default(inProgressColumn)) {
         throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
     }
@@ -62049,13 +62052,41 @@ const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, functio
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    const reviewColumn = (_b = columns.find((col) => [
+        Issue_1.JiraStatusReview.toLowerCase(),
+        Issue_1.JiraStatusTechReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _b === void 0 ? void 0 : _b.name;
     if (isNil_1.default(reviewColumn)) {
         throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
     }
     return reviewColumn;
 });
 exports.getReviewColumn = getReviewColumn;
+/**
+ * Some boards don't have a 'Validated' column. In that case we will just put them in
+ * 'Review', if it exists.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as validated.
+ */
+const getValidatedColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _c;
+    core_1.info(`Finding the 'Validated' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const validatedColumn = (_c = columns.find((col) => [
+        Issue_1.JiraStatusValidated.toLowerCase(),
+        Issue_1.JiraStatusReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _c === void 0 ? void 0 : _c.name;
+    if (isNil_1.default(validatedColumn)) {
+        throw new Error(`Couldn't find a validated column for project ${projectId} - giving up`);
+    }
+    return validatedColumn;
+});
+exports.getValidatedColumn = getValidatedColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -61967,7 +61967,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getValidatedColumn = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -62025,7 +62025,10 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    const inProgressColumn = (_a = columns.find((col) => [
+        Issue_1.JiraStatusInDevelopment.toLowerCase(),
+        Issue_1.JiraStatusInProgress.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _a === void 0 ? void 0 : _a.name;
     if (isNil_1.default(inProgressColumn)) {
         throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
     }
@@ -62047,13 +62050,41 @@ const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, functio
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    const reviewColumn = (_b = columns.find((col) => [
+        Issue_1.JiraStatusReview.toLowerCase(),
+        Issue_1.JiraStatusTechReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _b === void 0 ? void 0 : _b.name;
     if (isNil_1.default(reviewColumn)) {
         throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
     }
     return reviewColumn;
 });
 exports.getReviewColumn = getReviewColumn;
+/**
+ * Some boards don't have a 'Validated' column. In that case we will just put them in
+ * 'Review', if it exists.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as validated.
+ */
+const getValidatedColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _c;
+    core_1.info(`Finding the 'Validated' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const validatedColumn = (_c = columns.find((col) => [
+        Issue_1.JiraStatusValidated.toLowerCase(),
+        Issue_1.JiraStatusReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _c === void 0 ? void 0 : _c.name;
+    if (isNil_1.default(validatedColumn)) {
+        throw new Error(`Couldn't find a validated column for project ${projectId} - giving up`);
+    }
+    return validatedColumn;
+});
+exports.getValidatedColumn = getValidatedColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -60380,12 +60380,18 @@ const pullRequestClosed = (payload) => __awaiter(void 0, void 0, void 0, functio
         core_1.info(`Couldn't find a Jira issue for ${prName} - ignoring`);
         return;
     }
-    if (issue.fields.status.name === Jira_1.JiraStatusValidated) {
-        core_1.info(`Jira issue ${issueKey} is already in '${Jira_1.JiraStatusValidated}' - ignoring`);
+    if (isNil_1.default(issue.fields.project)) {
+        core_1.info(`Couldn't find a project for Jira issue ${issueKey} - ignoring`);
         return;
     }
-    core_1.info(`Moving Jira issue ${issueKey} to '${Jira_1.JiraStatusValidated}'...`);
-    yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusValidated);
+    // Some boards use 'Review' rather than 'Tech review'.
+    const validatedColumn = yield Jira_1.getValidatedColumn(issue.fields.project.id);
+    if (issue.fields.status.name === validatedColumn) {
+        core_1.info(`Jira issue ${issueKey} is already in '${validatedColumn}' - ignoring`);
+        return;
+    }
+    core_1.info(`Moving Jira issue ${issueKey} to '${validatedColumn}'...`);
+    yield Jira_1.setIssueStatus(issue.id, validatedColumn);
 });
 exports.pullRequestClosed = pullRequestClosed;
 
@@ -61902,7 +61908,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getValidatedColumn = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61960,7 +61966,10 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    const inProgressColumn = (_a = columns.find((col) => [
+        Issue_1.JiraStatusInDevelopment.toLowerCase(),
+        Issue_1.JiraStatusInProgress.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _a === void 0 ? void 0 : _a.name;
     if (isNil_1.default(inProgressColumn)) {
         throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
     }
@@ -61982,13 +61991,41 @@ const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, functio
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    const reviewColumn = (_b = columns.find((col) => [
+        Issue_1.JiraStatusReview.toLowerCase(),
+        Issue_1.JiraStatusTechReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _b === void 0 ? void 0 : _b.name;
     if (isNil_1.default(reviewColumn)) {
         throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
     }
     return reviewColumn;
 });
 exports.getReviewColumn = getReviewColumn;
+/**
+ * Some boards don't have a 'Validated' column. In that case we will just put them in
+ * 'Review', if it exists.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as validated.
+ */
+const getValidatedColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _c;
+    core_1.info(`Finding the 'Validated' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const validatedColumn = (_c = columns.find((col) => [
+        Issue_1.JiraStatusValidated.toLowerCase(),
+        Issue_1.JiraStatusReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _c === void 0 ? void 0 : _c.name;
+    if (isNil_1.default(validatedColumn)) {
+        throw new Error(`Couldn't find a validated column for project ${projectId} - giving up`);
+    }
+    return validatedColumn;
+});
+exports.getValidatedColumn = getValidatedColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61883,7 +61883,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getValidatedColumn = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61941,7 +61941,10 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    const inProgressColumn = (_a = columns.find((col) => [
+        Issue_1.JiraStatusInDevelopment.toLowerCase(),
+        Issue_1.JiraStatusInProgress.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _a === void 0 ? void 0 : _a.name;
     if (isNil_1.default(inProgressColumn)) {
         throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
     }
@@ -61963,13 +61966,41 @@ const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, functio
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    const reviewColumn = (_b = columns.find((col) => [
+        Issue_1.JiraStatusReview.toLowerCase(),
+        Issue_1.JiraStatusTechReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _b === void 0 ? void 0 : _b.name;
     if (isNil_1.default(reviewColumn)) {
         throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
     }
     return reviewColumn;
 });
 exports.getReviewColumn = getReviewColumn;
+/**
+ * Some boards don't have a 'Validated' column. In that case we will just put them in
+ * 'Review', if it exists.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as validated.
+ */
+const getValidatedColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _c;
+    core_1.info(`Finding the 'Validated' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const validatedColumn = (_c = columns.find((col) => [
+        Issue_1.JiraStatusValidated.toLowerCase(),
+        Issue_1.JiraStatusReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _c === void 0 ? void 0 : _c.name;
+    if (isNil_1.default(validatedColumn)) {
+        throw new Error(`Couldn't find a validated column for project ${projectId} - giving up`);
+    }
+    return validatedColumn;
+});
+exports.getValidatedColumn = getValidatedColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61894,7 +61894,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getValidatedColumn = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61952,7 +61952,10 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    const inProgressColumn = (_a = columns.find((col) => [
+        Issue_1.JiraStatusInDevelopment.toLowerCase(),
+        Issue_1.JiraStatusInProgress.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _a === void 0 ? void 0 : _a.name;
     if (isNil_1.default(inProgressColumn)) {
         throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
     }
@@ -61974,13 +61977,41 @@ const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, functio
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    const reviewColumn = (_b = columns.find((col) => [
+        Issue_1.JiraStatusReview.toLowerCase(),
+        Issue_1.JiraStatusTechReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _b === void 0 ? void 0 : _b.name;
     if (isNil_1.default(reviewColumn)) {
         throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
     }
     return reviewColumn;
 });
 exports.getReviewColumn = getReviewColumn;
+/**
+ * Some boards don't have a 'Validated' column. In that case we will just put them in
+ * 'Review', if it exists.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as validated.
+ */
+const getValidatedColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _c;
+    core_1.info(`Finding the 'Validated' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const validatedColumn = (_c = columns.find((col) => [
+        Issue_1.JiraStatusValidated.toLowerCase(),
+        Issue_1.JiraStatusReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _c === void 0 ? void 0 : _c.name;
+    if (isNil_1.default(validatedColumn)) {
+        throw new Error(`Couldn't find a validated column for project ${projectId} - giving up`);
+    }
+    return validatedColumn;
+});
+exports.getValidatedColumn = getValidatedColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61896,7 +61896,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getValidatedColumn = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(2186);
 const isNil_1 = __importDefault(__nccwpck_require__(4977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(467));
@@ -61954,7 +61954,10 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    const inProgressColumn = (_a = columns.find((col) => [
+        Issue_1.JiraStatusInDevelopment.toLowerCase(),
+        Issue_1.JiraStatusInProgress.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _a === void 0 ? void 0 : _a.name;
     if (isNil_1.default(inProgressColumn)) {
         throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
     }
@@ -61976,13 +61979,41 @@ const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, functio
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    const reviewColumn = (_b = columns.find((col) => [
+        Issue_1.JiraStatusReview.toLowerCase(),
+        Issue_1.JiraStatusTechReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _b === void 0 ? void 0 : _b.name;
     if (isNil_1.default(reviewColumn)) {
         throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
     }
     return reviewColumn;
 });
 exports.getReviewColumn = getReviewColumn;
+/**
+ * Some boards don't have a 'Validated' column. In that case we will just put them in
+ * 'Review', if it exists.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as validated.
+ */
+const getValidatedColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _c;
+    core_1.info(`Finding the 'Validated' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const validatedColumn = (_c = columns.find((col) => [
+        Issue_1.JiraStatusValidated.toLowerCase(),
+        Issue_1.JiraStatusReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _c === void 0 ? void 0 : _c.name;
+    if (isNil_1.default(validatedColumn)) {
+        throw new Error(`Couldn't find a validated column for project ${projectId} - giving up`);
+    }
+    return validatedColumn;
+});
+exports.getValidatedColumn = getValidatedColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -63206,7 +63206,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getProject = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
+exports.getProject = exports.getValidatedColumn = exports.getReviewColumn = exports.getInProgressColumn = exports.getColumns = exports.getBoard = void 0;
 const core_1 = __nccwpck_require__(42186);
 const isNil_1 = __importDefault(__nccwpck_require__(84977));
 const node_fetch_1 = __importDefault(__nccwpck_require__(80467));
@@ -63264,7 +63264,10 @@ const getInProgressColumn = (projectId) => __awaiter(void 0, void 0, void 0, fun
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const inProgressColumn = (_a = columns.find((col) => [Issue_1.JiraStatusInDevelopment, Issue_1.JiraStatusInProgress].includes(col.name))) === null || _a === void 0 ? void 0 : _a.name;
+    const inProgressColumn = (_a = columns.find((col) => [
+        Issue_1.JiraStatusInDevelopment.toLowerCase(),
+        Issue_1.JiraStatusInProgress.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _a === void 0 ? void 0 : _a.name;
     if (isNil_1.default(inProgressColumn)) {
         throw new Error(`Couldn't find an in-progress column for project ${projectId} - giving up`);
     }
@@ -63286,13 +63289,41 @@ const getReviewColumn = (projectId) => __awaiter(void 0, void 0, void 0, functio
     if (isNil_1.default(columns) || columns.length === 0) {
         throw new Error(`No columns found for project ${projectId}`);
     }
-    const reviewColumn = (_b = columns.find((col) => [Issue_1.JiraStatusReview, Issue_1.JiraStatusTechReview].includes(col.name))) === null || _b === void 0 ? void 0 : _b.name;
+    const reviewColumn = (_b = columns.find((col) => [
+        Issue_1.JiraStatusReview.toLowerCase(),
+        Issue_1.JiraStatusTechReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _b === void 0 ? void 0 : _b.name;
     if (isNil_1.default(reviewColumn)) {
         throw new Error(`Couldn't find a review column for project ${projectId} - giving up`);
     }
     return reviewColumn;
 });
 exports.getReviewColumn = getReviewColumn;
+/**
+ * Some boards don't have a 'Validated' column. In that case we will just put them in
+ * 'Review', if it exists.
+ *
+ * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
+ *
+ * @returns {string} The name of the column used to mark issues as validated.
+ */
+const getValidatedColumn = (projectId) => __awaiter(void 0, void 0, void 0, function* () {
+    var _c;
+    core_1.info(`Finding the 'Validated' column names for the project ${projectId}...`);
+    const columns = yield exports.getColumns(projectId);
+    if (isNil_1.default(columns) || columns.length === 0) {
+        throw new Error(`No columns found for project ${projectId}`);
+    }
+    const validatedColumn = (_c = columns.find((col) => [
+        Issue_1.JiraStatusValidated.toLowerCase(),
+        Issue_1.JiraStatusReview.toLowerCase(),
+    ].includes(col.name.toLowerCase()))) === null || _c === void 0 ? void 0 : _c.name;
+    if (isNil_1.default(validatedColumn)) {
+        throw new Error(`Couldn't find a validated column for project ${projectId} - giving up`);
+    }
+    return validatedColumn;
+});
+exports.getValidatedColumn = getValidatedColumn;
 /**
  * Fetches the project with the given ID.
  *

--- a/src/actions/pull-request-closed-action/__tests__/pullRequestClosed.test.ts
+++ b/src/actions/pull-request-closed-action/__tests__/pullRequestClosed.test.ts
@@ -14,6 +14,8 @@ import {
 jest.mock('@sr-services/Jira', () => ({
   createRelease: jest.fn(),
   getIssue: jest.fn(),
+  getValidatedColumn: jest.fn(),
+  JiraStatusValidated: 'Validated',
   setIssueStatus: jest.fn(),
 }))
 jest.mock('@sr-services/Github', () => ({
@@ -26,6 +28,7 @@ describe('pull-request-closed-action', () => {
     const prName = `${mockGithubPullRequestPayload.repository.name}#${mockGithubPullRequestPayload.pull_request.number}`
     let getIssueSpy: jest.SpyInstance
     let getIssueKeySpy: jest.SpyInstance
+    let getValidatedColumnSpy: jest.SpyInstance
     let infoSpy: jest.SpyInstance
     let setIssueStatusSpy: jest.SpyInstance
 
@@ -38,6 +41,9 @@ describe('pull-request-closed-action', () => {
       getIssueKeySpy = jest
         .spyOn(Github, 'getIssueKey')
         .mockImplementation((_pr: Github.PullRequestContent) => 'ISSUE-236')
+      getValidatedColumnSpy = jest
+        .spyOn(Jira, 'getValidatedColumn')
+        .mockReturnValue(Promise.resolve(Jira.JiraStatusValidated))
       infoSpy = jest
         .spyOn(core, 'info')
         .mockImplementation((_message: string) => undefined)
@@ -51,6 +57,7 @@ describe('pull-request-closed-action', () => {
     afterEach(() => {
       getIssueSpy.mockRestore()
       getIssueKeySpy.mockRestore()
+      getValidatedColumnSpy.mockRestore()
       infoSpy.mockRestore()
       setIssueStatusSpy.mockRestore()
     })

--- a/src/services/Jira/__tests__/Project.test.ts
+++ b/src/services/Jira/__tests__/Project.test.ts
@@ -1,7 +1,11 @@
 import fetch from 'node-fetch'
 
 import { client } from '@sr-services/Jira/Client'
-import { JiraStatusInProgress, JiraStatusReview } from '@sr-services/Jira/Issue'
+import {
+  JiraStatusInProgress,
+  JiraStatusReview,
+  JiraStatusValidated,
+} from '@sr-services/Jira/Issue'
 import * as Project from '@sr-services/Jira/Project'
 import {
   mockJiraBoard,
@@ -63,6 +67,19 @@ describe('Project', () => {
         )
       const columnName = await Project.getReviewColumn('10003')
       expect(columnName).toEqual(JiraStatusReview)
+      spy.mockRestore()
+    })
+  })
+
+  describe('getValidatedColumn', () => {
+    it('returns the correct column name', async () => {
+      const spy = jest
+        .spyOn(Project, 'getColumns')
+        .mockReturnValue(
+          Promise.resolve([mockJiraBoardColumn, { name: JiraStatusValidated }])
+        )
+      const columnName = await Project.getValidatedColumn('10003')
+      expect(columnName).toEqual(JiraStatusValidated)
       spy.mockRestore()
     })
   })


### PR DESCRIPTION
## Handle 'Validated' column during Jira automation

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-238)

Some Jira projects don&#39;t have this column - we should fail gracefully in this case.

## How to test the PR

Merge a PR and check that the Jira issue is moved to `Validated`.

## Deployment Notes

None