### PR TITLE
Release Candidate 2021-04-02-0351 (Selfish Starfish)

### DIFF
--- a/.meta/SECURITY-334.md
+++ b/.meta/SECURITY-334.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-334
+
+Created at 2021-04-02T03:20:43.966Z

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -64271,6 +64271,10 @@ const jiraIssueTransitioned = (_email, issueKey) => __awaiter(void 0, void 0, vo
             leftmost = inProgressColumn;
         }
     }
+    // Jira seems to add capitalization in child status names that don't necessarily match the board.
+    if (!isNil_1.default(leftmost)) {
+        leftmost = columnNames.find(status => status.toLowerCase() === leftmost.toLowerCase());
+    }
     if (parent.fields.status.name === leftmost) {
         core_1.info(`The parent issue ${parent.key} is already in '${leftmost}' - nothing to do`);
     }
@@ -64278,9 +64282,13 @@ const jiraIssueTransitioned = (_email, issueKey) => __awaiter(void 0, void 0, vo
         leftmost === Jira_1.JiraStatusValidated) {
         core_1.info(`The parent issue ${parent.key} is an epic, so it can't be moved to '${leftmost}' automatically - nothing to do`);
     }
-    else {
+    else if (!isNil_1.default(leftmost)) {
         core_1.info(`Moved the parent issue ${parent.key} to '${leftmost}'`);
         yield Jira_1.setIssueStatus(parent.id, leftmost);
+    }
+    else {
+        // This should never happen, but Jira can be a bit inconsistent.
+        core_1.error('The leftmost status is empty - giving up');
     }
 });
 exports.jiraIssueTransitioned = jiraIssueTransitioned;

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-unused-imports": "^1.1.0",
-    "husky": "^5.1.3",
+    "husky": "^6.0.0",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "js-yaml": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/mustache": "^4.1.1",
     "@types/node": "^14.14.37",
     "@types/node-fetch": "^2.5.8",
-    "@typescript-eslint/parser": "^4.19.0",
+    "@typescript-eslint/parser": "^4.20.0",
     "@vercel/ncc": "0.27.0",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-typescript": "^12.3.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "js-yaml": "^4.0.0",
     "lint-staged": "^10.5.4",
     "prettier": "2.2.1",
-    "ts-jest": "^26.5.3",
+    "ts-jest": "^26.5.4",
     "tscpaths": "^0.0.9",
     "typescript": "^4.2.3"
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "unique-names-generator": "^4.4.0"
   },
   "devDependencies": {
-    "@octokit/webhooks": "^8.8.2",
+    "@octokit/webhooks": "^8.8.3",
     "@octokit/webhooks-definitions": "^3.65.2",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.22",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/parser": "^4.19.0",
     "@vercel/ncc": "0.27.0",
-    "eslint": "^7.22.0",
+    "eslint": "^7.23.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.1.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dateformat": "^4.5.1",
     "jira-client": "^6.21.0",
     "lodash": "^4.17.21",
-    "mustache": "^4.1.0",
+    "mustache": "^4.2.0",
     "node-fetch": "^2.6.1",
     "unique-names-generator": "^4.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "unique-names-generator": "^4.4.0"
   },
   "devDependencies": {
-    "@octokit/webhooks": "^8.8.3",
+    "@octokit/webhooks": "^8.10.1",
     "@octokit/webhooks-definitions": "^3.65.2",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.22",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "unique-names-generator": "^4.4.0"
   },
   "devDependencies": {
-    "@octokit/webhooks": "^8.8.0",
+    "@octokit/webhooks": "^8.8.2",
     "@octokit/webhooks-definitions": "^3.65.2",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.22",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.168",
     "@types/mustache": "^4.1.1",
-    "@types/node": "^14.14.35",
+    "@types/node": "^14.14.37",
     "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/parser": "^4.19.0",
     "@vercel/ncc": "0.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5494,9 +5494,9 @@ xmlchars@^2.2.0:
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2758,10 +2758,10 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-5.1.3.tgz#1a0645a4fe3ffc006c4d0d8bd0bcb4c98787cc9d"
-  integrity sha512-fbNJ+Gz5wx2LIBtMweJNY1D7Uc8p1XERi5KNRMccwfQA+rXlxWNSdUxswo0gT8XqxywTIw7Ywm/F4v/O35RdMg==
+husky@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
+  integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
 
 iconv-lite@0.4.24:
   version "0.4.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,10 +2130,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.22.0:
-  version "7.22.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.22.0.tgz#07ecc61052fec63661a2cab6bd507127c07adc6f"
-  integrity sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==
+eslint@^7.23.0:
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.23.0.tgz#8d029d252f6e8cf45894b4bee08f5493f8e94325"
+  integrity sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,10 +855,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^14.14.35":
-  version "14.14.35"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
-  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^14.14.37":
+  version "14.14.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
+  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,18 +660,18 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/webhooks-definitions@3.65.4", "@octokit/webhooks-definitions@^3.65.2":
-  version "3.65.4"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.4.tgz#1e2c1e7b38a3fbd7d4d0d51d3cac4d35bad736df"
-  integrity sha512-nXYWY9eTtCMjLtWQwxVFuvIqUJk8j7W+g2SQebgMbMKGVUoqUCJbHVVr7sC4rEIGYK1lofWoU9da9sn+w14k4Q==
+"@octokit/webhooks-definitions@3.65.5", "@octokit/webhooks-definitions@^3.65.2":
+  version "3.65.5"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.5.tgz#dbdf634e205968e50ba591716a01765aa2f1cc8b"
+  integrity sha512-cQxHFYIrOHINEaw/dE8qrZKCmrJ7h8OOj8ZKeMq9KtP9ueBr9VdHKddbG4OMYEVHtylGSlGsvYT6GZBPYJe8OQ==
 
-"@octokit/webhooks@^8.8.2":
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-8.8.2.tgz#727f045003ea609ddfac6cf20f08df27156d73c6"
-  integrity sha512-4aSf3Px0YbLr9eVc8+I/628et79o1Uh3DfiRXy9870+NzUf/F+6PaK73VI4f0db/+z+zOyRZRLydBPImyn8+GA==
+"@octokit/webhooks@^8.8.3":
+  version "8.8.3"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-8.8.3.tgz#0b0076f8e636f66f0e4aebce4e55545994f7f6a6"
+  integrity sha512-DADAY4SEEOXQzFPT6/RBX0pCSrQJ7k6u2Z8gGGZCjMfww74+n0g0MkS2fzUKX0j968P0koahhUEgval5gOVb6g==
   dependencies:
     "@octokit/request-error" "^2.0.2"
-    "@octokit/webhooks-definitions" "3.65.4"
+    "@octokit/webhooks-definitions" "3.65.5"
     aggregate-error "^3.1.0"
     debug "^4.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,18 +660,18 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/webhooks-definitions@3.65.5", "@octokit/webhooks-definitions@^3.65.2":
-  version "3.65.5"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.5.tgz#dbdf634e205968e50ba591716a01765aa2f1cc8b"
-  integrity sha512-cQxHFYIrOHINEaw/dE8qrZKCmrJ7h8OOj8ZKeMq9KtP9ueBr9VdHKddbG4OMYEVHtylGSlGsvYT6GZBPYJe8OQ==
+"@octokit/webhooks-definitions@3.65.6", "@octokit/webhooks-definitions@^3.65.2":
+  version "3.65.6"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.6.tgz#7b437fa6364d8c470d762a232e027c94f059afac"
+  integrity sha512-REj2D1GzZZLGznoj6vFX8mBRdMN5XxbQYP6G7AaqunqA32n35wpkgBnS3nWDA01gbKbNgFadFNTbkWcT/qrbvA==
 
-"@octokit/webhooks@^8.8.3":
-  version "8.8.3"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-8.8.3.tgz#0b0076f8e636f66f0e4aebce4e55545994f7f6a6"
-  integrity sha512-DADAY4SEEOXQzFPT6/RBX0pCSrQJ7k6u2Z8gGGZCjMfww74+n0g0MkS2fzUKX0j968P0koahhUEgval5gOVb6g==
+"@octokit/webhooks@^8.10.1":
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-8.10.1.tgz#7e8edba70f4dbbb82edc352ef1b88b2d874352a5"
+  integrity sha512-P84rQ7pFnAWZrO22cNbT0pitW/phGn3Ie6KRo7t5G/coqHhtACrbTZ/CNTq6sY7cbuv+s6ZtXVA7/kdv+9fUJQ==
   dependencies:
     "@octokit/request-error" "^2.0.2"
-    "@octokit/webhooks-definitions" "3.65.5"
+    "@octokit/webhooks-definitions" "3.65.6"
     aggregate-error "^3.1.0"
     debug "^4.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,10 +3927,10 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-mustache@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.1.0.tgz#8c1b042238a982d2eb2d30efc6c14296ae3f699d"
-  integrity sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ==
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5178,10 +5178,10 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-ts-jest@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.3.tgz#a6ee00ba547be3b09877550df40a1465d0295554"
-  integrity sha512-nBiiFGNvtujdLryU7MiMQh1iPmnZ/QvOskBbD2kURiI1MwqvxlxNnaAB/z9TbslMqCsSbu5BXvSSQPc5tvHGeA==
+ts-jest@^26.5.4:
+  version "26.5.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.4.tgz#207f4c114812a9c6d5746dd4d1cdf899eafc9686"
+  integrity sha512-I5Qsddo+VTm94SukBJ4cPimOoFZsYTeElR2xy6H2TOVs+NsvgYglW8KuQgKoApOKuaU/Ix/vrF9ebFZlb5D2Pg==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,23 +937,23 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@>=2.25.0", "@typescript-eslint/parser@^4.19.0", "@typescript-eslint/parser@^4.4.1":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.19.0.tgz#4ae77513b39f164f1751f21f348d2e6cb2d11128"
-  integrity sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==
+"@typescript-eslint/parser@>=2.25.0", "@typescript-eslint/parser@^4.20.0", "@typescript-eslint/parser@^4.4.1":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.20.0.tgz#8dd403c8b4258b99194972d9799e201b8d083bdd"
+  integrity sha512-m6vDtgL9EABdjMtKVw5rr6DdeMCH3OA1vFb0dAyuZSa3e5yw1YRzlwFnm9knma9Lz6b2GPvoNSa8vOXrqsaglA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.19.0"
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/typescript-estree" "4.19.0"
+    "@typescript-eslint/scope-manager" "4.20.0"
+    "@typescript-eslint/types" "4.20.0"
+    "@typescript-eslint/typescript-estree" "4.20.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz#5e0b49eca4df7684205d957c9856f4e720717a4f"
-  integrity sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==
+"@typescript-eslint/scope-manager@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.20.0.tgz#953ecbf3b00845ece7be66246608be9d126d05ca"
+  integrity sha512-/zm6WR6iclD5HhGpcwl/GOYDTzrTHmvf8LLLkwKqqPKG6+KZt/CfSgPCiybshmck66M2L5fWSF/MKNuCwtKQSQ==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/visitor-keys" "4.19.0"
+    "@typescript-eslint/types" "4.20.0"
+    "@typescript-eslint/visitor-keys" "4.20.0"
 
 "@typescript-eslint/scope-manager@4.5.0":
   version "4.5.0"
@@ -963,23 +963,23 @@
     "@typescript-eslint/types" "4.5.0"
     "@typescript-eslint/visitor-keys" "4.5.0"
 
-"@typescript-eslint/types@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.19.0.tgz#5181d5d2afd02e5b8f149ebb37ffc8bd7b07a568"
-  integrity sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==
+"@typescript-eslint/types@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.20.0.tgz#c6cf5ef3c9b1c8f699a9bbdafb7a1da1ca781225"
+  integrity sha512-cYY+1PIjei1nk49JAPnH1VEnu7OYdWRdJhYI5wiKOUMhLTG1qsx5cQxCUTuwWCmQoyriadz3Ni8HZmGSofeC+w==
 
 "@typescript-eslint/types@4.5.0":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.5.0.tgz#98256e07bad1c8d15d0c9627ebec82fd971bb3c3"
   integrity sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g==
 
-"@typescript-eslint/typescript-estree@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz#8a709ffa400284ab72df33376df085e2e2f61147"
-  integrity sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==
+"@typescript-eslint/typescript-estree@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.20.0.tgz#8b3b08f85f18a8da5d88f65cb400f013e88ab7be"
+  integrity sha512-Knpp0reOd4ZsyoEJdW8i/sK3mtZ47Ls7ZHvD8WVABNx5Xnn7KhenMTRGegoyMTx6TiXlOVgMz9r0pDgXTEEIHA==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/visitor-keys" "4.19.0"
+    "@typescript-eslint/types" "4.20.0"
+    "@typescript-eslint/visitor-keys" "4.20.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -1000,12 +1000,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz#cbea35109cbd9b26e597644556be4546465d8f7f"
-  integrity sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==
+"@typescript-eslint/visitor-keys@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.20.0.tgz#1e84db034da13f208325e6bfc995c3b75f7dbd62"
+  integrity sha512-NXKRM3oOVQL8yNFDNCZuieRIwZ5UtjNLYtmMx2PacEAGmbaEYtGgVHUHVyZvU/0rYZcizdrWjDo+WBtRPSgq+A==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
+    "@typescript-eslint/types" "4.20.0"
     eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.5.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,18 +660,18 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/webhooks-definitions@3.65.2", "@octokit/webhooks-definitions@^3.65.2":
-  version "3.65.2"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.2.tgz#ca644b8d0439870b6221b46b47e412005f50c1a1"
-  integrity sha512-xOPH/kGbnsHQrPLRTk75F3lkxkpY+1vPWqq74mBCUwfjYVnVv3q9l7yi+ZvyUrZ2O/kqjhuJWbG923G/icd0ag==
+"@octokit/webhooks-definitions@3.65.4", "@octokit/webhooks-definitions@^3.65.2":
+  version "3.65.4"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.4.tgz#1e2c1e7b38a3fbd7d4d0d51d3cac4d35bad736df"
+  integrity sha512-nXYWY9eTtCMjLtWQwxVFuvIqUJk8j7W+g2SQebgMbMKGVUoqUCJbHVVr7sC4rEIGYK1lofWoU9da9sn+w14k4Q==
 
-"@octokit/webhooks@^8.8.0":
-  version "8.8.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-8.8.0.tgz#bd4560217cfdd9c528739a374d2bea3a7a1e3c91"
-  integrity sha512-IuZNROGyMLegD/67+1YVv6kNIoxCQKhLLGvmNuitmk6okeMvqCuQGXNM6eyBF9LQ5uxQyr+2vVPaXvQU/p7QQQ==
+"@octokit/webhooks@^8.8.2":
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-8.8.2.tgz#727f045003ea609ddfac6cf20f08df27156d73c6"
+  integrity sha512-4aSf3Px0YbLr9eVc8+I/628et79o1Uh3DfiRXy9870+NzUf/F+6PaK73VI4f0db/+z+zOyRZRLydBPImyn8+GA==
   dependencies:
     "@octokit/request-error" "^2.0.2"
-    "@octokit/webhooks-definitions" "3.65.2"
+    "@octokit/webhooks-definitions" "3.65.4"
     aggregate-error "^3.1.0"
     debug "^4.0.0"
 


### PR DESCRIPTION
## Release Candidate 2021-04-02-0351 (Selfish Starfish)

### Pull Requests

- #458 Fix case-insensitivity issue in Jira status names ([SECURITY-334](https://shuttlerock.atlassian.net/browse/SECURITY-334))

### Dependency updates

- Bump @types/node from 14.14.35 to [14.14.37](https://github.com/Shuttlerock/actions/commit/19bf7d05ba0ff718279ebc12f2f2c4ed464a05f1)
- Bump @octokit/webhooks from 8.8.0 to [8.8.2](https://github.com/Shuttlerock/actions/commit/89168b2bd106b262071e4e73593829aa149adfe6)
- Bump y18n from 4.0.0 to [4.0.1](https://github.com/Shuttlerock/actions/commit/990309c527fd0b01f70f74b0e41ebf8b2ede1e0c)
- Bump eslint from 7.22.0 to [7.23.0](https://github.com/Shuttlerock/actions/commit/d1f3e7fa2379fc345abb9e0399ce8b1f6cd2e9e5)
- Bump @octokit/webhooks from 8.8.2 to [8.8.3](https://github.com/Shuttlerock/actions/commit/13e46fe8a0a87ecd781f64942e73e226db39c660)
- Bump ts-jest from 26.5.3 to [26.5.4](https://github.com/Shuttlerock/actions/commit/40e935946347d7eec30dcf3b049aef4cbdb7bb60)
- Bump @typescript-eslint/parser from 4.19.0 to [4.20.0](https://github.com/Shuttlerock/actions/commit/e1e57f01486ce4fa5ab08bd963181aede635e69b)
- Bump husky from 5.1.3 to [6.0.0](https://github.com/Shuttlerock/actions/commit/a7ea34a1657d7476c302d7bc963904c2cf8022fa)
- Bump mustache from 4.1.0 to [4.2.0](https://github.com/Shuttlerock/actions/commit/18108e65e19c04efbae9c28bc25d5aa5d40fd52f)
- Bump @octokit/webhooks from 8.8.3 to [8.10.1](https://github.com/Shuttlerock/actions/commit/0ed70e2c0a378918136b0c4635cc2980e17e1db1)
