### PR TITLE
[SHARED-76] Use case-insensitive compare when looking for Jira column names

### DIFF
--- a/.meta/SHARED-76.md
+++ b/.meta/SHARED-76.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SHARED-76
+
+Created at 2021-03-30T00:11:00.503Z


### PR DESCRIPTION

## Use case-insensitive compare when looking for Jira column names

[Jira Bug](https://shuttlerock.atlassian.net/browse/SHARED-76)



## How to test the PR

- How to test feature 1
  - Do this
  - Do that
  - Success
- How to test feature 2
- How to test feature 3

## Deployment Notes

It requires new Environmental variables:

- `EXAMPLE_ENV_VARIABLE=content`
- `EXAMPLE_ENV_VARIABLE2=content`
