### PR TITLE
[#471][STUDIO-1863] Do not move Jira task when checks fail

### DIFF
--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -60350,12 +60349,7 @@ const Slack_1 = __nccwpck_require__(4745);
 const handleFailure = (checkName, issue, repoName, pullRequest) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Adding the '${Constants_1.HasIssuesLabel}' label...`);
     yield Github_1.addLabels(repoName, pullRequest.number, [Constants_1.HasIssuesLabel]);
-    if (issue.fields.status.name === Jira_1.JiraStatusHasIssues) {
-        core_1.info(`Issue ${issue.key} is already in '${Jira_1.JiraStatusHasIssues}' - giving up`);
-        return undefined;
-    }
-    core_1.info(`Moving Jira issue ${issue.key} to '${Jira_1.JiraStatusHasIssues}'...`);
-    yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusHasIssues);
+    core_1.info(`Issue ${issue.key} is in status '${issue.fields.status.name}'`);
     return `Check suite _*${checkName}*_ failed for *<${pullRequest.html_url}|${pullRequest.title}>*`;
 });
 /**

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -60307,12 +60306,7 @@ const Slack_1 = __nccwpck_require__(4745);
 const handleFailure = (checkName, issue, repoName, pullRequest) => __awaiter(void 0, void 0, void 0, function* () {
     core_1.info(`Adding the '${Constants_1.HasIssuesLabel}' label...`);
     yield Github_1.addLabels(repoName, pullRequest.number, [Constants_1.HasIssuesLabel]);
-    if (issue.fields.status.name === Jira_1.JiraStatusHasIssues) {
-        core_1.info(`Issue ${issue.key} is already in '${Jira_1.JiraStatusHasIssues}' - giving up`);
-        return undefined;
-    }
-    core_1.info(`Moving Jira issue ${issue.key} to '${Jira_1.JiraStatusHasIssues}'...`);
-    yield Jira_1.setIssueStatus(issue.id, Jira_1.JiraStatusHasIssues);
+    core_1.info(`Issue ${issue.key} is in status '${issue.fields.status.name}'`);
     return `Check suite _*${checkName}*_ failed for *<${pullRequest.html_url}|${pullRequest.title}>*`;
 });
 /**

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -36308,7 +36308,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 8272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -37010,7 +37009,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -37680,7 +37680,6 @@ function plural(ms, msAbs, n, name) {
 /***/ 98272:
 /***/ (function(module) {
 
-// This file has been generated from mustache.mjs
 (function (global, factory) {
    true ? module.exports = factory() :
   0;
@@ -38382,7 +38381,7 @@ function plural(ms, msAbs, n, name) {
 
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.2.0',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,

--- a/src/actions/check-suite-completed-action/__tests__/checkSuiteCompleted.test.ts
+++ b/src/actions/check-suite-completed-action/__tests__/checkSuiteCompleted.test.ts
@@ -44,7 +44,6 @@ describe('check-suite-completed-action', () => {
     let getIssueSpy: jest.SpyInstance
     let getPullRequestSpy: jest.SpyInstance
     let infoSpy: jest.SpyInstance
-    let setIssueStatusSpy: jest.SpyInstance
 
     // Cast this via 'unknown' to avoid having to fill in a bunch of unused payload fields.
     const checkSuitePayload = (rawPayload as unknown) as Schema.CheckSuiteEvent
@@ -87,11 +86,6 @@ describe('check-suite-completed-action', () => {
       infoSpy = jest
         .spyOn(core, 'info')
         .mockImplementation((_message: string) => undefined)
-      setIssueStatusSpy = jest
-        .spyOn(Jira, 'setIssueStatus')
-        .mockImplementation((_issueId: string, _newStatus: string) =>
-          Promise.resolve(undefined)
-        )
     })
 
     afterEach(() => {
@@ -103,7 +97,6 @@ describe('check-suite-completed-action', () => {
       getIssueSpy.mockRestore()
       getPullRequestSpy.mockRestore()
       infoSpy.mockRestore()
-      setIssueStatusSpy.mockRestore()
     })
 
     it('does nothing if there are no pull requests associated with the check suite', async () => {
@@ -188,14 +181,6 @@ describe('check-suite-completed-action', () => {
         expect(addLabelsSpy).toHaveBeenCalledWith('actions', 123, [
           HasIssuesLabel,
         ])
-      })
-
-      it('moves the Jira issue', async () => {
-        await checkSuiteCompleted(checkSuitePayload)
-        expect(setIssueStatusSpy).toHaveBeenCalledWith(
-          '10000',
-          Jira.JiraStatusHasIssues
-        )
       })
     })
   })

--- a/src/actions/check-suite-completed-action/checkSuiteCompleted.ts
+++ b/src/actions/check-suite-completed-action/checkSuiteCompleted.ts
@@ -14,12 +14,7 @@ import {
   getPullRequest,
   Repository,
 } from '@sr-services/Github'
-import {
-  getIssue,
-  Issue,
-  JiraStatusHasIssues,
-  setIssueStatus,
-} from '@sr-services/Jira'
+import { getIssue, Issue } from '@sr-services/Jira'
 import { positiveEmoji, sendUserMessage } from '@sr-services/Slack'
 
 /**
@@ -40,16 +35,7 @@ const handleFailure = async (
 ): Promise<string | undefined> => {
   info(`Adding the '${HasIssuesLabel}' label...`)
   await addLabels(repoName, pullRequest.number, [HasIssuesLabel])
-
-  if (issue.fields.status.name === JiraStatusHasIssues) {
-    info(
-      `Issue ${issue.key} is already in '${JiraStatusHasIssues}' - giving up`
-    )
-    return undefined
-  }
-
-  info(`Moving Jira issue ${issue.key} to '${JiraStatusHasIssues}'...`)
-  await setIssueStatus(issue.id, JiraStatusHasIssues)
+  info(`Issue ${issue.key} is in status '${issue.fields.status.name}'`)
 
   return `Check suite _*${checkName}*_ failed for *<${pullRequest.html_url}|${pullRequest.title}>*`
 }


### PR DESCRIPTION
[Jira Story](https://shuttlerock.atlassian.net/browse/STUDIO-1863)

Don't move the jira status to the has issues column (or anywhere) when the checks fail on a PR.

When a PR's checks fail, leave its Jira task alone.


Deploy notes
-------------
none