### PR TITLE
[SECURITY-334] Fix case-insensitivity issue in Jira status names

### DIFF
--- a/.meta/SECURITY-334.md
+++ b/.meta/SECURITY-334.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-334
+
+Created at 2021-04-02T03:20:43.966Z

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -64271,6 +64271,10 @@ const jiraIssueTransitioned = (_email, issueKey) => __awaiter(void 0, void 0, vo
             leftmost = inProgressColumn;
         }
     }
+    // Jira seems to add capitalization in child status names that don't necessarily match the board.
+    if (!isNil_1.default(leftmost)) {
+        leftmost = columnNames.find(status => status.toLowerCase() === leftmost.toLowerCase());
+    }
     if (parent.fields.status.name === leftmost) {
         core_1.info(`The parent issue ${parent.key} is already in '${leftmost}' - nothing to do`);
     }
@@ -64278,9 +64282,13 @@ const jiraIssueTransitioned = (_email, issueKey) => __awaiter(void 0, void 0, vo
         leftmost === Jira_1.JiraStatusValidated) {
         core_1.info(`The parent issue ${parent.key} is an epic, so it can't be moved to '${leftmost}' automatically - nothing to do`);
     }
-    else {
+    else if (!isNil_1.default(leftmost)) {
         core_1.info(`Moved the parent issue ${parent.key} to '${leftmost}'`);
         yield Jira_1.setIssueStatus(parent.id, leftmost);
+    }
+    else {
+        // This should never happen, but Jira can be a bit inconsistent.
+        core_1.error('The leftmost status is empty - giving up');
     }
 });
 exports.jiraIssueTransitioned = jiraIssueTransitioned;


### PR DESCRIPTION
## Fix case-insensitivity issue in Jira status names

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-334)
[Jira Epic](https://shuttlerock.atlassian.net/browse/SECURITY-244)

Status names for board columns don&#39;t necessarily have the same case as the same status within the Issue API response. Jira seems to capitalize the name in the issues, leading to an elusive bug where statuses couldn&#39;t be found.

## How to test the PR

Move an issue belonging to an epic to `In progress` in the `SECURITY` board. The board status is `In progress`, but the issue status becomes `In Progress` with a capital `P`. This PR should handle the mismatch gracefully.

## Deployment Notes

None