### PR TITLE
[STUDIO-1859] Handle errors during release creation more gracefully

### DIFF
--- a/.meta/STUDIO-1859.md
+++ b/.meta/STUDIO-1859.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-1859
+
+Created at 2021-04-12T01:52:52.398Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -61283,7 +61282,16 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
             .map((commit) => PullRequest_1.extractPullRequestNumber(commit.commit.message))
             .filter((prNumber) => prNumber)),
     ];
-    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () { return PullRequest_1.getPullRequest(repoName, prNumber); })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
+    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            return PullRequest_1.getPullRequest(repoName, prNumber);
+        }
+        catch (err) {
+            core_1.error(`Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`);
+            commits.map((commit) => core_1.error(`  ${commit.commit.message}`));
+            return undefined;
+        }
+    })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
     let description = `## Release Candidate ${releaseDate} (${releaseName})\n\n`;
     // Github only gives us 250 commits. This is usually enough, but add a note if we hit the limit.
     if (commits.length === 250) {

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -61281,7 +61280,16 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
             .map((commit) => PullRequest_1.extractPullRequestNumber(commit.commit.message))
             .filter((prNumber) => prNumber)),
     ];
-    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () { return PullRequest_1.getPullRequest(repoName, prNumber); })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
+    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            return PullRequest_1.getPullRequest(repoName, prNumber);
+        }
+        catch (err) {
+            core_1.error(`Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`);
+            commits.map((commit) => core_1.error(`  ${commit.commit.message}`));
+            return undefined;
+        }
+    })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
     let description = `## Release Candidate ${releaseDate} (${releaseName})\n\n`;
     // Github only gives us 250 commits. This is usually enough, but add a note if we hit the limit.
     if (commits.length === 250) {

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -61222,7 +61221,16 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
             .map((commit) => PullRequest_1.extractPullRequestNumber(commit.commit.message))
             .filter((prNumber) => prNumber)),
     ];
-    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () { return PullRequest_1.getPullRequest(repoName, prNumber); })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
+    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            return PullRequest_1.getPullRequest(repoName, prNumber);
+        }
+        catch (err) {
+            core_1.error(`Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`);
+            commits.map((commit) => core_1.error(`  ${commit.commit.message}`));
+            return undefined;
+        }
+    })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
     let description = `## Release Candidate ${releaseDate} (${releaseName})\n\n`;
     // Github only gives us 250 commits. This is usually enough, but add a note if we hit the limit.
     if (commits.length === 250) {

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -61197,7 +61196,16 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
             .map((commit) => PullRequest_1.extractPullRequestNumber(commit.commit.message))
             .filter((prNumber) => prNumber)),
     ];
-    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () { return PullRequest_1.getPullRequest(repoName, prNumber); })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
+    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            return PullRequest_1.getPullRequest(repoName, prNumber);
+        }
+        catch (err) {
+            core_1.error(`Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`);
+            commits.map((commit) => core_1.error(`  ${commit.commit.message}`));
+            return undefined;
+        }
+    })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
     let description = `## Release Candidate ${releaseDate} (${releaseName})\n\n`;
     // Github only gives us 250 commits. This is usually enough, but add a note if we hit the limit.
     if (commits.length === 250) {

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -61205,7 +61204,16 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
             .map((commit) => PullRequest_1.extractPullRequestNumber(commit.commit.message))
             .filter((prNumber) => prNumber)),
     ];
-    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () { return PullRequest_1.getPullRequest(repoName, prNumber); })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
+    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            return PullRequest_1.getPullRequest(repoName, prNumber);
+        }
+        catch (err) {
+            core_1.error(`Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`);
+            commits.map((commit) => core_1.error(`  ${commit.commit.message}`));
+            return undefined;
+        }
+    })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
     let description = `## Release Candidate ${releaseDate} (${releaseName})\n\n`;
     // Github only gives us 250 commits. This is usually enough, but add a note if we hit the limit.
     if (commits.length === 250) {

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -61210,7 +61209,16 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
             .map((commit) => PullRequest_1.extractPullRequestNumber(commit.commit.message))
             .filter((prNumber) => prNumber)),
     ];
-    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () { return PullRequest_1.getPullRequest(repoName, prNumber); })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
+    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            return PullRequest_1.getPullRequest(repoName, prNumber);
+        }
+        catch (err) {
+            core_1.error(`Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`);
+            commits.map((commit) => core_1.error(`  ${commit.commit.message}`));
+            return undefined;
+        }
+    })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
     let description = `## Release Candidate ${releaseDate} (${releaseName})\n\n`;
     // Github only gives us 250 commits. This is usually enough, but add a note if we hit the limit.
     if (commits.length === 250) {

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -37680,7 +37680,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 98272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -38382,7 +38381,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -62520,7 +62519,16 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => __await
             .map((commit) => PullRequest_1.extractPullRequestNumber(commit.commit.message))
             .filter((prNumber) => prNumber)),
     ];
-    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () { return PullRequest_1.getPullRequest(repoName, prNumber); })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
+    const pulls = (yield Promise.all(prNumbers.map((prNumber) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            return PullRequest_1.getPullRequest(repoName, prNumber);
+        }
+        catch (err) {
+            core_1.error(`Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`);
+            commits.map((commit) => core_1.error(`  ${commit.commit.message}`));
+            return undefined;
+        }
+    })))).filter((pull) => pull && !/Bump .+ from .+ to .*$/.exec(pull.title));
     let description = `## Release Candidate ${releaseDate} (${releaseName})\n\n`;
     // Github only gives us 250 commits. This is usually enough, but add a note if we hit the limit.
     if (commits.length === 250) {

--- a/src/services/Github/Release.ts
+++ b/src/services/Github/Release.ts
@@ -76,9 +76,17 @@ const getReleaseNotes = async (
 
   const pulls = (
     await Promise.all(
-      (prNumbers as number[]).map(async (prNumber: number) =>
-        getPullRequest(repoName, prNumber)
-      )
+      (prNumbers as number[]).map(async (prNumber: number) => {
+        try {
+          return getPullRequest(repoName, prNumber)
+        } catch (err) {
+          error(
+            `Couldn't find the pull request ${repoName}#${prNumber} for release notes. Here's the commit list:`
+          )
+          commits.map((commit: Commit) => error(`  ${commit.commit.message}`))
+          return undefined
+        }
+      })
     )
   ).filter(
     (pull: PullsGetResponseData | undefined) =>


### PR DESCRIPTION
## Handle errors during release creation more gracefully

[Jira Chore](https://shuttlerock.atlassian.net/browse/STUDIO-1859)

Currently we get 404s and creation fails, if a PR can&#39;t be found while creating notes.

## How to test the PR

Create a release and make sure everything works.

## Deployment Notes

None