### PR TITLE
[SECURITY-381] Fix mustache template errors during PR automation

### DIFF
--- a/.meta/SECURITY-381.md
+++ b/.meta/SECURITY-381.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-381
+
+Created at 2021-05-06T01:57:21.408Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61391,7 +61391,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61755,7 +61755,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61907,10 +61907,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61938,7 +61938,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61971,7 +61971,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61980,7 +61980,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61988,7 +61988,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -62000,14 +62000,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62019,7 +62019,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -61391,7 +61391,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61755,7 +61755,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61907,10 +61907,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61938,7 +61938,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61971,7 +61971,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61980,7 +61980,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61988,7 +61988,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -62000,14 +62000,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62019,7 +62019,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61390,7 +61390,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61754,7 +61754,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61906,10 +61906,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61937,7 +61937,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61970,7 +61970,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61979,7 +61979,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61987,7 +61987,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -61999,14 +61999,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62018,7 +62018,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61390,7 +61390,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61754,7 +61754,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61906,10 +61906,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61937,7 +61937,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61970,7 +61970,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61979,7 +61979,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61987,7 +61987,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -61999,14 +61999,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62018,7 +62018,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61406,7 +61406,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61770,7 +61770,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61922,10 +61922,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61953,7 +61953,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61986,7 +61986,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61995,7 +61995,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -62003,7 +62003,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -62015,14 +62015,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62034,7 +62034,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61390,7 +61390,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61754,7 +61754,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61906,10 +61906,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61937,7 +61937,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61970,7 +61970,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61979,7 +61979,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61987,7 +61987,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -61999,14 +61999,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62018,7 +62018,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61330,10 +61330,6 @@ __nccwpck_require__.d(Inputs_namespaceObject, {
   "slackToken": () => (slackToken)
 });
 
-// NAMESPACE OBJECT: ./node_modules/mustache/mustache.mjs
-var mustache_namespaceObject = {};
-__nccwpck_require__.r(mustache_namespaceObject);
-
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
@@ -63557,7 +63553,7 @@ mustache.Scanner = Scanner;
 mustache.Context = Context;
 mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const mustache_mustache = (mustache);
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -63569,7 +63565,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const render = (template, vars) => (0,mustache_namespaceObject.render)(template, vars);
+const render = (template, vars) => mustache_mustache.render(template, vars);
 const PullRequestForEpicTemplate = `
 ## {{&summary}}
 

--- a/src/services/Template.ts
+++ b/src/services/Template.ts
@@ -1,4 +1,4 @@
-import { render as mustacheRender } from 'mustache'
+import mustache from 'mustache'
 
 interface TemplateVars {
   [key: string]: string | number | boolean | undefined
@@ -13,7 +13,7 @@ interface TemplateVars {
  * @returns {string} The rendered template.
  */
 export const render = (template: string, vars: TemplateVars): string =>
-  mustacheRender(template, vars)
+  mustache.render(template, vars)
 
 export const PullRequestForEpicTemplate = `
 ## {{&summary}}


### PR DESCRIPTION
## Fix mustache template errors during PR automation

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-381)

For some reason the import structure has changed, and we now get &#x60;(0 , mustache_namespaceObject.render) is not a function&#x60;.

## How to test the PR

Create a PR via automation - if no errors are thrown, it works.

## Deployment Notes

None