### PR TITLE
Release Candidate 2021-05-06-0257 (Qualified Quelea)

### DIFF
--- a/.meta/SECURITY-381.md
+++ b/.meta/SECURITY-381.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-381
+
+Created at 2021-05-06T01:57:21.408Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -61391,7 +61391,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61755,7 +61755,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61907,10 +61907,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61938,7 +61938,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61971,7 +61971,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61980,7 +61980,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61988,7 +61988,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -62000,14 +62000,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62019,7 +62019,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -61391,7 +61391,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61755,7 +61755,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61907,10 +61907,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61938,7 +61938,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61971,7 +61971,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61980,7 +61980,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61988,7 +61988,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -62000,14 +62000,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62019,7 +62019,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -61390,7 +61390,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61754,7 +61754,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61906,10 +61906,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61937,7 +61937,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61970,7 +61970,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61979,7 +61979,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61987,7 +61987,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -61999,14 +61999,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62018,7 +62018,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -61390,7 +61390,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61754,7 +61754,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61906,10 +61906,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61937,7 +61937,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61970,7 +61970,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61979,7 +61979,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61987,7 +61987,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -61999,14 +61999,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62018,7 +62018,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -61406,7 +61406,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61770,7 +61770,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61922,10 +61922,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61953,7 +61953,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61986,7 +61986,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61995,7 +61995,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -62003,7 +62003,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -62015,14 +62015,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62034,7 +62034,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -61390,7 +61390,7 @@ function parseTemplate (template, tags) {
     closingCurlyRe = new RegExp('\\s*' + mustache_escapeRegExp('}' + tagsToCompile[1]));
   }
 
-  compileTags(tags || mustache.tags);
+  compileTags(tags || mustache_mustache.tags);
 
   var scanner = new Scanner(template);
 
@@ -61754,7 +61754,7 @@ Writer.prototype.clearCache = function clearCache () {
  */
 Writer.prototype.parse = function parse (template, tags) {
   var cache = this.templateCache;
-  var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+  var cacheKey = template + ':' + (tags || mustache_mustache.tags).join(':');
   var isCacheEnabled = typeof cache !== 'undefined';
   var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
 
@@ -61906,10 +61906,10 @@ Writer.prototype.unescapedValue = function unescapedValue (token, context) {
 };
 
 Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-  var escape = this.getConfigEscape(config) || mustache.escape;
+  var escape = this.getConfigEscape(config) || mustache_mustache.escape;
   var value = context.lookup(token[1]);
   if (value != null)
-    return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+    return (typeof value === 'number' && escape === mustache_mustache.escape) ? String(value) : escape(value);
 };
 
 Writer.prototype.rawValue = function rawValue (token) {
@@ -61937,7 +61937,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
   }
 };
 
-var mustache = {
+var mustache_mustache = {
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -61970,7 +61970,7 @@ var defaultWriter = new Writer();
 /**
  * Clears all cached templates in the default writer.
  */
-mustache.clearCache = function clearCache () {
+mustache_mustache.clearCache = function clearCache () {
   return defaultWriter.clearCache();
 };
 
@@ -61979,7 +61979,7 @@ mustache.clearCache = function clearCache () {
  * array of tokens it contains. Doing this ahead of time avoids the need to
  * parse templates on the fly as they are rendered.
  */
-mustache.parse = function parse (template, tags) {
+mustache_mustache.parse = function parse (template, tags) {
   return defaultWriter.parse(template, tags);
 };
 
@@ -61987,7 +61987,7 @@ mustache.parse = function parse (template, tags) {
  * Renders the `template` with the given `view`, `partials`, and `config`
  * using the default writer.
  */
-mustache.render = function render (template, view, partials, config) {
+mustache_mustache.render = function render (template, view, partials, config) {
   if (typeof template !== 'string') {
     throw new TypeError('Invalid template! Template should be a "string" ' +
                         'but "' + typeStr(template) + '" was given as the first ' +
@@ -61999,14 +61999,14 @@ mustache.render = function render (template, view, partials, config) {
 
 // Export the escaping function so that the user may override it.
 // See https://github.com/janl/mustache.js/issues/244
-mustache.escape = escapeHtml;
+mustache_mustache.escape = escapeHtml;
 
 // Export these mainly for testing, but also for advanced usage.
-mustache.Scanner = Scanner;
-mustache.Context = Context;
-mustache.Writer = Writer;
+mustache_mustache.Scanner = Scanner;
+mustache_mustache.Context = Context;
+mustache_mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const node_modules_mustache_mustache = ((/* unused pure expression or super */ null && (mustache_mustache)));
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -62018,7 +62018,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const Template_render = (template, vars) => mustacheRender(template, vars);
+const Template_render = (template, vars) => mustache.render(template, vars);
 const Template_PullRequestForEpicTemplate = (/* unused pure expression or super */ null && (`
 ## {{&summary}}
 

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61330,10 +61330,6 @@ __nccwpck_require__.d(Inputs_namespaceObject, {
   "slackToken": () => (slackToken)
 });
 
-// NAMESPACE OBJECT: ./node_modules/mustache/mustache.mjs
-var mustache_namespaceObject = {};
-__nccwpck_require__.r(mustache_namespaceObject);
-
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
@@ -63557,7 +63553,7 @@ mustache.Scanner = Scanner;
 mustache.Context = Context;
 mustache.Writer = Writer;
 
-/* harmony default export */ const mustache_mustache = ((/* unused pure expression or super */ null && (mustache)));
+/* harmony default export */ const mustache_mustache = (mustache);
 
 ;// CONCATENATED MODULE: ./src/services/Template.ts
 
@@ -63569,7 +63565,7 @@ mustache.Writer = Writer;
  *
  * @returns {string} The rendered template.
  */
-const render = (template, vars) => (0,mustache_namespaceObject.render)(template, vars);
+const render = (template, vars) => mustache_mustache.render(template, vars);
 const PullRequestForEpicTemplate = `
 ## {{&summary}}
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-github": "^4.1.3",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.6",
-    "eslint-plugin-jsdoc": "^32.3.1",
+    "eslint-plugin-jsdoc": "^33.1.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-unused-imports": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/mustache": "^4.1.1",
     "@types/node": "^15.0.2",
     "@types/node-fetch": "^2.5.10",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/parser": "^4.22.1",
     "@vercel/ncc": "0.28.3",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-typescript": "^12.3.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/parser": "^4.22.0",
     "@vercel/ncc": "0.28.3",
-    "eslint": "^7.24.0",
+    "eslint": "^7.25.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^15.0.2",
     "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/parser": "^4.22.1",
-    "@vercel/ncc": "0.28.3",
+    "@vercel/ncc": "0.28.5",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "js-yaml": "^4.1.0",
     "lint-staged": "^10.5.4",
     "prettier": "2.2.1",
-    "ts-jest": "^26.5.5",
+    "ts-jest": "^26.5.6",
     "tscpaths": "^0.0.9",
     "typescript": "^4.2.4"
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.168",
     "@types/mustache": "^4.1.1",
-    "@types/node": "^14.14.41",
+    "@types/node": "^15.0.2",
     "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/parser": "^4.22.0",
     "@vercel/ncc": "0.28.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@octokit/webhooks": "^9.2.0",
     "@octokit/webhooks-definitions": "^3.67.2",
     "@types/dateformat": "^3.0.1",
-    "@types/jest": "^26.0.22",
+    "@types/jest": "^26.0.23",
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.168",
     "@types/mustache": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "unique-names-generator": "^4.4.0"
   },
   "devDependencies": {
-    "@octokit/webhooks": "^9.2.0",
+    "@octokit/webhooks": "^9.4.0",
     "@octokit/webhooks-definitions": "^3.67.2",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.23",

--- a/src/services/Template.ts
+++ b/src/services/Template.ts
@@ -1,4 +1,4 @@
-import { render as mustacheRender } from 'mustache'
+import mustache from 'mustache'
 
 interface TemplateVars {
   [key: string]: string | number | boolean | undefined
@@ -13,7 +13,7 @@ interface TemplateVars {
  * @returns {string} The rendered template.
  */
 export const render = (template: string, vars: TemplateVars): string =>
-  mustacheRender(template, vars)
+  mustache.render(template, vars)
 
 export const PullRequestForEpicTemplate = `
 ## {{&summary}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,14 +948,14 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^4.20.0", "@typescript-eslint/parser@^4.22.0", "@typescript-eslint/parser@^4.4.1":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.0.tgz#e1637327fcf796c641fe55f73530e90b16ac8fe8"
-  integrity sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==
+"@typescript-eslint/parser@^4.20.0", "@typescript-eslint/parser@^4.22.1", "@typescript-eslint/parser@^4.4.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.1.tgz#a95bda0fd01d994a15fc3e99dc984294f25c19cc"
+  integrity sha512-l+sUJFInWhuMxA6rtirzjooh8cM/AATAe3amvIkqKFeMzkn85V+eLzb1RyuXkHak4dLfYzOmF6DXPyflJvjQnw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.22.0"
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/typescript-estree" "4.22.0"
+    "@typescript-eslint/scope-manager" "4.22.1"
+    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/typescript-estree" "4.22.1"
     debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.21.0":
@@ -966,23 +966,23 @@
     "@typescript-eslint/types" "4.21.0"
     "@typescript-eslint/visitor-keys" "4.21.0"
 
-"@typescript-eslint/scope-manager@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz#ed411545e61161a8d702e703a4b7d96ec065b09a"
-  integrity sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==
+"@typescript-eslint/scope-manager@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz#5bb357f94f9cd8b94e6be43dd637eb73b8f355b4"
+  integrity sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==
   dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
+    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/visitor-keys" "4.22.1"
 
 "@typescript-eslint/types@4.21.0":
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.21.0.tgz#abdc3463bda5d31156984fa5bc316789c960edef"
   integrity sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==
 
-"@typescript-eslint/types@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
-  integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
+"@typescript-eslint/types@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.1.tgz#bf99c6cec0b4a23d53a61894816927f2adad856a"
+  integrity sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==
 
 "@typescript-eslint/typescript-estree@4.21.0":
   version "4.21.0"
@@ -997,13 +997,13 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz#b5d95d6d366ff3b72f5168c75775a3e46250d05c"
-  integrity sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==
+"@typescript-eslint/typescript-estree@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.1.tgz#dca379eead8cdfd4edc04805e83af6d148c164f9"
+  integrity sha512-p3We0pAPacT+onSGM+sPR+M9CblVqdA9F1JEdIqRVlxK5Qth4ochXQgIyb9daBomyQKAXbygxp1aXQRV0GC79A==
   dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
+    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/visitor-keys" "4.22.1"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -1018,12 +1018,12 @@
     "@typescript-eslint/types" "4.21.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz#169dae26d3c122935da7528c839f42a8a42f6e47"
-  integrity sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==
+"@typescript-eslint/visitor-keys@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz#6045ae25a11662c671f90b3a403d682dfca0b7a6"
+  integrity sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==
   dependencies:
-    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/types" "4.22.1"
     eslint-visitor-keys "^2.0.0"
 
 "@vercel/ncc@0.28.3":

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,10 +865,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^14.14.41":
-  version "14.14.41"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
-  integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^15.0.2":
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
+  integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,10 +2140,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.24.0:
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.24.0.tgz#2e44fa62d93892bfdb100521f17345ba54b8513a"
-  integrity sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==
+eslint@^7.25.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.25.0.tgz#1309e4404d94e676e3e831b3a3ad2b050031eb67"
+  integrity sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,10 +816,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.22":
-  version "26.0.22"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
-  integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
+"@types/jest@^26.0.23":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,6 +327,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@es-joy/jsdoccomment@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.4.3.tgz#c66b42aa66d2e0718f77fccc8d9061cf0b1092ac"
+  integrity sha512-t0JWZfQiG+Qkr6+tl05dlGcgE/MMPqs7QfNlFkTsbpcCu2Zfukcan/fIiHKTc0iOs4Yh3cnfklMayJnlmKaOwQ==
+  dependencies:
+    comment-parser "^1.1.5"
+    esquery "^1.4.0"
+    jsdoctypeparser "^9.0.0"
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -1599,10 +1608,10 @@ commander@^6.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
   integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
-comment-parser@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.2.tgz#e5317d7a2ec22b470dcb54a29b25426c30bf39d8"
-  integrity sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==
+comment-parser@1.1.5, comment-parser@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.5.tgz#453627ef8f67dbcec44e79a9bd5baa37f0bce9b2"
+  integrity sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -2061,17 +2070,19 @@ eslint-plugin-jest@^24.3.6:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-jsdoc@^32.3.1:
-  version "32.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.1.tgz#1c50b82b12f903bdb4117f7b68e97fb2f65a5f73"
-  integrity sha512-Xcbc8Cr79QveH+MndVwtZ3uafDdXyrsIkS8lP71Fhn5Qi1Lr8TU2QZNkMYIJSvmuLqDB5Jj/VVULMCvaBZBkvg==
+eslint-plugin-jsdoc@^33.1.0:
+  version "33.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-33.1.0.tgz#9aa52d0eb0126ea42528aa352265007dce320565"
+  integrity sha512-nyH1qAj5f4uDnDpg4aiAS65wJSfxfBDf0lIgNfxtew31z3VRaM8WsVmpe4UhI2u27oOD/ChRuye6KAzzuHn6Jw==
   dependencies:
-    comment-parser "1.1.2"
+    "@es-joy/jsdoccomment" "^0.4.3"
+    comment-parser "1.1.5"
     debug "^4.3.1"
+    esquery "^1.4.0"
     jsdoctypeparser "^9.0.0"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     regextras "^0.7.1"
-    semver "^7.3.4"
+    semver "^7.3.5"
     spdx-expression-parse "^3.0.1"
 
 eslint-plugin-jsx-a11y@^6.4.1:
@@ -4733,10 +4744,10 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5188,10 +5188,10 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-ts-jest@^26.5.5:
-  version "26.5.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.5.tgz#e40481b6ee4dd162626ba481a2be05fa57160ea5"
-  integrity sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==
+ts-jest@^26.5.6:
+  version "26.5.6"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
+  integrity sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,19 +679,19 @@
   resolved "https://registry.yarnpkg.com/@octokit/webhooks-methods/-/webhooks-methods-1.0.0.tgz#274799138725c89a3466e3af2026afe755f28c4b"
   integrity sha512-pVceMQcj9SZ5p2RkemL0TuuPdGULNQj9F3Pq1cNM1xH+Kst1VNt0dj3PEGZRZV473njrDnYdi/OG4wWY9TLbbA==
 
-"@octokit/webhooks-types@3.70.0":
-  version "3.70.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-3.70.0.tgz#e417051cad9e204c6ec546058e5acfa8a700a147"
-  integrity sha512-Hq7ZQ3v2Z10K9h27kycjkkLhAp+MwDLB/hPsruKduL33bZJHVJTiDq1kt9C6ScapFkBnxIiCcO8m+vm6cCYuHQ==
+"@octokit/webhooks-types@3.72.0":
+  version "3.72.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-3.72.0.tgz#43dc2125cfb6217c3bd69479c79dc76da2551550"
+  integrity sha512-G+XcAeGU+IImH/4L0LTKAUj2GbyuHBkQVkFHuga/zgsCXdm3iSwoPjkW462Cq1U3U8QzuH4kJp17M5W/omKE8Q==
 
-"@octokit/webhooks@^9.2.0":
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-9.2.0.tgz#46d3f994b3bbdaedd169ac705d9f27c7e959da52"
-  integrity sha512-thg2ZI0LOhpKSxBmym7WrtJ7nqvn/k4T9BeRc0N27GdABHtma2LgOGF2A88mNC7qSSW9cjGLlg5r2XVGpc4EvA==
+"@octokit/webhooks@^9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-9.4.0.tgz#d346006c23ea0d533fd1817023029772bdd656e5"
+  integrity sha512-bEJZVsIpe2mhlyPgldw9PF/MFPAg7aRqbbGJkras2n9iJTHhHSDSfgLRzgvCWXe9zaSvX59B+NU25c8+v52YBg==
   dependencies:
     "@octokit/request-error" "^2.0.2"
     "@octokit/webhooks-methods" "^1.0.0"
-    "@octokit/webhooks-types" "3.70.0"
+    "@octokit/webhooks-types" "3.72.0"
     aggregate-error "^3.1.0"
 
 "@sinonjs/commons@^1.7.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,10 +1026,10 @@
     "@typescript-eslint/types" "4.22.1"
     eslint-visitor-keys "^2.0.0"
 
-"@vercel/ncc@0.28.3":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.28.3.tgz#9461bdbf334d616759b0e7e5415e2f480b9aa30f"
-  integrity sha512-g3gk4D9itbhUQa5MtN7TOdeoQnNLkPDCox5SBaQ/H3Or5lo59TOaZWrLb+x47StiAJ+8DXZS/9MJ67cIBWSsRw==
+"@vercel/ncc@0.28.5":
+  version "0.28.5"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.28.5.tgz#6d735379f81b70b708a9c3d2196507b2a841824f"
+  integrity sha512-ZSwD4EDCon2EsnPZ2/Qcigx4N2DiuBLV/rDnF04giEPFuDeBeUDdnSTyYYfX8KNic/prrJuS1vUEmAOHmj+fRg==
 
 abab@^2.0.3:
   version "2.0.4"


### PR DESCRIPTION
## Release Candidate 2021-05-06-0257 (Qualified Quelea)

### Pull Requests

- #513 Fix mustache template errors during PR automation ([SECURITY-381](https://shuttlerock.atlassian.net/browse/SECURITY-381))

### Dependency updates

- Bump eslint from 7.24.0 to [7.25.0](https://github.com/Shuttlerock/actions/commit/72ebde49acc50bdf3152b21404d6ed345961245c)
- Bump @types/jest from 26.0.22 to [26.0.23](https://github.com/Shuttlerock/actions/commit/1d5cc2d6dfca6abfd561257c7457f7f5c9a2a978)
- Bump @types/node from 14.14.41 to [15.0.2](https://github.com/Shuttlerock/actions/commit/fdb9f5865cdbe1de7ee9bcafcbe9596c6ebc4d5b)
- Bump @typescript-eslint/parser from 4.22.0 to [4.22.1](https://github.com/Shuttlerock/actions/commit/3c28aea49f9b590c045203700b7e484623074a02)
- Bump ts-jest from 26.5.5 to [26.5.6](https://github.com/Shuttlerock/actions/commit/4b511dde28bf03b06ca5ce29b907ffdfa75d1a84)
- Bump @vercel/ncc from 0.28.3 to [0.28.5](https://github.com/Shuttlerock/actions/commit/12a473b7e5817ff43e26c671c99ea1f753041b3a)
- Bump eslint-plugin-jsdoc from 32.3.1 to [33.1.0](https://github.com/Shuttlerock/actions/commit/456a7cb07b35eff4660f3d4a0edf80c4f9936cc6)
- Bump @octokit/webhooks from 9.2.0 to [9.4.0](https://github.com/Shuttlerock/actions/commit/9cef3a6982c70819b4e1c28cdcffb8b42ea2e757)
