### PR TITLE
Release Candidate 2021-05-20-0715 (Quickest Quail)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ Thumbs.db
 
 # Shuttlerock custom.
 /.secrets
+
+# WebStorm IDE
+/.idea

--- a/.meta/STUDIO-2037.md
+++ b/.meta/STUDIO-2037.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/STUDIO-2037
+
+Created at 2021-05-16T22:28:03.552Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -5,7 +5,7 @@
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.1.0","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.7.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
+module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.2.3","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":"^3.0.0","@slack/types":"^2.0.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0","is-electron":"^2.2.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
 
 /***/ }),
 
@@ -3764,6 +3764,7 @@ exports.v = Octokit;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ConsoleLogger = exports.LogLevel = void 0;
 /**
  * Severity levels for log entries
  */
@@ -3836,6 +3837,7 @@ class ConsoleLogger {
         return ConsoleLogger.severity[a] >= ConsoleLogger.severity[b];
     }
 }
+exports.ConsoleLogger = ConsoleLogger;
 /** Map of labels for each log level */
 ConsoleLogger.labels = (() => {
     const entries = Object.entries(LogLevel);
@@ -3851,7 +3853,6 @@ ConsoleLogger.severity = {
     [LogLevel.INFO]: 200,
     [LogLevel.DEBUG]: 100,
 };
-exports.ConsoleLogger = ConsoleLogger;
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -3927,6 +3928,7 @@ const p_queue_1 = __importDefault(__nccwpck_require__(8983)); // tslint:disable-
 const p_retry_1 = __importStar(__nccwpck_require__(2548));
 const axios_1 = __importDefault(__nccwpck_require__(6545));
 const form_data_1 = __importDefault(__nccwpck_require__(4334)); // tslint:disable-line:import-name
+const is_electron_1 = __importDefault(__nccwpck_require__(7439));
 const methods_1 = __nccwpck_require__(1571);
 const instrument_1 = __nccwpck_require__(7763);
 const errors_1 = __nccwpck_require__(9781);
@@ -3943,7 +3945,7 @@ class WebClient extends methods_1.Methods {
     /**
      * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
      */
-    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = logger_1.LogLevel.INFO, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
+    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = undefined, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
         super();
         this.token = token;
         this.slackApiUrl = slackApiUrl;
@@ -3961,13 +3963,11 @@ class WebClient extends methods_1.Methods {
             }
         }
         else {
-            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel, logger);
+            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel !== null && logLevel !== void 0 ? logLevel : logger_1.LogLevel.INFO, logger);
         }
         this.axios = axios_1.default.create({
             baseURL: slackApiUrl,
-            headers: Object.assign({
-                'User-Agent': instrument_1.getUserAgent(),
-            }, headers),
+            headers: is_electron_1.default() ? headers : Object.assign({ 'User-Agent': instrument_1.getUserAgent() }, headers),
             httpAgent: agent,
             httpsAgent: agent,
             transformRequest: [this.serializeApiCallOptions.bind(this)],
@@ -3992,6 +3992,8 @@ class WebClient extends methods_1.Methods {
     async apiCall(method, options) {
         this.logger.debug(`apiCall('${method}') start`);
         warnDeprecations(method, this.logger);
+        warnIfFallbackIsMissing(method, this.logger, options);
+        warnIfThreadTsIsNotString(method, this.logger, options);
         if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
             throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
         }
@@ -4231,7 +4233,7 @@ class WebClient extends methods_1.Methods {
         }, initialValue));
     }
     /**
-     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
+     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevant
      * HTTP headers into the object.
      * @param response - an http response
      */
@@ -4323,6 +4325,44 @@ function warnDeprecations(method, logger) {
     }
     else if (isDeprecated) {
         logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
+    }
+}
+/**
+ * Log a warning when using chat.postMessage without text argument or attachments with fallback argument
+ * @param method api method being called
+ * @param logger instance of we clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfFallbackIsMissing(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+    const isTargetMethod = targetMethods.includes(method);
+    const missingAttachmentFallbackDetected = (args) => Array.isArray(args.attachments)
+        && args.attachments.some(attachment => !attachment.fallback || attachment.fallback.trim() === 0);
+    const isEmptyText = (args) => args.text === undefined || args.text === null || args.text === '';
+    const buildWarningMessage = (missing) => `The \`${missing}\` argument is missing in the request payload for a ${method} call - ` +
+        `It's a best practice to always provide a \`${missing}\` argument when posting a message. ` +
+        `The \`${missing}\` is used in places where the content cannot be rendered such as: ` +
+        'system push notifications, assistive technology such as screen readers, etc.';
+    if (isTargetMethod && typeof options === 'object' && isEmptyText(options)) {
+        if (missingAttachmentFallbackDetected(options)) {
+            logger.warn(buildWarningMessage('fallback'));
+        }
+        else {
+            logger.warn(buildWarningMessage('text'));
+        }
+    }
+}
+/**
+ * Log a warning when thread_ts is not a string
+ * @param method api method being called
+ * @param logger instance of web clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfThreadTsIsNotString(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'files.upload'];
+    const isTargetMethod = targetMethods.includes(method);
+    if (isTargetMethod && (options === null || options === void 0 ? void 0 : options.thread_ts) !== undefined && typeof (options === null || options === void 0 ? void 0 : options.thread_ts) !== 'string') {
+        logger.warn(`The given thread_ts value in the request payload for a ${method} call is a float value. We highly recommend using a string value instead.`);
     }
 }
 //# sourceMappingURL=WebClient.js.map
@@ -4457,6 +4497,7 @@ Object.defineProperty(exports, "retryPolicies", ({ enumerable: true, get: functi
 var instrument_1 = __nccwpck_require__(7763);
 Object.defineProperty(exports, "addAppMetadata", ({ enumerable: true, get: function () { return instrument_1.addAppMetadata; } }));
 __exportStar(__nccwpck_require__(1571), exports);
+__exportStar(__nccwpck_require__(677), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -4599,11 +4640,13 @@ class Methods extends eventemitter3_1.EventEmitter {
     constructor() {
         super();
         this.admin = {
+            // TODO: admin.analytics.getFile
             apps: {
                 approve: bindApiCall(this, 'admin.apps.approve'),
                 approved: {
                     list: bindApiCall(this, 'admin.apps.approved.list'),
                 },
+                clearResolution: bindApiCall(this, 'admin.apps.clearResolution'),
                 requests: {
                     list: bindApiCall(this, 'admin.apps.requests.list'),
                 },
@@ -4611,6 +4654,7 @@ class Methods extends eventemitter3_1.EventEmitter {
                 restricted: {
                     list: bindApiCall(this, 'admin.apps.restricted.list'),
                 },
+                uninstall: bindApiCall(this, 'admin.apps.uninstall'),
             },
             barriers: {
                 create: bindApiCall(this, 'admin.barriers.create'),
@@ -4692,6 +4736,9 @@ class Methods extends eventemitter3_1.EventEmitter {
                     list: bindApiCall(this, 'admin.users.session.list'),
                     reset: bindApiCall(this, 'admin.users.session.reset'),
                     invalidate: bindApiCall(this, 'admin.users.session.invalidate'),
+                    getSettings: bindApiCall(this, 'admin.users.session.getSettings'),
+                    setSettings: bindApiCall(this, 'admin.users.session.setSettings'),
+                    clearSettings: bindApiCall(this, 'admin.users.session.clearSettings'),
                 },
                 setAdmin: bindApiCall(this, 'admin.users.setAdmin'),
                 setExpiration: bindApiCall(this, 'admin.users.setExpiration'),
@@ -4733,23 +4780,6 @@ class Methods extends eventemitter3_1.EventEmitter {
                 remove: bindApiCall(this, 'calls.participants.remove'),
             },
         };
-        this.channels = {
-            archive: bindApiCall(this, 'channels.archive'),
-            create: bindApiCall(this, 'channels.create'),
-            history: bindApiCall(this, 'channels.history'),
-            info: bindApiCall(this, 'channels.info'),
-            invite: bindApiCall(this, 'channels.invite'),
-            join: bindApiCall(this, 'channels.join'),
-            kick: bindApiCall(this, 'channels.kick'),
-            leave: bindApiCall(this, 'channels.leave'),
-            list: bindApiCall(this, 'channels.list'),
-            mark: bindApiCall(this, 'channels.mark'),
-            rename: bindApiCall(this, 'channels.rename'),
-            replies: bindApiCall(this, 'channels.replies'),
-            setPurpose: bindApiCall(this, 'channels.setPurpose'),
-            setTopic: bindApiCall(this, 'channels.setTopic'),
-            unarchive: bindApiCall(this, 'channels.unarchive'),
-        };
         this.chat = {
             delete: bindApiCall(this, 'chat.delete'),
             deleteScheduledMessage: bindApiCall(this, 'chat.deleteScheduledMessage'),
@@ -4784,12 +4814,6 @@ class Methods extends eventemitter3_1.EventEmitter {
             setTopic: bindApiCall(this, 'conversations.setTopic'),
             unarchive: bindApiCall(this, 'conversations.unarchive'),
         };
-        this.views = {
-            open: bindApiCall(this, 'views.open'),
-            publish: bindApiCall(this, 'views.publish'),
-            push: bindApiCall(this, 'views.push'),
-            update: bindApiCall(this, 'views.update'),
-        };
         this.dialog = {
             open: bindApiCall(this, 'dialog.open'),
         };
@@ -4822,42 +4846,8 @@ class Methods extends eventemitter3_1.EventEmitter {
                 share: bindApiCall(this, 'files.remote.share'),
             },
         };
-        this.groups = {
-            archive: bindApiCall(this, 'groups.archive'),
-            create: bindApiCall(this, 'groups.create'),
-            createChild: bindApiCall(this, 'groups.createChild'),
-            history: bindApiCall(this, 'groups.history'),
-            info: bindApiCall(this, 'groups.info'),
-            invite: bindApiCall(this, 'groups.invite'),
-            kick: bindApiCall(this, 'groups.kick'),
-            leave: bindApiCall(this, 'groups.leave'),
-            list: bindApiCall(this, 'groups.list'),
-            mark: bindApiCall(this, 'groups.mark'),
-            open: bindApiCall(this, 'groups.open'),
-            rename: bindApiCall(this, 'groups.rename'),
-            replies: bindApiCall(this, 'groups.replies'),
-            setPurpose: bindApiCall(this, 'groups.setPurpose'),
-            setTopic: bindApiCall(this, 'groups.setTopic'),
-            unarchive: bindApiCall(this, 'groups.unarchive'),
-        };
-        this.im = {
-            close: bindApiCall(this, 'im.close'),
-            history: bindApiCall(this, 'im.history'),
-            list: bindApiCall(this, 'im.list'),
-            mark: bindApiCall(this, 'im.mark'),
-            open: bindApiCall(this, 'im.open'),
-            replies: bindApiCall(this, 'im.replies'),
-        };
         this.migration = {
             exchange: bindApiCall(this, 'migration.exchange'),
-        };
-        this.mpim = {
-            close: bindApiCall(this, 'mpim.close'),
-            history: bindApiCall(this, 'mpim.history'),
-            list: bindApiCall(this, 'mpim.list'),
-            mark: bindApiCall(this, 'mpim.mark'),
-            open: bindApiCall(this, 'mpim.open'),
-            replies: bindApiCall(this, 'mpim.replies'),
         };
         this.oauth = {
             access: bindApiCall(this, 'oauth.access'),
@@ -4932,10 +4922,70 @@ class Methods extends eventemitter3_1.EventEmitter {
                 set: bindApiCall(this, 'users.profile.set'),
             },
         };
+        this.views = {
+            open: bindApiCall(this, 'views.open'),
+            publish: bindApiCall(this, 'views.publish'),
+            push: bindApiCall(this, 'views.push'),
+            update: bindApiCall(this, 'views.update'),
+        };
         this.workflows = {
             stepCompleted: bindApiCall(this, 'workflows.stepCompleted'),
             stepFailed: bindApiCall(this, 'workflows.stepFailed'),
             updateStep: bindApiCall(this, 'workflows.updateStep'),
+        };
+        // ---------------------------------
+        // Deprecated methods
+        // ---------------------------------
+        this.channels = {
+            archive: bindApiCall(this, 'channels.archive'),
+            create: bindApiCall(this, 'channels.create'),
+            history: bindApiCall(this, 'channels.history'),
+            info: bindApiCall(this, 'channels.info'),
+            invite: bindApiCall(this, 'channels.invite'),
+            join: bindApiCall(this, 'channels.join'),
+            kick: bindApiCall(this, 'channels.kick'),
+            leave: bindApiCall(this, 'channels.leave'),
+            list: bindApiCall(this, 'channels.list'),
+            mark: bindApiCall(this, 'channels.mark'),
+            rename: bindApiCall(this, 'channels.rename'),
+            replies: bindApiCall(this, 'channels.replies'),
+            setPurpose: bindApiCall(this, 'channels.setPurpose'),
+            setTopic: bindApiCall(this, 'channels.setTopic'),
+            unarchive: bindApiCall(this, 'channels.unarchive'),
+        };
+        this.groups = {
+            archive: bindApiCall(this, 'groups.archive'),
+            create: bindApiCall(this, 'groups.create'),
+            createChild: bindApiCall(this, 'groups.createChild'),
+            history: bindApiCall(this, 'groups.history'),
+            info: bindApiCall(this, 'groups.info'),
+            invite: bindApiCall(this, 'groups.invite'),
+            kick: bindApiCall(this, 'groups.kick'),
+            leave: bindApiCall(this, 'groups.leave'),
+            list: bindApiCall(this, 'groups.list'),
+            mark: bindApiCall(this, 'groups.mark'),
+            open: bindApiCall(this, 'groups.open'),
+            rename: bindApiCall(this, 'groups.rename'),
+            replies: bindApiCall(this, 'groups.replies'),
+            setPurpose: bindApiCall(this, 'groups.setPurpose'),
+            setTopic: bindApiCall(this, 'groups.setTopic'),
+            unarchive: bindApiCall(this, 'groups.unarchive'),
+        };
+        this.im = {
+            close: bindApiCall(this, 'im.close'),
+            history: bindApiCall(this, 'im.history'),
+            list: bindApiCall(this, 'im.list'),
+            mark: bindApiCall(this, 'im.mark'),
+            open: bindApiCall(this, 'im.open'),
+            replies: bindApiCall(this, 'im.replies'),
+        };
+        this.mpim = {
+            close: bindApiCall(this, 'mpim.close'),
+            history: bindApiCall(this, 'mpim.history'),
+            list: bindApiCall(this, 'mpim.list'),
+            mark: bindApiCall(this, 'mpim.mark'),
+            open: bindApiCall(this, 'mpim.open'),
+            replies: bindApiCall(this, 'mpim.replies'),
         };
         // Check that the class being created extends from `WebClient` rather than this class
         if (new.target !== WebClient_1.WebClient && !(new.target.prototype instanceof WebClient_1.WebClient)) {
@@ -4983,6 +5033,16 @@ exports.cursorPaginationEnabledMethods.add('users.conversations');
 exports.cursorPaginationEnabledMethods.add('users.list');
 __exportStar(__nccwpck_require__(4380), exports);
 //# sourceMappingURL=methods.js.map
+
+/***/ }),
+
+/***/ 677:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
@@ -26756,6 +26816,34 @@ module.exports = {
     return (h1.equals(h2));
   }
 };
+
+
+/***/ }),
+
+/***/ 7439:
+/***/ ((module) => {
+
+// https://github.com/electron/electron/issues/2288
+function isElectron() {
+    // Renderer process
+    if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer') {
+        return true;
+    }
+
+    // Main process
+    if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron) {
+        return true;
+    }
+
+    // Detect the user agent when the `nodeIntegration` option is set to true
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = isElectron;
 
 
 /***/ }),

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -60011,7 +60011,6 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60036,7 +60035,6 @@ const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, v
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 const Credentials_fetchRepository = (name) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60095,7 +60093,6 @@ const Git_TreeTypes = {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60113,7 +60110,6 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60132,7 +60128,6 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60150,7 +60145,6 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60167,7 +60161,6 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60197,7 +60190,6 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60213,7 +60205,6 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60235,7 +60226,6 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60249,7 +60239,6 @@ const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, vo
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 const Repository_repositoryUrl = (repo) => `https://github.com/${organizationName()}/${repo}`;
@@ -60274,7 +60263,6 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60299,7 +60287,6 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60328,7 +60315,6 @@ const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 const Branch_createBranch = (repo, baseBranchName, newBranchName, filePath, fileContent, commitMessage) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60373,7 +60359,6 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60394,7 +60379,6 @@ const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaite
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 const PullRequest_createPullRequest = (repo, base, head, title, body, token) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60413,7 +60397,6 @@ const PullRequest_createPullRequest = (repo, base, head, title, body, token) => 
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 const PullRequest_getIssueKey = (pr) => {
@@ -60437,7 +60420,6 @@ const PullRequest_getIssueKey = (pr) => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60463,7 +60445,6 @@ const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0,
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60485,7 +60466,6 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 const PullRequest_extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\d+)\].*$/, '$1'), 10) ||
@@ -60496,7 +60476,6 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60512,7 +60491,6 @@ const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organizationName()}/${repo}/pull/${number}`;
@@ -60523,7 +60501,6 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60542,7 +60519,6 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60581,7 +60557,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60599,7 +60574,6 @@ const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, 
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 const Label_addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60689,7 +60663,6 @@ const JiraFieldStoryPointEstimate = 'Story point estimate';
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (issue, fieldName) => {
@@ -60701,7 +60674,6 @@ const idForFieldName = (issue, fieldName) => {
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue) => {
@@ -60729,7 +60701,6 @@ const populateExplicitFields = (issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60753,7 +60724,6 @@ const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* 
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60772,7 +60742,6 @@ const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 const getEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60800,7 +60769,6 @@ const recursiveGetEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60820,7 +60788,6 @@ const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60834,7 +60801,6 @@ const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
@@ -60842,10 +60808,8 @@ const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 const moveIssueToBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60928,7 +60892,6 @@ var Project_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60944,7 +60907,6 @@ const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60964,7 +60926,6 @@ const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, functi
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60988,7 +60949,6 @@ const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61012,7 +60972,6 @@ const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, f
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61035,7 +60994,6 @@ const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61071,7 +61029,6 @@ var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 const createJiraRelease = (projectKey, name, description) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61101,7 +61058,6 @@ const createJiraRelease = (projectKey, name, description) => Release_awaiter(voi
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 const findJiraRelease = (projectKey, name) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61208,7 +61164,6 @@ var lodash_startCase = __nccwpck_require__(9274);
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 const String_parameterize = (str) => snakeCase(str.trim().toLowerCase())
@@ -62016,7 +61971,6 @@ mustache_mustache.Writer = Writer;
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 const Template_render = (template, vars) => mustache.render(template, vars);
@@ -62101,7 +62055,6 @@ var Epic_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, void 0, void 0, function* () {
@@ -62230,7 +62183,6 @@ const positiveEmoji = () => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 const scrubMessage = (message) => {
@@ -62248,7 +62200,6 @@ const scrubMessage = (message) => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62267,7 +62218,6 @@ const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, fu
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const Message_sendUserMessage = (userId, message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62327,7 +62277,6 @@ var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thi
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62388,7 +62337,6 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62415,7 +62363,6 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62445,7 +62392,6 @@ const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Gith
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62458,7 +62404,6 @@ const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0,
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62471,7 +62416,6 @@ const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, 
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62534,7 +62478,6 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62585,7 +62528,6 @@ var checkSuiteCompleted_awaiter = (undefined && undefined.__awaiter) || function
  * @param {Issue}                issue       The Jira issue that the PR is linked to.
  * @param {Repository}           repoName    The name of the Github repository.
  * @param {PullsGetResponseData} pullRequest The pull request being checked.
- *
  * @returns {string | undefined} A message to be sent to the user in Slack.
  */
 const handleFailure = (checkName, issue, repoName, pullRequest) => checkSuiteCompleted_awaiter(void 0, void 0, void 0, function* () {
@@ -62599,7 +62541,6 @@ const handleFailure = (checkName, issue, repoName, pullRequest) => checkSuiteCom
  *
  * @param {string}               checkName   The name of the Github app running the check.
  * @param {PullsGetResponseData} pullRequest The pull request being checked.
- *
  * @returns {string | undefined} A message to be sent to the user in Slack.
  */
 const handleSuccess = (checkName, pullRequest) => {

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -5,7 +5,7 @@
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.1.0","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.7.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
+module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.2.3","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":"^3.0.0","@slack/types":"^2.0.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0","is-electron":"^2.2.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
 
 /***/ }),
 
@@ -3764,6 +3764,7 @@ exports.v = Octokit;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ConsoleLogger = exports.LogLevel = void 0;
 /**
  * Severity levels for log entries
  */
@@ -3836,6 +3837,7 @@ class ConsoleLogger {
         return ConsoleLogger.severity[a] >= ConsoleLogger.severity[b];
     }
 }
+exports.ConsoleLogger = ConsoleLogger;
 /** Map of labels for each log level */
 ConsoleLogger.labels = (() => {
     const entries = Object.entries(LogLevel);
@@ -3851,7 +3853,6 @@ ConsoleLogger.severity = {
     [LogLevel.INFO]: 200,
     [LogLevel.DEBUG]: 100,
 };
-exports.ConsoleLogger = ConsoleLogger;
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -3927,6 +3928,7 @@ const p_queue_1 = __importDefault(__nccwpck_require__(8983)); // tslint:disable-
 const p_retry_1 = __importStar(__nccwpck_require__(2548));
 const axios_1 = __importDefault(__nccwpck_require__(6545));
 const form_data_1 = __importDefault(__nccwpck_require__(4334)); // tslint:disable-line:import-name
+const is_electron_1 = __importDefault(__nccwpck_require__(7439));
 const methods_1 = __nccwpck_require__(1571);
 const instrument_1 = __nccwpck_require__(7763);
 const errors_1 = __nccwpck_require__(9781);
@@ -3943,7 +3945,7 @@ class WebClient extends methods_1.Methods {
     /**
      * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
      */
-    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = logger_1.LogLevel.INFO, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
+    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = undefined, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
         super();
         this.token = token;
         this.slackApiUrl = slackApiUrl;
@@ -3961,13 +3963,11 @@ class WebClient extends methods_1.Methods {
             }
         }
         else {
-            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel, logger);
+            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel !== null && logLevel !== void 0 ? logLevel : logger_1.LogLevel.INFO, logger);
         }
         this.axios = axios_1.default.create({
             baseURL: slackApiUrl,
-            headers: Object.assign({
-                'User-Agent': instrument_1.getUserAgent(),
-            }, headers),
+            headers: is_electron_1.default() ? headers : Object.assign({ 'User-Agent': instrument_1.getUserAgent() }, headers),
             httpAgent: agent,
             httpsAgent: agent,
             transformRequest: [this.serializeApiCallOptions.bind(this)],
@@ -3992,6 +3992,8 @@ class WebClient extends methods_1.Methods {
     async apiCall(method, options) {
         this.logger.debug(`apiCall('${method}') start`);
         warnDeprecations(method, this.logger);
+        warnIfFallbackIsMissing(method, this.logger, options);
+        warnIfThreadTsIsNotString(method, this.logger, options);
         if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
             throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
         }
@@ -4231,7 +4233,7 @@ class WebClient extends methods_1.Methods {
         }, initialValue));
     }
     /**
-     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
+     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevant
      * HTTP headers into the object.
      * @param response - an http response
      */
@@ -4323,6 +4325,44 @@ function warnDeprecations(method, logger) {
     }
     else if (isDeprecated) {
         logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
+    }
+}
+/**
+ * Log a warning when using chat.postMessage without text argument or attachments with fallback argument
+ * @param method api method being called
+ * @param logger instance of we clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfFallbackIsMissing(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+    const isTargetMethod = targetMethods.includes(method);
+    const missingAttachmentFallbackDetected = (args) => Array.isArray(args.attachments)
+        && args.attachments.some(attachment => !attachment.fallback || attachment.fallback.trim() === 0);
+    const isEmptyText = (args) => args.text === undefined || args.text === null || args.text === '';
+    const buildWarningMessage = (missing) => `The \`${missing}\` argument is missing in the request payload for a ${method} call - ` +
+        `It's a best practice to always provide a \`${missing}\` argument when posting a message. ` +
+        `The \`${missing}\` is used in places where the content cannot be rendered such as: ` +
+        'system push notifications, assistive technology such as screen readers, etc.';
+    if (isTargetMethod && typeof options === 'object' && isEmptyText(options)) {
+        if (missingAttachmentFallbackDetected(options)) {
+            logger.warn(buildWarningMessage('fallback'));
+        }
+        else {
+            logger.warn(buildWarningMessage('text'));
+        }
+    }
+}
+/**
+ * Log a warning when thread_ts is not a string
+ * @param method api method being called
+ * @param logger instance of web clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfThreadTsIsNotString(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'files.upload'];
+    const isTargetMethod = targetMethods.includes(method);
+    if (isTargetMethod && (options === null || options === void 0 ? void 0 : options.thread_ts) !== undefined && typeof (options === null || options === void 0 ? void 0 : options.thread_ts) !== 'string') {
+        logger.warn(`The given thread_ts value in the request payload for a ${method} call is a float value. We highly recommend using a string value instead.`);
     }
 }
 //# sourceMappingURL=WebClient.js.map
@@ -4457,6 +4497,7 @@ Object.defineProperty(exports, "retryPolicies", ({ enumerable: true, get: functi
 var instrument_1 = __nccwpck_require__(7763);
 Object.defineProperty(exports, "addAppMetadata", ({ enumerable: true, get: function () { return instrument_1.addAppMetadata; } }));
 __exportStar(__nccwpck_require__(1571), exports);
+__exportStar(__nccwpck_require__(677), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -4599,11 +4640,13 @@ class Methods extends eventemitter3_1.EventEmitter {
     constructor() {
         super();
         this.admin = {
+            // TODO: admin.analytics.getFile
             apps: {
                 approve: bindApiCall(this, 'admin.apps.approve'),
                 approved: {
                     list: bindApiCall(this, 'admin.apps.approved.list'),
                 },
+                clearResolution: bindApiCall(this, 'admin.apps.clearResolution'),
                 requests: {
                     list: bindApiCall(this, 'admin.apps.requests.list'),
                 },
@@ -4611,6 +4654,7 @@ class Methods extends eventemitter3_1.EventEmitter {
                 restricted: {
                     list: bindApiCall(this, 'admin.apps.restricted.list'),
                 },
+                uninstall: bindApiCall(this, 'admin.apps.uninstall'),
             },
             barriers: {
                 create: bindApiCall(this, 'admin.barriers.create'),
@@ -4692,6 +4736,9 @@ class Methods extends eventemitter3_1.EventEmitter {
                     list: bindApiCall(this, 'admin.users.session.list'),
                     reset: bindApiCall(this, 'admin.users.session.reset'),
                     invalidate: bindApiCall(this, 'admin.users.session.invalidate'),
+                    getSettings: bindApiCall(this, 'admin.users.session.getSettings'),
+                    setSettings: bindApiCall(this, 'admin.users.session.setSettings'),
+                    clearSettings: bindApiCall(this, 'admin.users.session.clearSettings'),
                 },
                 setAdmin: bindApiCall(this, 'admin.users.setAdmin'),
                 setExpiration: bindApiCall(this, 'admin.users.setExpiration'),
@@ -4733,23 +4780,6 @@ class Methods extends eventemitter3_1.EventEmitter {
                 remove: bindApiCall(this, 'calls.participants.remove'),
             },
         };
-        this.channels = {
-            archive: bindApiCall(this, 'channels.archive'),
-            create: bindApiCall(this, 'channels.create'),
-            history: bindApiCall(this, 'channels.history'),
-            info: bindApiCall(this, 'channels.info'),
-            invite: bindApiCall(this, 'channels.invite'),
-            join: bindApiCall(this, 'channels.join'),
-            kick: bindApiCall(this, 'channels.kick'),
-            leave: bindApiCall(this, 'channels.leave'),
-            list: bindApiCall(this, 'channels.list'),
-            mark: bindApiCall(this, 'channels.mark'),
-            rename: bindApiCall(this, 'channels.rename'),
-            replies: bindApiCall(this, 'channels.replies'),
-            setPurpose: bindApiCall(this, 'channels.setPurpose'),
-            setTopic: bindApiCall(this, 'channels.setTopic'),
-            unarchive: bindApiCall(this, 'channels.unarchive'),
-        };
         this.chat = {
             delete: bindApiCall(this, 'chat.delete'),
             deleteScheduledMessage: bindApiCall(this, 'chat.deleteScheduledMessage'),
@@ -4784,12 +4814,6 @@ class Methods extends eventemitter3_1.EventEmitter {
             setTopic: bindApiCall(this, 'conversations.setTopic'),
             unarchive: bindApiCall(this, 'conversations.unarchive'),
         };
-        this.views = {
-            open: bindApiCall(this, 'views.open'),
-            publish: bindApiCall(this, 'views.publish'),
-            push: bindApiCall(this, 'views.push'),
-            update: bindApiCall(this, 'views.update'),
-        };
         this.dialog = {
             open: bindApiCall(this, 'dialog.open'),
         };
@@ -4822,42 +4846,8 @@ class Methods extends eventemitter3_1.EventEmitter {
                 share: bindApiCall(this, 'files.remote.share'),
             },
         };
-        this.groups = {
-            archive: bindApiCall(this, 'groups.archive'),
-            create: bindApiCall(this, 'groups.create'),
-            createChild: bindApiCall(this, 'groups.createChild'),
-            history: bindApiCall(this, 'groups.history'),
-            info: bindApiCall(this, 'groups.info'),
-            invite: bindApiCall(this, 'groups.invite'),
-            kick: bindApiCall(this, 'groups.kick'),
-            leave: bindApiCall(this, 'groups.leave'),
-            list: bindApiCall(this, 'groups.list'),
-            mark: bindApiCall(this, 'groups.mark'),
-            open: bindApiCall(this, 'groups.open'),
-            rename: bindApiCall(this, 'groups.rename'),
-            replies: bindApiCall(this, 'groups.replies'),
-            setPurpose: bindApiCall(this, 'groups.setPurpose'),
-            setTopic: bindApiCall(this, 'groups.setTopic'),
-            unarchive: bindApiCall(this, 'groups.unarchive'),
-        };
-        this.im = {
-            close: bindApiCall(this, 'im.close'),
-            history: bindApiCall(this, 'im.history'),
-            list: bindApiCall(this, 'im.list'),
-            mark: bindApiCall(this, 'im.mark'),
-            open: bindApiCall(this, 'im.open'),
-            replies: bindApiCall(this, 'im.replies'),
-        };
         this.migration = {
             exchange: bindApiCall(this, 'migration.exchange'),
-        };
-        this.mpim = {
-            close: bindApiCall(this, 'mpim.close'),
-            history: bindApiCall(this, 'mpim.history'),
-            list: bindApiCall(this, 'mpim.list'),
-            mark: bindApiCall(this, 'mpim.mark'),
-            open: bindApiCall(this, 'mpim.open'),
-            replies: bindApiCall(this, 'mpim.replies'),
         };
         this.oauth = {
             access: bindApiCall(this, 'oauth.access'),
@@ -4932,10 +4922,70 @@ class Methods extends eventemitter3_1.EventEmitter {
                 set: bindApiCall(this, 'users.profile.set'),
             },
         };
+        this.views = {
+            open: bindApiCall(this, 'views.open'),
+            publish: bindApiCall(this, 'views.publish'),
+            push: bindApiCall(this, 'views.push'),
+            update: bindApiCall(this, 'views.update'),
+        };
         this.workflows = {
             stepCompleted: bindApiCall(this, 'workflows.stepCompleted'),
             stepFailed: bindApiCall(this, 'workflows.stepFailed'),
             updateStep: bindApiCall(this, 'workflows.updateStep'),
+        };
+        // ---------------------------------
+        // Deprecated methods
+        // ---------------------------------
+        this.channels = {
+            archive: bindApiCall(this, 'channels.archive'),
+            create: bindApiCall(this, 'channels.create'),
+            history: bindApiCall(this, 'channels.history'),
+            info: bindApiCall(this, 'channels.info'),
+            invite: bindApiCall(this, 'channels.invite'),
+            join: bindApiCall(this, 'channels.join'),
+            kick: bindApiCall(this, 'channels.kick'),
+            leave: bindApiCall(this, 'channels.leave'),
+            list: bindApiCall(this, 'channels.list'),
+            mark: bindApiCall(this, 'channels.mark'),
+            rename: bindApiCall(this, 'channels.rename'),
+            replies: bindApiCall(this, 'channels.replies'),
+            setPurpose: bindApiCall(this, 'channels.setPurpose'),
+            setTopic: bindApiCall(this, 'channels.setTopic'),
+            unarchive: bindApiCall(this, 'channels.unarchive'),
+        };
+        this.groups = {
+            archive: bindApiCall(this, 'groups.archive'),
+            create: bindApiCall(this, 'groups.create'),
+            createChild: bindApiCall(this, 'groups.createChild'),
+            history: bindApiCall(this, 'groups.history'),
+            info: bindApiCall(this, 'groups.info'),
+            invite: bindApiCall(this, 'groups.invite'),
+            kick: bindApiCall(this, 'groups.kick'),
+            leave: bindApiCall(this, 'groups.leave'),
+            list: bindApiCall(this, 'groups.list'),
+            mark: bindApiCall(this, 'groups.mark'),
+            open: bindApiCall(this, 'groups.open'),
+            rename: bindApiCall(this, 'groups.rename'),
+            replies: bindApiCall(this, 'groups.replies'),
+            setPurpose: bindApiCall(this, 'groups.setPurpose'),
+            setTopic: bindApiCall(this, 'groups.setTopic'),
+            unarchive: bindApiCall(this, 'groups.unarchive'),
+        };
+        this.im = {
+            close: bindApiCall(this, 'im.close'),
+            history: bindApiCall(this, 'im.history'),
+            list: bindApiCall(this, 'im.list'),
+            mark: bindApiCall(this, 'im.mark'),
+            open: bindApiCall(this, 'im.open'),
+            replies: bindApiCall(this, 'im.replies'),
+        };
+        this.mpim = {
+            close: bindApiCall(this, 'mpim.close'),
+            history: bindApiCall(this, 'mpim.history'),
+            list: bindApiCall(this, 'mpim.list'),
+            mark: bindApiCall(this, 'mpim.mark'),
+            open: bindApiCall(this, 'mpim.open'),
+            replies: bindApiCall(this, 'mpim.replies'),
         };
         // Check that the class being created extends from `WebClient` rather than this class
         if (new.target !== WebClient_1.WebClient && !(new.target.prototype instanceof WebClient_1.WebClient)) {
@@ -4983,6 +5033,16 @@ exports.cursorPaginationEnabledMethods.add('users.conversations');
 exports.cursorPaginationEnabledMethods.add('users.list');
 __exportStar(__nccwpck_require__(4380), exports);
 //# sourceMappingURL=methods.js.map
+
+/***/ }),
+
+/***/ 677:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
@@ -26756,6 +26816,34 @@ module.exports = {
     return (h1.equals(h2));
   }
 };
+
+
+/***/ }),
+
+/***/ 7439:
+/***/ ((module) => {
+
+// https://github.com/electron/electron/issues/2288
+function isElectron() {
+    // Renderer process
+    if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer') {
+        return true;
+    }
+
+    // Main process
+    if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron) {
+        return true;
+    }
+
+    // Detect the user agent when the `nodeIntegration` option is set to true
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = isElectron;
 
 
 /***/ }),

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -60011,7 +60011,6 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60036,7 +60035,6 @@ const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, v
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 const Credentials_fetchRepository = (name) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60095,7 +60093,6 @@ const Git_TreeTypes = {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60113,7 +60110,6 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60132,7 +60128,6 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60150,7 +60145,6 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60167,7 +60161,6 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60197,7 +60190,6 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60213,7 +60205,6 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60235,7 +60226,6 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60249,7 +60239,6 @@ const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, vo
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 const Repository_repositoryUrl = (repo) => `https://github.com/${organizationName()}/${repo}`;
@@ -60274,7 +60263,6 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60299,7 +60287,6 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60328,7 +60315,6 @@ const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 const Branch_createBranch = (repo, baseBranchName, newBranchName, filePath, fileContent, commitMessage) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60373,7 +60359,6 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60394,7 +60379,6 @@ const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaite
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 const PullRequest_createPullRequest = (repo, base, head, title, body, token) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60413,7 +60397,6 @@ const PullRequest_createPullRequest = (repo, base, head, title, body, token) => 
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 const PullRequest_getIssueKey = (pr) => {
@@ -60437,7 +60420,6 @@ const PullRequest_getIssueKey = (pr) => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60463,7 +60445,6 @@ const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0,
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60485,7 +60466,6 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 const PullRequest_extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\d+)\].*$/, '$1'), 10) ||
@@ -60496,7 +60476,6 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60512,7 +60491,6 @@ const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organizationName()}/${repo}/pull/${number}`;
@@ -60523,7 +60501,6 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60542,7 +60519,6 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60581,7 +60557,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60599,7 +60574,6 @@ const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, 
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 const Label_addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60689,7 +60663,6 @@ const JiraFieldStoryPointEstimate = 'Story point estimate';
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (issue, fieldName) => {
@@ -60701,7 +60674,6 @@ const idForFieldName = (issue, fieldName) => {
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue) => {
@@ -60729,7 +60701,6 @@ const populateExplicitFields = (issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60753,7 +60724,6 @@ const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* 
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60772,7 +60742,6 @@ const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 const getEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60800,7 +60769,6 @@ const recursiveGetEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60820,7 +60788,6 @@ const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60834,7 +60801,6 @@ const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
@@ -60842,10 +60808,8 @@ const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 const moveIssueToBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60928,7 +60892,6 @@ var Project_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60944,7 +60907,6 @@ const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60964,7 +60926,6 @@ const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, functi
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60988,7 +60949,6 @@ const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61012,7 +60972,6 @@ const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, f
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61035,7 +60994,6 @@ const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61071,7 +61029,6 @@ var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 const createJiraRelease = (projectKey, name, description) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61101,7 +61058,6 @@ const createJiraRelease = (projectKey, name, description) => Release_awaiter(voi
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 const findJiraRelease = (projectKey, name) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61208,7 +61164,6 @@ var lodash_startCase = __nccwpck_require__(9274);
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 const String_parameterize = (str) => snakeCase(str.trim().toLowerCase())
@@ -62016,7 +61971,6 @@ mustache_mustache.Writer = Writer;
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 const Template_render = (template, vars) => mustache.render(template, vars);
@@ -62101,7 +62055,6 @@ var Epic_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, void 0, void 0, function* () {
@@ -62230,7 +62183,6 @@ const positiveEmoji = () => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 const scrubMessage = (message) => {
@@ -62248,7 +62200,6 @@ const scrubMessage = (message) => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62267,7 +62218,6 @@ const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, fu
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const Message_sendUserMessage = (userId, message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62327,7 +62277,6 @@ var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thi
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62388,7 +62337,6 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62415,7 +62363,6 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62445,7 +62392,6 @@ const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Gith
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62458,7 +62404,6 @@ const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0,
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62471,7 +62416,6 @@ const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, 
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62534,7 +62478,6 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62585,7 +62528,6 @@ var checkSuiteCompleted_awaiter = (undefined && undefined.__awaiter) || function
  * @param {Issue}                issue       The Jira issue that the PR is linked to.
  * @param {Repository}           repoName    The name of the Github repository.
  * @param {PullsGetResponseData} pullRequest The pull request being checked.
- *
  * @returns {string | undefined} A message to be sent to the user in Slack.
  */
 const handleFailure = (checkName, issue, repoName, pullRequest) => checkSuiteCompleted_awaiter(void 0, void 0, void 0, function* () {
@@ -62599,7 +62541,6 @@ const handleFailure = (checkName, issue, repoName, pullRequest) => checkSuiteCom
  *
  * @param {string}               checkName   The name of the Github app running the check.
  * @param {PullsGetResponseData} pullRequest The pull request being checked.
- *
  * @returns {string | undefined} A message to be sent to the user in Slack.
  */
 const handleSuccess = (checkName, pullRequest) => {

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -60008,7 +60008,6 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60033,7 +60032,6 @@ const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, v
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 const fetchRepository = (name) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60092,7 +60090,6 @@ const Git_TreeTypes = {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60110,7 +60107,6 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60129,7 +60125,6 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60147,7 +60142,6 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60164,7 +60158,6 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60194,7 +60187,6 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60210,7 +60202,6 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60232,7 +60223,6 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60246,7 +60236,6 @@ const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, vo
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 const Repository_repositoryUrl = (repo) => `https://github.com/${organizationName()}/${repo}`;
@@ -60271,7 +60260,6 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60296,7 +60284,6 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60325,7 +60312,6 @@ const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 const Branch_createBranch = (repo, baseBranchName, newBranchName, filePath, fileContent, commitMessage) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60369,7 +60355,6 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60390,7 +60375,6 @@ const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaite
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 const PullRequest_createPullRequest = (repo, base, head, title, body, token) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60409,7 +60393,6 @@ const PullRequest_createPullRequest = (repo, base, head, title, body, token) => 
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 const PullRequest_getIssueKey = (pr) => {
@@ -60433,7 +60416,6 @@ const PullRequest_getIssueKey = (pr) => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60459,7 +60441,6 @@ const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0,
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60481,7 +60462,6 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 const PullRequest_extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\d+)\].*$/, '$1'), 10) ||
@@ -60492,7 +60472,6 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60508,7 +60487,6 @@ const listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, voi
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Inputs_organizationName()}/${repo}/pull/${number}`;
@@ -60519,7 +60497,6 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Input
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60538,7 +60515,6 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60577,7 +60553,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60595,7 +60570,6 @@ const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, 
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 const Label_addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60685,7 +60659,6 @@ const JiraFieldStoryPointEstimate = 'Story point estimate';
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (issue, fieldName) => {
@@ -60697,7 +60670,6 @@ const idForFieldName = (issue, fieldName) => {
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue) => {
@@ -60725,7 +60697,6 @@ const populateExplicitFields = (issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60749,7 +60720,6 @@ const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* 
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60768,7 +60738,6 @@ const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 const getEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60796,7 +60765,6 @@ const recursiveGetEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60816,7 +60784,6 @@ const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60830,7 +60797,6 @@ const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
@@ -60838,10 +60804,8 @@ const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 const moveIssueToBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60924,7 +60888,6 @@ var Project_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60940,7 +60903,6 @@ const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60960,7 +60922,6 @@ const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, functi
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60984,7 +60945,6 @@ const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61008,7 +60968,6 @@ const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, f
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61031,7 +60990,6 @@ const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 const getProject = (projectKey) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61070,7 +61028,6 @@ var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 const createJiraRelease = (projectKey, name, description) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61100,7 +61057,6 @@ const createJiraRelease = (projectKey, name, description) => Release_awaiter(voi
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 const findJiraRelease = (projectKey, name) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61207,7 +61163,6 @@ var lodash_startCase = __nccwpck_require__(9274);
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 const String_parameterize = (str) => snakeCase(str.trim().toLowerCase())
@@ -62015,7 +61970,6 @@ mustache_mustache.Writer = Writer;
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 const Template_render = (template, vars) => mustache.render(template, vars);
@@ -62100,7 +62054,6 @@ var Epic_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, void 0, void 0, function* () {
@@ -62229,7 +62182,6 @@ const positiveEmoji = () => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 const scrubMessage = (message) => {
@@ -62247,7 +62199,6 @@ const scrubMessage = (message) => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62266,7 +62217,6 @@ const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, fu
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const Message_sendUserMessage = (userId, message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62326,7 +62276,6 @@ var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thi
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62387,7 +62336,6 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62414,7 +62362,6 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62444,7 +62391,6 @@ const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Gith
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62457,7 +62403,6 @@ const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0,
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62470,7 +62415,6 @@ const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, 
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62533,7 +62477,6 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -59962,10 +59962,11 @@ const Constants_DevelopBranchName = 'develop';
 const Constants_MasterBranchName = 'master';
 const Constants_ReleaseBranchName = `${Constants_GithubWriteUser}/release-candidate`;
 
-// EXTERNAL MODULE: ./node_modules/lodash/isUndefined.js
-var lodash_isUndefined = __nccwpck_require__(2825);
-// EXTERNAL MODULE: ./node_modules/@octokit/rest/dist-node/index.js
-var dist_node = __nccwpck_require__(5375);
+// EXTERNAL MODULE: external "crypto"
+var external_crypto_ = __nccwpck_require__(6417);
+// EXTERNAL MODULE: ./node_modules/node-fetch/lib/index.js
+var lib = __nccwpck_require__(467);
+var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
@@ -59989,6 +59990,72 @@ const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { re
 // Token with write access to Slack.
 const slackToken = () => (0,core.getInput)('slack-token', { required: true });
 
+;// CONCATENATED MODULE: ./src/services/Credentials.ts
+var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+
+
+
+/**
+ * Fetches the user credentials from the remote credential service for the given email or name.
+ *
+ * @param {string} identifier The email address or Jira display name of the user to look up.
+ *
+ * @returns {Credentials} The credentials object.
+ */
+const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, void 0, function* () {
+    if (isNil(identifier)) {
+        throw new Error('Could not lookup user credentials because no identifier or display name was found');
+    }
+    const id = Buffer.from(identifier).toString('base64');
+    const signature = createHmac('sha256', credentialsApiSecret())
+        .update(identifier)
+        .digest('hex');
+    const url = `${credentialsApiPrefix()}credentials/${id}`;
+    const response = yield fetch(url, {
+        headers: { 'Shuttlerock-Signature': `sha256=${signature}` },
+    });
+    const credentials = (yield response.json());
+    if (credentials.status !== 'ok') {
+        throw new Error(`Could not get credentials for the user ${identifier}`);
+    }
+    return credentials;
+});
+/**
+ * Fetches the repository with the given name from the remote credential service.
+ *
+ * @param {string} name The name of the repository to look up.
+ *
+ * @returns {Repository} The repository object.
+ */
+const fetchRepository = (name) => __awaiter(void 0, void 0, void 0, function* () {
+    const id = Buffer.from(name).toString('base64');
+    const signature = (0,external_crypto_.createHmac)('sha256', Inputs_credentialsApiSecret())
+        .update(name)
+        .digest('hex');
+    const url = `${Inputs_credentialsApiPrefix()}repositories/${id}`;
+    const response = yield lib_default()(url, {
+        headers: { 'Shuttlerock-Signature': `sha256=${signature}` },
+    });
+    const repository = (yield response.json());
+    if (repository.status !== 'ok') {
+        throw new Error(`Could not get repository with the name ${name}`);
+    }
+    return repository;
+});
+
+// EXTERNAL MODULE: ./node_modules/lodash/isUndefined.js
+var lodash_isUndefined = __nccwpck_require__(2825);
+// EXTERNAL MODULE: ./node_modules/@octokit/rest/dist-node/index.js
+var dist_node = __nccwpck_require__(5375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
@@ -59999,7 +60066,7 @@ const Client_clientForToken = (token) => {
 };
 
 ;// CONCATENATED MODULE: ./src/services/Github/Git.ts
-var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+var Git_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -60028,7 +60095,7 @@ const Git_TreeTypes = {
  *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
-const Git_createGitBlob = (repo, content) => __awaiter(void 0, void 0, void 0, function* () {
+const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
     const response = yield client.git.createBlob({
         owner: organizationName(),
         repo,
@@ -60046,7 +60113,7 @@ const Git_createGitBlob = (repo, content) => __awaiter(void 0, void 0, void 0, f
  *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
-const Git_createGitCommit = (repo, message, tree, parent) => __awaiter(void 0, void 0, void 0, function* () {
+const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
     const response = yield client.git.createCommit({
         owner: organizationName(),
         repo,
@@ -60065,7 +60132,7 @@ const Git_createGitCommit = (repo, message, tree, parent) => __awaiter(void 0, v
  *
  * @returns {GitCreateRefResponseData} The branch data.
  */
-const Git_createGitBranch = (repo, branch, sha) => __awaiter(void 0, void 0, void 0, function* () {
+const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
     const response = yield client.git.createRef({
         owner: organizationName(),
         repo,
@@ -60083,7 +60150,7 @@ const Git_createGitBranch = (repo, branch, sha) => __awaiter(void 0, void 0, voi
  *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
-const Git_createGitTree = (repo, tree, baseTree) => __awaiter(void 0, void 0, void 0, function* () {
+const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
     const response = yield client.git.createTree({
         owner: organizationName(),
         repo,
@@ -60100,7 +60167,7 @@ const Git_createGitTree = (repo, tree, baseTree) => __awaiter(void 0, void 0, vo
  *
  * @returns {GitGetCommitResponseData} The commit data.
  */
-const getCommit = (repo, sha) => __awaiter(void 0, void 0, void 0, function* () {
+const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
     const response = yield readClient.git.getCommit({
         owner: organizationName(),
         repo,
@@ -60565,9 +60632,6 @@ const Label_addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, v
     return Label_setLabels(repo, number, toKeep);
 });
 
-// EXTERNAL MODULE: ./node_modules/node-fetch/lib/index.js
-var lib = __nccwpck_require__(467);
-var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 // EXTERNAL MODULE: ./node_modules/jira-client/lib/jira.js
 var jira = __nccwpck_require__(6411);
 var jira_default = /*#__PURE__*/__nccwpck_require__.n(jira);
@@ -60980,70 +61044,6 @@ var lodash_isEmpty = __nccwpck_require__(2384);
 var isEmpty_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isEmpty);
 // EXTERNAL MODULE: external "querystring"
 var external_querystring_ = __nccwpck_require__(1191);
-// EXTERNAL MODULE: external "crypto"
-var external_crypto_ = __nccwpck_require__(6417);
-;// CONCATENATED MODULE: ./src/services/Credentials.ts
-var Credentials_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-
-
-
-
-/**
- * Fetches the user credentials from the remote credential service for the given email or name.
- *
- * @param {string} identifier The email address or Jira display name of the user to look up.
- *
- * @returns {Credentials} The credentials object.
- */
-const Credentials_fetchCredentials = (identifier) => Credentials_awaiter(void 0, void 0, void 0, function* () {
-    if (isNil(identifier)) {
-        throw new Error('Could not lookup user credentials because no identifier or display name was found');
-    }
-    const id = Buffer.from(identifier).toString('base64');
-    const signature = createHmac('sha256', credentialsApiSecret())
-        .update(identifier)
-        .digest('hex');
-    const url = `${credentialsApiPrefix()}credentials/${id}`;
-    const response = yield fetch(url, {
-        headers: { 'Shuttlerock-Signature': `sha256=${signature}` },
-    });
-    const credentials = (yield response.json());
-    if (credentials.status !== 'ok') {
-        throw new Error(`Could not get credentials for the user ${identifier}`);
-    }
-    return credentials;
-});
-/**
- * Fetches the repository with the given name from the remote credential service.
- *
- * @param {string} name The name of the repository to look up.
- *
- * @returns {Repository} The repository object.
- */
-const fetchRepository = (name) => Credentials_awaiter(void 0, void 0, void 0, function* () {
-    const id = Buffer.from(name).toString('base64');
-    const signature = (0,external_crypto_.createHmac)('sha256', Inputs_credentialsApiSecret())
-        .update(name)
-        .digest('hex');
-    const url = `${Inputs_credentialsApiPrefix()}repositories/${id}`;
-    const response = yield lib_default()(url, {
-        headers: { 'Shuttlerock-Signature': `sha256=${signature}` },
-    });
-    const repository = (yield response.json());
-    if (repository.status !== 'ok') {
-        throw new Error(`Could not get repository with the name ${name}`);
-    }
-    return repository;
-});
-
 ;// CONCATENATED MODULE: ./src/services/Jira/Release.ts
 var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -62574,6 +62574,7 @@ var pullRequestClosed_awaiter = (undefined && undefined.__awaiter) || function (
 
 
 
+
 /**
  * Runs whenever a pull request is closed (not necessarily merged).
  *
@@ -62597,8 +62598,11 @@ const pullRequestClosed = (payload) => pullRequestClosed_awaiter(void 0, void 0,
         else {
             const releaseVersion = `v${matches[1]}`; // v2021-01-12-0426
             const releaseName = matches[2]; // Energetic Eagle
-            (0,core.info)(`Creating Jira release ${releaseVersion} (${releaseName})...`);
-            yield createRelease(repository.name, pullRequest.number, releaseVersion, releaseName);
+            const repo = yield fetchRepository(repository.name);
+            if (repo === null || repo === void 0 ? void 0 : repo.allow_jira_release) {
+                (0,core.info)(`Creating Jira release ${releaseVersion} (${releaseName})...`);
+                yield createRelease(repository.name, pullRequest.number, releaseVersion, releaseName);
+            }
             // Discard the first line (the PR heading), because it is basically a duplicate of the release name.
             (0,core.info)(`Creating Github release ${releaseVersion} (${releaseName})...`);
             const [, ...releaseNotes] = pullRequest.body.split('\n');

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -5,7 +5,7 @@
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.1.0","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.7.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
+module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.2.3","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":"^3.0.0","@slack/types":"^2.0.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0","is-electron":"^2.2.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
 
 /***/ }),
 
@@ -3764,6 +3764,7 @@ exports.v = Octokit;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ConsoleLogger = exports.LogLevel = void 0;
 /**
  * Severity levels for log entries
  */
@@ -3836,6 +3837,7 @@ class ConsoleLogger {
         return ConsoleLogger.severity[a] >= ConsoleLogger.severity[b];
     }
 }
+exports.ConsoleLogger = ConsoleLogger;
 /** Map of labels for each log level */
 ConsoleLogger.labels = (() => {
     const entries = Object.entries(LogLevel);
@@ -3851,7 +3853,6 @@ ConsoleLogger.severity = {
     [LogLevel.INFO]: 200,
     [LogLevel.DEBUG]: 100,
 };
-exports.ConsoleLogger = ConsoleLogger;
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -3927,6 +3928,7 @@ const p_queue_1 = __importDefault(__nccwpck_require__(8983)); // tslint:disable-
 const p_retry_1 = __importStar(__nccwpck_require__(2548));
 const axios_1 = __importDefault(__nccwpck_require__(6545));
 const form_data_1 = __importDefault(__nccwpck_require__(4334)); // tslint:disable-line:import-name
+const is_electron_1 = __importDefault(__nccwpck_require__(7439));
 const methods_1 = __nccwpck_require__(1571);
 const instrument_1 = __nccwpck_require__(7763);
 const errors_1 = __nccwpck_require__(9781);
@@ -3943,7 +3945,7 @@ class WebClient extends methods_1.Methods {
     /**
      * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
      */
-    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = logger_1.LogLevel.INFO, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
+    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = undefined, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
         super();
         this.token = token;
         this.slackApiUrl = slackApiUrl;
@@ -3961,13 +3963,11 @@ class WebClient extends methods_1.Methods {
             }
         }
         else {
-            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel, logger);
+            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel !== null && logLevel !== void 0 ? logLevel : logger_1.LogLevel.INFO, logger);
         }
         this.axios = axios_1.default.create({
             baseURL: slackApiUrl,
-            headers: Object.assign({
-                'User-Agent': instrument_1.getUserAgent(),
-            }, headers),
+            headers: is_electron_1.default() ? headers : Object.assign({ 'User-Agent': instrument_1.getUserAgent() }, headers),
             httpAgent: agent,
             httpsAgent: agent,
             transformRequest: [this.serializeApiCallOptions.bind(this)],
@@ -3992,6 +3992,8 @@ class WebClient extends methods_1.Methods {
     async apiCall(method, options) {
         this.logger.debug(`apiCall('${method}') start`);
         warnDeprecations(method, this.logger);
+        warnIfFallbackIsMissing(method, this.logger, options);
+        warnIfThreadTsIsNotString(method, this.logger, options);
         if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
             throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
         }
@@ -4231,7 +4233,7 @@ class WebClient extends methods_1.Methods {
         }, initialValue));
     }
     /**
-     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
+     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevant
      * HTTP headers into the object.
      * @param response - an http response
      */
@@ -4323,6 +4325,44 @@ function warnDeprecations(method, logger) {
     }
     else if (isDeprecated) {
         logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
+    }
+}
+/**
+ * Log a warning when using chat.postMessage without text argument or attachments with fallback argument
+ * @param method api method being called
+ * @param logger instance of we clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfFallbackIsMissing(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+    const isTargetMethod = targetMethods.includes(method);
+    const missingAttachmentFallbackDetected = (args) => Array.isArray(args.attachments)
+        && args.attachments.some(attachment => !attachment.fallback || attachment.fallback.trim() === 0);
+    const isEmptyText = (args) => args.text === undefined || args.text === null || args.text === '';
+    const buildWarningMessage = (missing) => `The \`${missing}\` argument is missing in the request payload for a ${method} call - ` +
+        `It's a best practice to always provide a \`${missing}\` argument when posting a message. ` +
+        `The \`${missing}\` is used in places where the content cannot be rendered such as: ` +
+        'system push notifications, assistive technology such as screen readers, etc.';
+    if (isTargetMethod && typeof options === 'object' && isEmptyText(options)) {
+        if (missingAttachmentFallbackDetected(options)) {
+            logger.warn(buildWarningMessage('fallback'));
+        }
+        else {
+            logger.warn(buildWarningMessage('text'));
+        }
+    }
+}
+/**
+ * Log a warning when thread_ts is not a string
+ * @param method api method being called
+ * @param logger instance of web clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfThreadTsIsNotString(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'files.upload'];
+    const isTargetMethod = targetMethods.includes(method);
+    if (isTargetMethod && (options === null || options === void 0 ? void 0 : options.thread_ts) !== undefined && typeof (options === null || options === void 0 ? void 0 : options.thread_ts) !== 'string') {
+        logger.warn(`The given thread_ts value in the request payload for a ${method} call is a float value. We highly recommend using a string value instead.`);
     }
 }
 //# sourceMappingURL=WebClient.js.map
@@ -4457,6 +4497,7 @@ Object.defineProperty(exports, "retryPolicies", ({ enumerable: true, get: functi
 var instrument_1 = __nccwpck_require__(7763);
 Object.defineProperty(exports, "addAppMetadata", ({ enumerable: true, get: function () { return instrument_1.addAppMetadata; } }));
 __exportStar(__nccwpck_require__(1571), exports);
+__exportStar(__nccwpck_require__(677), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -4599,11 +4640,13 @@ class Methods extends eventemitter3_1.EventEmitter {
     constructor() {
         super();
         this.admin = {
+            // TODO: admin.analytics.getFile
             apps: {
                 approve: bindApiCall(this, 'admin.apps.approve'),
                 approved: {
                     list: bindApiCall(this, 'admin.apps.approved.list'),
                 },
+                clearResolution: bindApiCall(this, 'admin.apps.clearResolution'),
                 requests: {
                     list: bindApiCall(this, 'admin.apps.requests.list'),
                 },
@@ -4611,6 +4654,7 @@ class Methods extends eventemitter3_1.EventEmitter {
                 restricted: {
                     list: bindApiCall(this, 'admin.apps.restricted.list'),
                 },
+                uninstall: bindApiCall(this, 'admin.apps.uninstall'),
             },
             barriers: {
                 create: bindApiCall(this, 'admin.barriers.create'),
@@ -4692,6 +4736,9 @@ class Methods extends eventemitter3_1.EventEmitter {
                     list: bindApiCall(this, 'admin.users.session.list'),
                     reset: bindApiCall(this, 'admin.users.session.reset'),
                     invalidate: bindApiCall(this, 'admin.users.session.invalidate'),
+                    getSettings: bindApiCall(this, 'admin.users.session.getSettings'),
+                    setSettings: bindApiCall(this, 'admin.users.session.setSettings'),
+                    clearSettings: bindApiCall(this, 'admin.users.session.clearSettings'),
                 },
                 setAdmin: bindApiCall(this, 'admin.users.setAdmin'),
                 setExpiration: bindApiCall(this, 'admin.users.setExpiration'),
@@ -4733,23 +4780,6 @@ class Methods extends eventemitter3_1.EventEmitter {
                 remove: bindApiCall(this, 'calls.participants.remove'),
             },
         };
-        this.channels = {
-            archive: bindApiCall(this, 'channels.archive'),
-            create: bindApiCall(this, 'channels.create'),
-            history: bindApiCall(this, 'channels.history'),
-            info: bindApiCall(this, 'channels.info'),
-            invite: bindApiCall(this, 'channels.invite'),
-            join: bindApiCall(this, 'channels.join'),
-            kick: bindApiCall(this, 'channels.kick'),
-            leave: bindApiCall(this, 'channels.leave'),
-            list: bindApiCall(this, 'channels.list'),
-            mark: bindApiCall(this, 'channels.mark'),
-            rename: bindApiCall(this, 'channels.rename'),
-            replies: bindApiCall(this, 'channels.replies'),
-            setPurpose: bindApiCall(this, 'channels.setPurpose'),
-            setTopic: bindApiCall(this, 'channels.setTopic'),
-            unarchive: bindApiCall(this, 'channels.unarchive'),
-        };
         this.chat = {
             delete: bindApiCall(this, 'chat.delete'),
             deleteScheduledMessage: bindApiCall(this, 'chat.deleteScheduledMessage'),
@@ -4784,12 +4814,6 @@ class Methods extends eventemitter3_1.EventEmitter {
             setTopic: bindApiCall(this, 'conversations.setTopic'),
             unarchive: bindApiCall(this, 'conversations.unarchive'),
         };
-        this.views = {
-            open: bindApiCall(this, 'views.open'),
-            publish: bindApiCall(this, 'views.publish'),
-            push: bindApiCall(this, 'views.push'),
-            update: bindApiCall(this, 'views.update'),
-        };
         this.dialog = {
             open: bindApiCall(this, 'dialog.open'),
         };
@@ -4822,42 +4846,8 @@ class Methods extends eventemitter3_1.EventEmitter {
                 share: bindApiCall(this, 'files.remote.share'),
             },
         };
-        this.groups = {
-            archive: bindApiCall(this, 'groups.archive'),
-            create: bindApiCall(this, 'groups.create'),
-            createChild: bindApiCall(this, 'groups.createChild'),
-            history: bindApiCall(this, 'groups.history'),
-            info: bindApiCall(this, 'groups.info'),
-            invite: bindApiCall(this, 'groups.invite'),
-            kick: bindApiCall(this, 'groups.kick'),
-            leave: bindApiCall(this, 'groups.leave'),
-            list: bindApiCall(this, 'groups.list'),
-            mark: bindApiCall(this, 'groups.mark'),
-            open: bindApiCall(this, 'groups.open'),
-            rename: bindApiCall(this, 'groups.rename'),
-            replies: bindApiCall(this, 'groups.replies'),
-            setPurpose: bindApiCall(this, 'groups.setPurpose'),
-            setTopic: bindApiCall(this, 'groups.setTopic'),
-            unarchive: bindApiCall(this, 'groups.unarchive'),
-        };
-        this.im = {
-            close: bindApiCall(this, 'im.close'),
-            history: bindApiCall(this, 'im.history'),
-            list: bindApiCall(this, 'im.list'),
-            mark: bindApiCall(this, 'im.mark'),
-            open: bindApiCall(this, 'im.open'),
-            replies: bindApiCall(this, 'im.replies'),
-        };
         this.migration = {
             exchange: bindApiCall(this, 'migration.exchange'),
-        };
-        this.mpim = {
-            close: bindApiCall(this, 'mpim.close'),
-            history: bindApiCall(this, 'mpim.history'),
-            list: bindApiCall(this, 'mpim.list'),
-            mark: bindApiCall(this, 'mpim.mark'),
-            open: bindApiCall(this, 'mpim.open'),
-            replies: bindApiCall(this, 'mpim.replies'),
         };
         this.oauth = {
             access: bindApiCall(this, 'oauth.access'),
@@ -4932,10 +4922,70 @@ class Methods extends eventemitter3_1.EventEmitter {
                 set: bindApiCall(this, 'users.profile.set'),
             },
         };
+        this.views = {
+            open: bindApiCall(this, 'views.open'),
+            publish: bindApiCall(this, 'views.publish'),
+            push: bindApiCall(this, 'views.push'),
+            update: bindApiCall(this, 'views.update'),
+        };
         this.workflows = {
             stepCompleted: bindApiCall(this, 'workflows.stepCompleted'),
             stepFailed: bindApiCall(this, 'workflows.stepFailed'),
             updateStep: bindApiCall(this, 'workflows.updateStep'),
+        };
+        // ---------------------------------
+        // Deprecated methods
+        // ---------------------------------
+        this.channels = {
+            archive: bindApiCall(this, 'channels.archive'),
+            create: bindApiCall(this, 'channels.create'),
+            history: bindApiCall(this, 'channels.history'),
+            info: bindApiCall(this, 'channels.info'),
+            invite: bindApiCall(this, 'channels.invite'),
+            join: bindApiCall(this, 'channels.join'),
+            kick: bindApiCall(this, 'channels.kick'),
+            leave: bindApiCall(this, 'channels.leave'),
+            list: bindApiCall(this, 'channels.list'),
+            mark: bindApiCall(this, 'channels.mark'),
+            rename: bindApiCall(this, 'channels.rename'),
+            replies: bindApiCall(this, 'channels.replies'),
+            setPurpose: bindApiCall(this, 'channels.setPurpose'),
+            setTopic: bindApiCall(this, 'channels.setTopic'),
+            unarchive: bindApiCall(this, 'channels.unarchive'),
+        };
+        this.groups = {
+            archive: bindApiCall(this, 'groups.archive'),
+            create: bindApiCall(this, 'groups.create'),
+            createChild: bindApiCall(this, 'groups.createChild'),
+            history: bindApiCall(this, 'groups.history'),
+            info: bindApiCall(this, 'groups.info'),
+            invite: bindApiCall(this, 'groups.invite'),
+            kick: bindApiCall(this, 'groups.kick'),
+            leave: bindApiCall(this, 'groups.leave'),
+            list: bindApiCall(this, 'groups.list'),
+            mark: bindApiCall(this, 'groups.mark'),
+            open: bindApiCall(this, 'groups.open'),
+            rename: bindApiCall(this, 'groups.rename'),
+            replies: bindApiCall(this, 'groups.replies'),
+            setPurpose: bindApiCall(this, 'groups.setPurpose'),
+            setTopic: bindApiCall(this, 'groups.setTopic'),
+            unarchive: bindApiCall(this, 'groups.unarchive'),
+        };
+        this.im = {
+            close: bindApiCall(this, 'im.close'),
+            history: bindApiCall(this, 'im.history'),
+            list: bindApiCall(this, 'im.list'),
+            mark: bindApiCall(this, 'im.mark'),
+            open: bindApiCall(this, 'im.open'),
+            replies: bindApiCall(this, 'im.replies'),
+        };
+        this.mpim = {
+            close: bindApiCall(this, 'mpim.close'),
+            history: bindApiCall(this, 'mpim.history'),
+            list: bindApiCall(this, 'mpim.list'),
+            mark: bindApiCall(this, 'mpim.mark'),
+            open: bindApiCall(this, 'mpim.open'),
+            replies: bindApiCall(this, 'mpim.replies'),
         };
         // Check that the class being created extends from `WebClient` rather than this class
         if (new.target !== WebClient_1.WebClient && !(new.target.prototype instanceof WebClient_1.WebClient)) {
@@ -4983,6 +5033,16 @@ exports.cursorPaginationEnabledMethods.add('users.conversations');
 exports.cursorPaginationEnabledMethods.add('users.list');
 __exportStar(__nccwpck_require__(4380), exports);
 //# sourceMappingURL=methods.js.map
+
+/***/ }),
+
+/***/ 677:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
@@ -26756,6 +26816,34 @@ module.exports = {
     return (h1.equals(h2));
   }
 };
+
+
+/***/ }),
+
+/***/ 7439:
+/***/ ((module) => {
+
+// https://github.com/electron/electron/issues/2288
+function isElectron() {
+    // Renderer process
+    if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer') {
+        return true;
+    }
+
+    // Main process
+    if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron) {
+        return true;
+    }
+
+    // Detect the user agent when the `nodeIntegration` option is set to true
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = isElectron;
 
 
 /***/ }),

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -60025,7 +60025,6 @@ const Git_TreeTypes = {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60043,7 +60042,6 @@ const Git_createGitBlob = (repo, content) => __awaiter(void 0, void 0, void 0, f
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60062,7 +60060,6 @@ const Git_createGitCommit = (repo, message, tree, parent) => __awaiter(void 0, v
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60080,7 +60077,6 @@ const Git_createGitBranch = (repo, branch, sha) => __awaiter(void 0, void 0, voi
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60097,7 +60093,6 @@ const Git_createGitTree = (repo, tree, baseTree) => __awaiter(void 0, void 0, vo
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60127,7 +60122,6 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60143,7 +60137,6 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60165,7 +60158,6 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60179,7 +60171,6 @@ const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, vo
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 const Repository_repositoryUrl = (repo) => `https://github.com/${organizationName()}/${repo}`;
@@ -60204,7 +60195,6 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60229,7 +60219,6 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60258,7 +60247,6 @@ const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 const Branch_createBranch = (repo, baseBranchName, newBranchName, filePath, fileContent, commitMessage) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60303,7 +60291,6 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60324,7 +60311,6 @@ const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaite
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 const PullRequest_createPullRequest = (repo, base, head, title, body, token) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60343,7 +60329,6 @@ const PullRequest_createPullRequest = (repo, base, head, title, body, token) => 
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 const PullRequest_getIssueKey = (pr) => {
@@ -60367,7 +60352,6 @@ const PullRequest_getIssueKey = (pr) => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60393,7 +60377,6 @@ const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0,
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60415,7 +60398,6 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 const PullRequest_extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\d+)\].*$/, '$1'), 10) ||
@@ -60426,7 +60408,6 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60442,7 +60423,6 @@ const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organizationName()}/${repo}/pull/${number}`;
@@ -60453,7 +60433,6 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60472,7 +60451,6 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60511,7 +60489,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60529,7 +60506,6 @@ const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, 
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 const Label_addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60622,7 +60598,6 @@ const JiraFieldStoryPointEstimate = 'Story point estimate';
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (issue, fieldName) => {
@@ -60634,7 +60609,6 @@ const idForFieldName = (issue, fieldName) => {
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue) => {
@@ -60662,7 +60636,6 @@ const populateExplicitFields = (issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60686,7 +60659,6 @@ const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* 
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60705,7 +60677,6 @@ const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 const getEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60733,7 +60704,6 @@ const recursiveGetEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60753,7 +60723,6 @@ const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60767,7 +60736,6 @@ const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
@@ -60775,10 +60743,8 @@ const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 const moveIssueToBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60861,7 +60827,6 @@ var Project_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60877,7 +60842,6 @@ const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60897,7 +60861,6 @@ const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, functi
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60921,7 +60884,6 @@ const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60945,7 +60907,6 @@ const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, f
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60968,7 +60929,6 @@ const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61000,7 +60960,6 @@ var Credentials_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 const Credentials_fetchCredentials = (identifier) => Credentials_awaiter(void 0, void 0, void 0, function* () {
@@ -61025,7 +60984,6 @@ const Credentials_fetchCredentials = (identifier) => Credentials_awaiter(void 0,
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 const Credentials_fetchRepository = (name) => Credentials_awaiter(void 0, void 0, void 0, function* () {
@@ -61070,7 +61028,6 @@ var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 const createJiraRelease = (projectKey, name, description) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61100,7 +61057,6 @@ const createJiraRelease = (projectKey, name, description) => Release_awaiter(voi
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 const findJiraRelease = (projectKey, name) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61207,7 +61163,6 @@ var lodash_startCase = __nccwpck_require__(9274);
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 const String_parameterize = (str) => snakeCase(str.trim().toLowerCase())
@@ -62015,7 +61970,6 @@ mustache_mustache.Writer = Writer;
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 const Template_render = (template, vars) => mustache.render(template, vars);
@@ -62100,7 +62054,6 @@ var Epic_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, void 0, void 0, function* () {
@@ -62229,7 +62182,6 @@ const positiveEmoji = () => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 const scrubMessage = (message) => {
@@ -62247,7 +62199,6 @@ const scrubMessage = (message) => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62266,7 +62217,6 @@ const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, fu
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const Message_sendUserMessage = (userId, message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62326,7 +62276,6 @@ var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thi
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62387,7 +62336,6 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62414,7 +62362,6 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62444,7 +62391,6 @@ const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Gith
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62457,7 +62403,6 @@ const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0,
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62470,7 +62415,6 @@ const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, 
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62533,7 +62477,6 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -5,7 +5,7 @@
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.1.0","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.7.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
+module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.2.3","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":"^3.0.0","@slack/types":"^2.0.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0","is-electron":"^2.2.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
 
 /***/ }),
 
@@ -3764,6 +3764,7 @@ exports.v = Octokit;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ConsoleLogger = exports.LogLevel = void 0;
 /**
  * Severity levels for log entries
  */
@@ -3836,6 +3837,7 @@ class ConsoleLogger {
         return ConsoleLogger.severity[a] >= ConsoleLogger.severity[b];
     }
 }
+exports.ConsoleLogger = ConsoleLogger;
 /** Map of labels for each log level */
 ConsoleLogger.labels = (() => {
     const entries = Object.entries(LogLevel);
@@ -3851,7 +3853,6 @@ ConsoleLogger.severity = {
     [LogLevel.INFO]: 200,
     [LogLevel.DEBUG]: 100,
 };
-exports.ConsoleLogger = ConsoleLogger;
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -3927,6 +3928,7 @@ const p_queue_1 = __importDefault(__nccwpck_require__(8983)); // tslint:disable-
 const p_retry_1 = __importStar(__nccwpck_require__(2548));
 const axios_1 = __importDefault(__nccwpck_require__(6545));
 const form_data_1 = __importDefault(__nccwpck_require__(4334)); // tslint:disable-line:import-name
+const is_electron_1 = __importDefault(__nccwpck_require__(7439));
 const methods_1 = __nccwpck_require__(1571);
 const instrument_1 = __nccwpck_require__(7763);
 const errors_1 = __nccwpck_require__(9781);
@@ -3943,7 +3945,7 @@ class WebClient extends methods_1.Methods {
     /**
      * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
      */
-    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = logger_1.LogLevel.INFO, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
+    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = undefined, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
         super();
         this.token = token;
         this.slackApiUrl = slackApiUrl;
@@ -3961,13 +3963,11 @@ class WebClient extends methods_1.Methods {
             }
         }
         else {
-            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel, logger);
+            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel !== null && logLevel !== void 0 ? logLevel : logger_1.LogLevel.INFO, logger);
         }
         this.axios = axios_1.default.create({
             baseURL: slackApiUrl,
-            headers: Object.assign({
-                'User-Agent': instrument_1.getUserAgent(),
-            }, headers),
+            headers: is_electron_1.default() ? headers : Object.assign({ 'User-Agent': instrument_1.getUserAgent() }, headers),
             httpAgent: agent,
             httpsAgent: agent,
             transformRequest: [this.serializeApiCallOptions.bind(this)],
@@ -3992,6 +3992,8 @@ class WebClient extends methods_1.Methods {
     async apiCall(method, options) {
         this.logger.debug(`apiCall('${method}') start`);
         warnDeprecations(method, this.logger);
+        warnIfFallbackIsMissing(method, this.logger, options);
+        warnIfThreadTsIsNotString(method, this.logger, options);
         if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
             throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
         }
@@ -4231,7 +4233,7 @@ class WebClient extends methods_1.Methods {
         }, initialValue));
     }
     /**
-     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
+     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevant
      * HTTP headers into the object.
      * @param response - an http response
      */
@@ -4323,6 +4325,44 @@ function warnDeprecations(method, logger) {
     }
     else if (isDeprecated) {
         logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
+    }
+}
+/**
+ * Log a warning when using chat.postMessage without text argument or attachments with fallback argument
+ * @param method api method being called
+ * @param logger instance of we clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfFallbackIsMissing(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+    const isTargetMethod = targetMethods.includes(method);
+    const missingAttachmentFallbackDetected = (args) => Array.isArray(args.attachments)
+        && args.attachments.some(attachment => !attachment.fallback || attachment.fallback.trim() === 0);
+    const isEmptyText = (args) => args.text === undefined || args.text === null || args.text === '';
+    const buildWarningMessage = (missing) => `The \`${missing}\` argument is missing in the request payload for a ${method} call - ` +
+        `It's a best practice to always provide a \`${missing}\` argument when posting a message. ` +
+        `The \`${missing}\` is used in places where the content cannot be rendered such as: ` +
+        'system push notifications, assistive technology such as screen readers, etc.';
+    if (isTargetMethod && typeof options === 'object' && isEmptyText(options)) {
+        if (missingAttachmentFallbackDetected(options)) {
+            logger.warn(buildWarningMessage('fallback'));
+        }
+        else {
+            logger.warn(buildWarningMessage('text'));
+        }
+    }
+}
+/**
+ * Log a warning when thread_ts is not a string
+ * @param method api method being called
+ * @param logger instance of web clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfThreadTsIsNotString(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'files.upload'];
+    const isTargetMethod = targetMethods.includes(method);
+    if (isTargetMethod && (options === null || options === void 0 ? void 0 : options.thread_ts) !== undefined && typeof (options === null || options === void 0 ? void 0 : options.thread_ts) !== 'string') {
+        logger.warn(`The given thread_ts value in the request payload for a ${method} call is a float value. We highly recommend using a string value instead.`);
     }
 }
 //# sourceMappingURL=WebClient.js.map
@@ -4457,6 +4497,7 @@ Object.defineProperty(exports, "retryPolicies", ({ enumerable: true, get: functi
 var instrument_1 = __nccwpck_require__(7763);
 Object.defineProperty(exports, "addAppMetadata", ({ enumerable: true, get: function () { return instrument_1.addAppMetadata; } }));
 __exportStar(__nccwpck_require__(1571), exports);
+__exportStar(__nccwpck_require__(677), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -4599,11 +4640,13 @@ class Methods extends eventemitter3_1.EventEmitter {
     constructor() {
         super();
         this.admin = {
+            // TODO: admin.analytics.getFile
             apps: {
                 approve: bindApiCall(this, 'admin.apps.approve'),
                 approved: {
                     list: bindApiCall(this, 'admin.apps.approved.list'),
                 },
+                clearResolution: bindApiCall(this, 'admin.apps.clearResolution'),
                 requests: {
                     list: bindApiCall(this, 'admin.apps.requests.list'),
                 },
@@ -4611,6 +4654,7 @@ class Methods extends eventemitter3_1.EventEmitter {
                 restricted: {
                     list: bindApiCall(this, 'admin.apps.restricted.list'),
                 },
+                uninstall: bindApiCall(this, 'admin.apps.uninstall'),
             },
             barriers: {
                 create: bindApiCall(this, 'admin.barriers.create'),
@@ -4692,6 +4736,9 @@ class Methods extends eventemitter3_1.EventEmitter {
                     list: bindApiCall(this, 'admin.users.session.list'),
                     reset: bindApiCall(this, 'admin.users.session.reset'),
                     invalidate: bindApiCall(this, 'admin.users.session.invalidate'),
+                    getSettings: bindApiCall(this, 'admin.users.session.getSettings'),
+                    setSettings: bindApiCall(this, 'admin.users.session.setSettings'),
+                    clearSettings: bindApiCall(this, 'admin.users.session.clearSettings'),
                 },
                 setAdmin: bindApiCall(this, 'admin.users.setAdmin'),
                 setExpiration: bindApiCall(this, 'admin.users.setExpiration'),
@@ -4733,23 +4780,6 @@ class Methods extends eventemitter3_1.EventEmitter {
                 remove: bindApiCall(this, 'calls.participants.remove'),
             },
         };
-        this.channels = {
-            archive: bindApiCall(this, 'channels.archive'),
-            create: bindApiCall(this, 'channels.create'),
-            history: bindApiCall(this, 'channels.history'),
-            info: bindApiCall(this, 'channels.info'),
-            invite: bindApiCall(this, 'channels.invite'),
-            join: bindApiCall(this, 'channels.join'),
-            kick: bindApiCall(this, 'channels.kick'),
-            leave: bindApiCall(this, 'channels.leave'),
-            list: bindApiCall(this, 'channels.list'),
-            mark: bindApiCall(this, 'channels.mark'),
-            rename: bindApiCall(this, 'channels.rename'),
-            replies: bindApiCall(this, 'channels.replies'),
-            setPurpose: bindApiCall(this, 'channels.setPurpose'),
-            setTopic: bindApiCall(this, 'channels.setTopic'),
-            unarchive: bindApiCall(this, 'channels.unarchive'),
-        };
         this.chat = {
             delete: bindApiCall(this, 'chat.delete'),
             deleteScheduledMessage: bindApiCall(this, 'chat.deleteScheduledMessage'),
@@ -4784,12 +4814,6 @@ class Methods extends eventemitter3_1.EventEmitter {
             setTopic: bindApiCall(this, 'conversations.setTopic'),
             unarchive: bindApiCall(this, 'conversations.unarchive'),
         };
-        this.views = {
-            open: bindApiCall(this, 'views.open'),
-            publish: bindApiCall(this, 'views.publish'),
-            push: bindApiCall(this, 'views.push'),
-            update: bindApiCall(this, 'views.update'),
-        };
         this.dialog = {
             open: bindApiCall(this, 'dialog.open'),
         };
@@ -4822,42 +4846,8 @@ class Methods extends eventemitter3_1.EventEmitter {
                 share: bindApiCall(this, 'files.remote.share'),
             },
         };
-        this.groups = {
-            archive: bindApiCall(this, 'groups.archive'),
-            create: bindApiCall(this, 'groups.create'),
-            createChild: bindApiCall(this, 'groups.createChild'),
-            history: bindApiCall(this, 'groups.history'),
-            info: bindApiCall(this, 'groups.info'),
-            invite: bindApiCall(this, 'groups.invite'),
-            kick: bindApiCall(this, 'groups.kick'),
-            leave: bindApiCall(this, 'groups.leave'),
-            list: bindApiCall(this, 'groups.list'),
-            mark: bindApiCall(this, 'groups.mark'),
-            open: bindApiCall(this, 'groups.open'),
-            rename: bindApiCall(this, 'groups.rename'),
-            replies: bindApiCall(this, 'groups.replies'),
-            setPurpose: bindApiCall(this, 'groups.setPurpose'),
-            setTopic: bindApiCall(this, 'groups.setTopic'),
-            unarchive: bindApiCall(this, 'groups.unarchive'),
-        };
-        this.im = {
-            close: bindApiCall(this, 'im.close'),
-            history: bindApiCall(this, 'im.history'),
-            list: bindApiCall(this, 'im.list'),
-            mark: bindApiCall(this, 'im.mark'),
-            open: bindApiCall(this, 'im.open'),
-            replies: bindApiCall(this, 'im.replies'),
-        };
         this.migration = {
             exchange: bindApiCall(this, 'migration.exchange'),
-        };
-        this.mpim = {
-            close: bindApiCall(this, 'mpim.close'),
-            history: bindApiCall(this, 'mpim.history'),
-            list: bindApiCall(this, 'mpim.list'),
-            mark: bindApiCall(this, 'mpim.mark'),
-            open: bindApiCall(this, 'mpim.open'),
-            replies: bindApiCall(this, 'mpim.replies'),
         };
         this.oauth = {
             access: bindApiCall(this, 'oauth.access'),
@@ -4932,10 +4922,70 @@ class Methods extends eventemitter3_1.EventEmitter {
                 set: bindApiCall(this, 'users.profile.set'),
             },
         };
+        this.views = {
+            open: bindApiCall(this, 'views.open'),
+            publish: bindApiCall(this, 'views.publish'),
+            push: bindApiCall(this, 'views.push'),
+            update: bindApiCall(this, 'views.update'),
+        };
         this.workflows = {
             stepCompleted: bindApiCall(this, 'workflows.stepCompleted'),
             stepFailed: bindApiCall(this, 'workflows.stepFailed'),
             updateStep: bindApiCall(this, 'workflows.updateStep'),
+        };
+        // ---------------------------------
+        // Deprecated methods
+        // ---------------------------------
+        this.channels = {
+            archive: bindApiCall(this, 'channels.archive'),
+            create: bindApiCall(this, 'channels.create'),
+            history: bindApiCall(this, 'channels.history'),
+            info: bindApiCall(this, 'channels.info'),
+            invite: bindApiCall(this, 'channels.invite'),
+            join: bindApiCall(this, 'channels.join'),
+            kick: bindApiCall(this, 'channels.kick'),
+            leave: bindApiCall(this, 'channels.leave'),
+            list: bindApiCall(this, 'channels.list'),
+            mark: bindApiCall(this, 'channels.mark'),
+            rename: bindApiCall(this, 'channels.rename'),
+            replies: bindApiCall(this, 'channels.replies'),
+            setPurpose: bindApiCall(this, 'channels.setPurpose'),
+            setTopic: bindApiCall(this, 'channels.setTopic'),
+            unarchive: bindApiCall(this, 'channels.unarchive'),
+        };
+        this.groups = {
+            archive: bindApiCall(this, 'groups.archive'),
+            create: bindApiCall(this, 'groups.create'),
+            createChild: bindApiCall(this, 'groups.createChild'),
+            history: bindApiCall(this, 'groups.history'),
+            info: bindApiCall(this, 'groups.info'),
+            invite: bindApiCall(this, 'groups.invite'),
+            kick: bindApiCall(this, 'groups.kick'),
+            leave: bindApiCall(this, 'groups.leave'),
+            list: bindApiCall(this, 'groups.list'),
+            mark: bindApiCall(this, 'groups.mark'),
+            open: bindApiCall(this, 'groups.open'),
+            rename: bindApiCall(this, 'groups.rename'),
+            replies: bindApiCall(this, 'groups.replies'),
+            setPurpose: bindApiCall(this, 'groups.setPurpose'),
+            setTopic: bindApiCall(this, 'groups.setTopic'),
+            unarchive: bindApiCall(this, 'groups.unarchive'),
+        };
+        this.im = {
+            close: bindApiCall(this, 'im.close'),
+            history: bindApiCall(this, 'im.history'),
+            list: bindApiCall(this, 'im.list'),
+            mark: bindApiCall(this, 'im.mark'),
+            open: bindApiCall(this, 'im.open'),
+            replies: bindApiCall(this, 'im.replies'),
+        };
+        this.mpim = {
+            close: bindApiCall(this, 'mpim.close'),
+            history: bindApiCall(this, 'mpim.history'),
+            list: bindApiCall(this, 'mpim.list'),
+            mark: bindApiCall(this, 'mpim.mark'),
+            open: bindApiCall(this, 'mpim.open'),
+            replies: bindApiCall(this, 'mpim.replies'),
         };
         // Check that the class being created extends from `WebClient` rather than this class
         if (new.target !== WebClient_1.WebClient && !(new.target.prototype instanceof WebClient_1.WebClient)) {
@@ -4983,6 +5033,16 @@ exports.cursorPaginationEnabledMethods.add('users.conversations');
 exports.cursorPaginationEnabledMethods.add('users.list');
 __exportStar(__nccwpck_require__(4380), exports);
 //# sourceMappingURL=methods.js.map
+
+/***/ }),
+
+/***/ 677:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
@@ -26756,6 +26816,34 @@ module.exports = {
     return (h1.equals(h2));
   }
 };
+
+
+/***/ }),
+
+/***/ 7439:
+/***/ ((module) => {
+
+// https://github.com/electron/electron/issues/2288
+function isElectron() {
+    // Renderer process
+    if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer') {
+        return true;
+    }
+
+    // Main process
+    if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron) {
+        return true;
+    }
+
+    // Detect the user agent when the `nodeIntegration` option is set to true
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = isElectron;
 
 
 /***/ }),

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -60024,7 +60024,6 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60049,7 +60048,6 @@ const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, v
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 const Credentials_fetchRepository = (name) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60108,7 +60106,6 @@ const Git_TreeTypes = {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60126,7 +60123,6 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60145,7 +60141,6 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60163,7 +60158,6 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60180,7 +60174,6 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60210,7 +60203,6 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60226,7 +60218,6 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60248,7 +60239,6 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60262,7 +60252,6 @@ const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, vo
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 const Repository_repositoryUrl = (repo) => `https://github.com/${organizationName()}/${repo}`;
@@ -60287,7 +60276,6 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60312,7 +60300,6 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60341,7 +60328,6 @@ const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 const Branch_createBranch = (repo, baseBranchName, newBranchName, filePath, fileContent, commitMessage) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60386,7 +60372,6 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60407,7 +60392,6 @@ const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaite
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 const PullRequest_createPullRequest = (repo, base, head, title, body, token) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60426,7 +60410,6 @@ const PullRequest_createPullRequest = (repo, base, head, title, body, token) => 
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 const PullRequest_getIssueKey = (pr) => {
@@ -60450,7 +60433,6 @@ const PullRequest_getIssueKey = (pr) => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60476,7 +60458,6 @@ const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0,
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60498,7 +60479,6 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 const PullRequest_extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\d+)\].*$/, '$1'), 10) ||
@@ -60509,7 +60489,6 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60525,7 +60504,6 @@ const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Inputs_organizationName()}/${repo}/pull/${number}`;
@@ -60536,7 +60514,6 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Input
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60555,7 +60532,6 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60594,7 +60570,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60612,7 +60587,6 @@ const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, 
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 const Label_addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60702,7 +60676,6 @@ const JiraFieldStoryPointEstimate = 'Story point estimate';
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (issue, fieldName) => {
@@ -60714,7 +60687,6 @@ const idForFieldName = (issue, fieldName) => {
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue) => {
@@ -60742,7 +60714,6 @@ const populateExplicitFields = (issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60766,7 +60737,6 @@ const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* 
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60785,7 +60755,6 @@ const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 const getEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60813,7 +60782,6 @@ const recursiveGetEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60833,7 +60801,6 @@ const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60847,7 +60814,6 @@ const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
@@ -60855,10 +60821,8 @@ const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 const moveIssueToBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60941,7 +60905,6 @@ var Project_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60957,7 +60920,6 @@ const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60977,7 +60939,6 @@ const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, functi
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61001,7 +60962,6 @@ const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61025,7 +60985,6 @@ const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, f
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61048,7 +61007,6 @@ const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61086,7 +61044,6 @@ var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 const createJiraRelease = (projectKey, name, description) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61116,7 +61073,6 @@ const createJiraRelease = (projectKey, name, description) => Release_awaiter(voi
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 const findJiraRelease = (projectKey, name) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61223,7 +61179,6 @@ var lodash_startCase = __nccwpck_require__(9274);
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 const String_parameterize = (str) => snakeCase(str.trim().toLowerCase())
@@ -62031,7 +61986,6 @@ mustache_mustache.Writer = Writer;
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 const Template_render = (template, vars) => mustache.render(template, vars);
@@ -62116,7 +62070,6 @@ var Epic_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, void 0, void 0, function* () {
@@ -62247,7 +62200,6 @@ const positiveEmoji = () => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 const scrubMessage = (message) => {
@@ -62265,7 +62217,6 @@ const scrubMessage = (message) => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62284,7 +62235,6 @@ const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, fu
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const Message_sendUserMessage = (userId, message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62344,7 +62294,6 @@ var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thi
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62405,7 +62354,6 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62432,7 +62380,6 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62462,7 +62409,6 @@ const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Gith
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62475,7 +62421,6 @@ const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0,
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62488,7 +62433,6 @@ const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, 
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62551,7 +62495,6 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -5,7 +5,7 @@
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.1.0","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.7.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
+module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.2.3","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":"^3.0.0","@slack/types":"^2.0.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0","is-electron":"^2.2.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
 
 /***/ }),
 
@@ -3764,6 +3764,7 @@ exports.v = Octokit;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ConsoleLogger = exports.LogLevel = void 0;
 /**
  * Severity levels for log entries
  */
@@ -3836,6 +3837,7 @@ class ConsoleLogger {
         return ConsoleLogger.severity[a] >= ConsoleLogger.severity[b];
     }
 }
+exports.ConsoleLogger = ConsoleLogger;
 /** Map of labels for each log level */
 ConsoleLogger.labels = (() => {
     const entries = Object.entries(LogLevel);
@@ -3851,7 +3853,6 @@ ConsoleLogger.severity = {
     [LogLevel.INFO]: 200,
     [LogLevel.DEBUG]: 100,
 };
-exports.ConsoleLogger = ConsoleLogger;
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -3927,6 +3928,7 @@ const p_queue_1 = __importDefault(__nccwpck_require__(8983)); // tslint:disable-
 const p_retry_1 = __importStar(__nccwpck_require__(2548));
 const axios_1 = __importDefault(__nccwpck_require__(6545));
 const form_data_1 = __importDefault(__nccwpck_require__(4334)); // tslint:disable-line:import-name
+const is_electron_1 = __importDefault(__nccwpck_require__(7439));
 const methods_1 = __nccwpck_require__(1571);
 const instrument_1 = __nccwpck_require__(7763);
 const errors_1 = __nccwpck_require__(9781);
@@ -3943,7 +3945,7 @@ class WebClient extends methods_1.Methods {
     /**
      * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
      */
-    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = logger_1.LogLevel.INFO, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
+    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = undefined, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
         super();
         this.token = token;
         this.slackApiUrl = slackApiUrl;
@@ -3961,13 +3963,11 @@ class WebClient extends methods_1.Methods {
             }
         }
         else {
-            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel, logger);
+            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel !== null && logLevel !== void 0 ? logLevel : logger_1.LogLevel.INFO, logger);
         }
         this.axios = axios_1.default.create({
             baseURL: slackApiUrl,
-            headers: Object.assign({
-                'User-Agent': instrument_1.getUserAgent(),
-            }, headers),
+            headers: is_electron_1.default() ? headers : Object.assign({ 'User-Agent': instrument_1.getUserAgent() }, headers),
             httpAgent: agent,
             httpsAgent: agent,
             transformRequest: [this.serializeApiCallOptions.bind(this)],
@@ -3992,6 +3992,8 @@ class WebClient extends methods_1.Methods {
     async apiCall(method, options) {
         this.logger.debug(`apiCall('${method}') start`);
         warnDeprecations(method, this.logger);
+        warnIfFallbackIsMissing(method, this.logger, options);
+        warnIfThreadTsIsNotString(method, this.logger, options);
         if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
             throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
         }
@@ -4231,7 +4233,7 @@ class WebClient extends methods_1.Methods {
         }, initialValue));
     }
     /**
-     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
+     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevant
      * HTTP headers into the object.
      * @param response - an http response
      */
@@ -4323,6 +4325,44 @@ function warnDeprecations(method, logger) {
     }
     else if (isDeprecated) {
         logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
+    }
+}
+/**
+ * Log a warning when using chat.postMessage without text argument or attachments with fallback argument
+ * @param method api method being called
+ * @param logger instance of we clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfFallbackIsMissing(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+    const isTargetMethod = targetMethods.includes(method);
+    const missingAttachmentFallbackDetected = (args) => Array.isArray(args.attachments)
+        && args.attachments.some(attachment => !attachment.fallback || attachment.fallback.trim() === 0);
+    const isEmptyText = (args) => args.text === undefined || args.text === null || args.text === '';
+    const buildWarningMessage = (missing) => `The \`${missing}\` argument is missing in the request payload for a ${method} call - ` +
+        `It's a best practice to always provide a \`${missing}\` argument when posting a message. ` +
+        `The \`${missing}\` is used in places where the content cannot be rendered such as: ` +
+        'system push notifications, assistive technology such as screen readers, etc.';
+    if (isTargetMethod && typeof options === 'object' && isEmptyText(options)) {
+        if (missingAttachmentFallbackDetected(options)) {
+            logger.warn(buildWarningMessage('fallback'));
+        }
+        else {
+            logger.warn(buildWarningMessage('text'));
+        }
+    }
+}
+/**
+ * Log a warning when thread_ts is not a string
+ * @param method api method being called
+ * @param logger instance of web clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfThreadTsIsNotString(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'files.upload'];
+    const isTargetMethod = targetMethods.includes(method);
+    if (isTargetMethod && (options === null || options === void 0 ? void 0 : options.thread_ts) !== undefined && typeof (options === null || options === void 0 ? void 0 : options.thread_ts) !== 'string') {
+        logger.warn(`The given thread_ts value in the request payload for a ${method} call is a float value. We highly recommend using a string value instead.`);
     }
 }
 //# sourceMappingURL=WebClient.js.map
@@ -4457,6 +4497,7 @@ Object.defineProperty(exports, "retryPolicies", ({ enumerable: true, get: functi
 var instrument_1 = __nccwpck_require__(7763);
 Object.defineProperty(exports, "addAppMetadata", ({ enumerable: true, get: function () { return instrument_1.addAppMetadata; } }));
 __exportStar(__nccwpck_require__(1571), exports);
+__exportStar(__nccwpck_require__(677), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -4599,11 +4640,13 @@ class Methods extends eventemitter3_1.EventEmitter {
     constructor() {
         super();
         this.admin = {
+            // TODO: admin.analytics.getFile
             apps: {
                 approve: bindApiCall(this, 'admin.apps.approve'),
                 approved: {
                     list: bindApiCall(this, 'admin.apps.approved.list'),
                 },
+                clearResolution: bindApiCall(this, 'admin.apps.clearResolution'),
                 requests: {
                     list: bindApiCall(this, 'admin.apps.requests.list'),
                 },
@@ -4611,6 +4654,7 @@ class Methods extends eventemitter3_1.EventEmitter {
                 restricted: {
                     list: bindApiCall(this, 'admin.apps.restricted.list'),
                 },
+                uninstall: bindApiCall(this, 'admin.apps.uninstall'),
             },
             barriers: {
                 create: bindApiCall(this, 'admin.barriers.create'),
@@ -4692,6 +4736,9 @@ class Methods extends eventemitter3_1.EventEmitter {
                     list: bindApiCall(this, 'admin.users.session.list'),
                     reset: bindApiCall(this, 'admin.users.session.reset'),
                     invalidate: bindApiCall(this, 'admin.users.session.invalidate'),
+                    getSettings: bindApiCall(this, 'admin.users.session.getSettings'),
+                    setSettings: bindApiCall(this, 'admin.users.session.setSettings'),
+                    clearSettings: bindApiCall(this, 'admin.users.session.clearSettings'),
                 },
                 setAdmin: bindApiCall(this, 'admin.users.setAdmin'),
                 setExpiration: bindApiCall(this, 'admin.users.setExpiration'),
@@ -4733,23 +4780,6 @@ class Methods extends eventemitter3_1.EventEmitter {
                 remove: bindApiCall(this, 'calls.participants.remove'),
             },
         };
-        this.channels = {
-            archive: bindApiCall(this, 'channels.archive'),
-            create: bindApiCall(this, 'channels.create'),
-            history: bindApiCall(this, 'channels.history'),
-            info: bindApiCall(this, 'channels.info'),
-            invite: bindApiCall(this, 'channels.invite'),
-            join: bindApiCall(this, 'channels.join'),
-            kick: bindApiCall(this, 'channels.kick'),
-            leave: bindApiCall(this, 'channels.leave'),
-            list: bindApiCall(this, 'channels.list'),
-            mark: bindApiCall(this, 'channels.mark'),
-            rename: bindApiCall(this, 'channels.rename'),
-            replies: bindApiCall(this, 'channels.replies'),
-            setPurpose: bindApiCall(this, 'channels.setPurpose'),
-            setTopic: bindApiCall(this, 'channels.setTopic'),
-            unarchive: bindApiCall(this, 'channels.unarchive'),
-        };
         this.chat = {
             delete: bindApiCall(this, 'chat.delete'),
             deleteScheduledMessage: bindApiCall(this, 'chat.deleteScheduledMessage'),
@@ -4784,12 +4814,6 @@ class Methods extends eventemitter3_1.EventEmitter {
             setTopic: bindApiCall(this, 'conversations.setTopic'),
             unarchive: bindApiCall(this, 'conversations.unarchive'),
         };
-        this.views = {
-            open: bindApiCall(this, 'views.open'),
-            publish: bindApiCall(this, 'views.publish'),
-            push: bindApiCall(this, 'views.push'),
-            update: bindApiCall(this, 'views.update'),
-        };
         this.dialog = {
             open: bindApiCall(this, 'dialog.open'),
         };
@@ -4822,42 +4846,8 @@ class Methods extends eventemitter3_1.EventEmitter {
                 share: bindApiCall(this, 'files.remote.share'),
             },
         };
-        this.groups = {
-            archive: bindApiCall(this, 'groups.archive'),
-            create: bindApiCall(this, 'groups.create'),
-            createChild: bindApiCall(this, 'groups.createChild'),
-            history: bindApiCall(this, 'groups.history'),
-            info: bindApiCall(this, 'groups.info'),
-            invite: bindApiCall(this, 'groups.invite'),
-            kick: bindApiCall(this, 'groups.kick'),
-            leave: bindApiCall(this, 'groups.leave'),
-            list: bindApiCall(this, 'groups.list'),
-            mark: bindApiCall(this, 'groups.mark'),
-            open: bindApiCall(this, 'groups.open'),
-            rename: bindApiCall(this, 'groups.rename'),
-            replies: bindApiCall(this, 'groups.replies'),
-            setPurpose: bindApiCall(this, 'groups.setPurpose'),
-            setTopic: bindApiCall(this, 'groups.setTopic'),
-            unarchive: bindApiCall(this, 'groups.unarchive'),
-        };
-        this.im = {
-            close: bindApiCall(this, 'im.close'),
-            history: bindApiCall(this, 'im.history'),
-            list: bindApiCall(this, 'im.list'),
-            mark: bindApiCall(this, 'im.mark'),
-            open: bindApiCall(this, 'im.open'),
-            replies: bindApiCall(this, 'im.replies'),
-        };
         this.migration = {
             exchange: bindApiCall(this, 'migration.exchange'),
-        };
-        this.mpim = {
-            close: bindApiCall(this, 'mpim.close'),
-            history: bindApiCall(this, 'mpim.history'),
-            list: bindApiCall(this, 'mpim.list'),
-            mark: bindApiCall(this, 'mpim.mark'),
-            open: bindApiCall(this, 'mpim.open'),
-            replies: bindApiCall(this, 'mpim.replies'),
         };
         this.oauth = {
             access: bindApiCall(this, 'oauth.access'),
@@ -4932,10 +4922,70 @@ class Methods extends eventemitter3_1.EventEmitter {
                 set: bindApiCall(this, 'users.profile.set'),
             },
         };
+        this.views = {
+            open: bindApiCall(this, 'views.open'),
+            publish: bindApiCall(this, 'views.publish'),
+            push: bindApiCall(this, 'views.push'),
+            update: bindApiCall(this, 'views.update'),
+        };
         this.workflows = {
             stepCompleted: bindApiCall(this, 'workflows.stepCompleted'),
             stepFailed: bindApiCall(this, 'workflows.stepFailed'),
             updateStep: bindApiCall(this, 'workflows.updateStep'),
+        };
+        // ---------------------------------
+        // Deprecated methods
+        // ---------------------------------
+        this.channels = {
+            archive: bindApiCall(this, 'channels.archive'),
+            create: bindApiCall(this, 'channels.create'),
+            history: bindApiCall(this, 'channels.history'),
+            info: bindApiCall(this, 'channels.info'),
+            invite: bindApiCall(this, 'channels.invite'),
+            join: bindApiCall(this, 'channels.join'),
+            kick: bindApiCall(this, 'channels.kick'),
+            leave: bindApiCall(this, 'channels.leave'),
+            list: bindApiCall(this, 'channels.list'),
+            mark: bindApiCall(this, 'channels.mark'),
+            rename: bindApiCall(this, 'channels.rename'),
+            replies: bindApiCall(this, 'channels.replies'),
+            setPurpose: bindApiCall(this, 'channels.setPurpose'),
+            setTopic: bindApiCall(this, 'channels.setTopic'),
+            unarchive: bindApiCall(this, 'channels.unarchive'),
+        };
+        this.groups = {
+            archive: bindApiCall(this, 'groups.archive'),
+            create: bindApiCall(this, 'groups.create'),
+            createChild: bindApiCall(this, 'groups.createChild'),
+            history: bindApiCall(this, 'groups.history'),
+            info: bindApiCall(this, 'groups.info'),
+            invite: bindApiCall(this, 'groups.invite'),
+            kick: bindApiCall(this, 'groups.kick'),
+            leave: bindApiCall(this, 'groups.leave'),
+            list: bindApiCall(this, 'groups.list'),
+            mark: bindApiCall(this, 'groups.mark'),
+            open: bindApiCall(this, 'groups.open'),
+            rename: bindApiCall(this, 'groups.rename'),
+            replies: bindApiCall(this, 'groups.replies'),
+            setPurpose: bindApiCall(this, 'groups.setPurpose'),
+            setTopic: bindApiCall(this, 'groups.setTopic'),
+            unarchive: bindApiCall(this, 'groups.unarchive'),
+        };
+        this.im = {
+            close: bindApiCall(this, 'im.close'),
+            history: bindApiCall(this, 'im.history'),
+            list: bindApiCall(this, 'im.list'),
+            mark: bindApiCall(this, 'im.mark'),
+            open: bindApiCall(this, 'im.open'),
+            replies: bindApiCall(this, 'im.replies'),
+        };
+        this.mpim = {
+            close: bindApiCall(this, 'mpim.close'),
+            history: bindApiCall(this, 'mpim.history'),
+            list: bindApiCall(this, 'mpim.list'),
+            mark: bindApiCall(this, 'mpim.mark'),
+            open: bindApiCall(this, 'mpim.open'),
+            replies: bindApiCall(this, 'mpim.replies'),
         };
         // Check that the class being created extends from `WebClient` rather than this class
         if (new.target !== WebClient_1.WebClient && !(new.target.prototype instanceof WebClient_1.WebClient)) {
@@ -4983,6 +5033,16 @@ exports.cursorPaginationEnabledMethods.add('users.conversations');
 exports.cursorPaginationEnabledMethods.add('users.list');
 __exportStar(__nccwpck_require__(4380), exports);
 //# sourceMappingURL=methods.js.map
+
+/***/ }),
+
+/***/ 677:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
@@ -26756,6 +26816,34 @@ module.exports = {
     return (h1.equals(h2));
   }
 };
+
+
+/***/ }),
+
+/***/ 7439:
+/***/ ((module) => {
+
+// https://github.com/electron/electron/issues/2288
+function isElectron() {
+    // Renderer process
+    if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer') {
+        return true;
+    }
+
+    // Main process
+    if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron) {
+        return true;
+    }
+
+    // Detect the user agent when the `nodeIntegration` option is set to true
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = isElectron;
 
 
 /***/ }),

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60008,7 +60008,6 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60033,7 +60032,6 @@ const Credentials_fetchCredentials = (identifier) => __awaiter(void 0, void 0, v
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 const Credentials_fetchRepository = (name) => __awaiter(void 0, void 0, void 0, function* () {
@@ -60092,7 +60090,6 @@ const Git_TreeTypes = {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60110,7 +60107,6 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60129,7 +60125,6 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60147,7 +60142,6 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60164,7 +60158,6 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -60194,7 +60187,6 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60210,7 +60202,6 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60232,7 +60223,6 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -60246,7 +60236,6 @@ const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, vo
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 const Repository_repositoryUrl = (repo) => `https://github.com/${organizationName()}/${repo}`;
@@ -60271,7 +60260,6 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60296,7 +60284,6 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60325,7 +60312,6 @@ const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 const Branch_createBranch = (repo, baseBranchName, newBranchName, filePath, fileContent, commitMessage) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -60370,7 +60356,6 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60391,7 +60376,6 @@ const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaite
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 const PullRequest_createPullRequest = (repo, base, head, title, body, token) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60410,7 +60394,6 @@ const PullRequest_createPullRequest = (repo, base, head, title, body, token) => 
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 const PullRequest_getIssueKey = (pr) => {
@@ -60434,7 +60417,6 @@ const PullRequest_getIssueKey = (pr) => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60460,7 +60442,6 @@ const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0,
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60482,7 +60463,6 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 const PullRequest_extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\d+)\].*$/, '$1'), 10) ||
@@ -60493,7 +60473,6 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60509,7 +60488,6 @@ const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organizationName()}/${repo}/pull/${number}`;
@@ -60520,7 +60498,6 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60539,7 +60516,6 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -60578,7 +60554,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60596,7 +60571,6 @@ const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, 
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 const Label_addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -60686,7 +60660,6 @@ const JiraFieldStoryPointEstimate = 'Story point estimate';
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (issue, fieldName) => {
@@ -60698,7 +60671,6 @@ const idForFieldName = (issue, fieldName) => {
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue) => {
@@ -60726,7 +60698,6 @@ const populateExplicitFields = (issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60750,7 +60721,6 @@ const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* 
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60769,7 +60739,6 @@ const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 const getEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60797,7 +60766,6 @@ const recursiveGetEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60817,7 +60785,6 @@ const Issue_getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60831,7 +60798,6 @@ const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
@@ -60839,10 +60805,8 @@ const Issue_issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 const moveIssueToBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -60925,7 +60889,6 @@ var Project_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60941,7 +60904,6 @@ const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60961,7 +60923,6 @@ const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, functi
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -60985,7 +60946,6 @@ const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61009,7 +60969,6 @@ const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, f
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61032,7 +60991,6 @@ const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -61070,7 +61028,6 @@ var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 const createJiraRelease = (projectKey, name, description) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61100,7 +61057,6 @@ const createJiraRelease = (projectKey, name, description) => Release_awaiter(voi
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 const findJiraRelease = (projectKey, name) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -61207,7 +61163,6 @@ var lodash_startCase = __nccwpck_require__(9274);
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 const String_parameterize = (str) => snakeCase(str.trim().toLowerCase())
@@ -62015,7 +61970,6 @@ mustache_mustache.Writer = Writer;
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 const Template_render = (template, vars) => mustache.render(template, vars);
@@ -62100,7 +62054,6 @@ var Epic_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, void 0, void 0, function* () {
@@ -62229,7 +62182,6 @@ const positiveEmoji = () => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 const scrubMessage = (message) => {
@@ -62247,7 +62199,6 @@ const scrubMessage = (message) => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62266,7 +62217,6 @@ const sendErrorMessage = (message) => Message_awaiter(void 0, void 0, void 0, fu
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const Message_sendUserMessage = (userId, message) => Message_awaiter(void 0, void 0, void 0, function* () {
@@ -62326,7 +62276,6 @@ var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thi
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62387,7 +62336,6 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62414,7 +62362,6 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62444,7 +62391,6 @@ const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Gith
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62457,7 +62403,6 @@ const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0,
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62470,7 +62415,6 @@ const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, 
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62533,7 +62477,6 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -5,7 +5,7 @@
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.1.0","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.7.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
+module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.2.3","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":"^3.0.0","@slack/types":"^2.0.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0","is-electron":"^2.2.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
 
 /***/ }),
 
@@ -3764,6 +3764,7 @@ exports.v = Octokit;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ConsoleLogger = exports.LogLevel = void 0;
 /**
  * Severity levels for log entries
  */
@@ -3836,6 +3837,7 @@ class ConsoleLogger {
         return ConsoleLogger.severity[a] >= ConsoleLogger.severity[b];
     }
 }
+exports.ConsoleLogger = ConsoleLogger;
 /** Map of labels for each log level */
 ConsoleLogger.labels = (() => {
     const entries = Object.entries(LogLevel);
@@ -3851,7 +3853,6 @@ ConsoleLogger.severity = {
     [LogLevel.INFO]: 200,
     [LogLevel.DEBUG]: 100,
 };
-exports.ConsoleLogger = ConsoleLogger;
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -3927,6 +3928,7 @@ const p_queue_1 = __importDefault(__nccwpck_require__(8983)); // tslint:disable-
 const p_retry_1 = __importStar(__nccwpck_require__(2548));
 const axios_1 = __importDefault(__nccwpck_require__(6545));
 const form_data_1 = __importDefault(__nccwpck_require__(4334)); // tslint:disable-line:import-name
+const is_electron_1 = __importDefault(__nccwpck_require__(7439));
 const methods_1 = __nccwpck_require__(1571);
 const instrument_1 = __nccwpck_require__(7763);
 const errors_1 = __nccwpck_require__(9781);
@@ -3943,7 +3945,7 @@ class WebClient extends methods_1.Methods {
     /**
      * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
      */
-    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = logger_1.LogLevel.INFO, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
+    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = undefined, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
         super();
         this.token = token;
         this.slackApiUrl = slackApiUrl;
@@ -3961,13 +3963,11 @@ class WebClient extends methods_1.Methods {
             }
         }
         else {
-            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel, logger);
+            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel !== null && logLevel !== void 0 ? logLevel : logger_1.LogLevel.INFO, logger);
         }
         this.axios = axios_1.default.create({
             baseURL: slackApiUrl,
-            headers: Object.assign({
-                'User-Agent': instrument_1.getUserAgent(),
-            }, headers),
+            headers: is_electron_1.default() ? headers : Object.assign({ 'User-Agent': instrument_1.getUserAgent() }, headers),
             httpAgent: agent,
             httpsAgent: agent,
             transformRequest: [this.serializeApiCallOptions.bind(this)],
@@ -3992,6 +3992,8 @@ class WebClient extends methods_1.Methods {
     async apiCall(method, options) {
         this.logger.debug(`apiCall('${method}') start`);
         warnDeprecations(method, this.logger);
+        warnIfFallbackIsMissing(method, this.logger, options);
+        warnIfThreadTsIsNotString(method, this.logger, options);
         if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
             throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
         }
@@ -4231,7 +4233,7 @@ class WebClient extends methods_1.Methods {
         }, initialValue));
     }
     /**
-     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
+     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevant
      * HTTP headers into the object.
      * @param response - an http response
      */
@@ -4323,6 +4325,44 @@ function warnDeprecations(method, logger) {
     }
     else if (isDeprecated) {
         logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
+    }
+}
+/**
+ * Log a warning when using chat.postMessage without text argument or attachments with fallback argument
+ * @param method api method being called
+ * @param logger instance of we clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfFallbackIsMissing(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+    const isTargetMethod = targetMethods.includes(method);
+    const missingAttachmentFallbackDetected = (args) => Array.isArray(args.attachments)
+        && args.attachments.some(attachment => !attachment.fallback || attachment.fallback.trim() === 0);
+    const isEmptyText = (args) => args.text === undefined || args.text === null || args.text === '';
+    const buildWarningMessage = (missing) => `The \`${missing}\` argument is missing in the request payload for a ${method} call - ` +
+        `It's a best practice to always provide a \`${missing}\` argument when posting a message. ` +
+        `The \`${missing}\` is used in places where the content cannot be rendered such as: ` +
+        'system push notifications, assistive technology such as screen readers, etc.';
+    if (isTargetMethod && typeof options === 'object' && isEmptyText(options)) {
+        if (missingAttachmentFallbackDetected(options)) {
+            logger.warn(buildWarningMessage('fallback'));
+        }
+        else {
+            logger.warn(buildWarningMessage('text'));
+        }
+    }
+}
+/**
+ * Log a warning when thread_ts is not a string
+ * @param method api method being called
+ * @param logger instance of web clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfThreadTsIsNotString(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'files.upload'];
+    const isTargetMethod = targetMethods.includes(method);
+    if (isTargetMethod && (options === null || options === void 0 ? void 0 : options.thread_ts) !== undefined && typeof (options === null || options === void 0 ? void 0 : options.thread_ts) !== 'string') {
+        logger.warn(`The given thread_ts value in the request payload for a ${method} call is a float value. We highly recommend using a string value instead.`);
     }
 }
 //# sourceMappingURL=WebClient.js.map
@@ -4457,6 +4497,7 @@ Object.defineProperty(exports, "retryPolicies", ({ enumerable: true, get: functi
 var instrument_1 = __nccwpck_require__(7763);
 Object.defineProperty(exports, "addAppMetadata", ({ enumerable: true, get: function () { return instrument_1.addAppMetadata; } }));
 __exportStar(__nccwpck_require__(1571), exports);
+__exportStar(__nccwpck_require__(677), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
@@ -4599,11 +4640,13 @@ class Methods extends eventemitter3_1.EventEmitter {
     constructor() {
         super();
         this.admin = {
+            // TODO: admin.analytics.getFile
             apps: {
                 approve: bindApiCall(this, 'admin.apps.approve'),
                 approved: {
                     list: bindApiCall(this, 'admin.apps.approved.list'),
                 },
+                clearResolution: bindApiCall(this, 'admin.apps.clearResolution'),
                 requests: {
                     list: bindApiCall(this, 'admin.apps.requests.list'),
                 },
@@ -4611,6 +4654,7 @@ class Methods extends eventemitter3_1.EventEmitter {
                 restricted: {
                     list: bindApiCall(this, 'admin.apps.restricted.list'),
                 },
+                uninstall: bindApiCall(this, 'admin.apps.uninstall'),
             },
             barriers: {
                 create: bindApiCall(this, 'admin.barriers.create'),
@@ -4692,6 +4736,9 @@ class Methods extends eventemitter3_1.EventEmitter {
                     list: bindApiCall(this, 'admin.users.session.list'),
                     reset: bindApiCall(this, 'admin.users.session.reset'),
                     invalidate: bindApiCall(this, 'admin.users.session.invalidate'),
+                    getSettings: bindApiCall(this, 'admin.users.session.getSettings'),
+                    setSettings: bindApiCall(this, 'admin.users.session.setSettings'),
+                    clearSettings: bindApiCall(this, 'admin.users.session.clearSettings'),
                 },
                 setAdmin: bindApiCall(this, 'admin.users.setAdmin'),
                 setExpiration: bindApiCall(this, 'admin.users.setExpiration'),
@@ -4733,23 +4780,6 @@ class Methods extends eventemitter3_1.EventEmitter {
                 remove: bindApiCall(this, 'calls.participants.remove'),
             },
         };
-        this.channels = {
-            archive: bindApiCall(this, 'channels.archive'),
-            create: bindApiCall(this, 'channels.create'),
-            history: bindApiCall(this, 'channels.history'),
-            info: bindApiCall(this, 'channels.info'),
-            invite: bindApiCall(this, 'channels.invite'),
-            join: bindApiCall(this, 'channels.join'),
-            kick: bindApiCall(this, 'channels.kick'),
-            leave: bindApiCall(this, 'channels.leave'),
-            list: bindApiCall(this, 'channels.list'),
-            mark: bindApiCall(this, 'channels.mark'),
-            rename: bindApiCall(this, 'channels.rename'),
-            replies: bindApiCall(this, 'channels.replies'),
-            setPurpose: bindApiCall(this, 'channels.setPurpose'),
-            setTopic: bindApiCall(this, 'channels.setTopic'),
-            unarchive: bindApiCall(this, 'channels.unarchive'),
-        };
         this.chat = {
             delete: bindApiCall(this, 'chat.delete'),
             deleteScheduledMessage: bindApiCall(this, 'chat.deleteScheduledMessage'),
@@ -4784,12 +4814,6 @@ class Methods extends eventemitter3_1.EventEmitter {
             setTopic: bindApiCall(this, 'conversations.setTopic'),
             unarchive: bindApiCall(this, 'conversations.unarchive'),
         };
-        this.views = {
-            open: bindApiCall(this, 'views.open'),
-            publish: bindApiCall(this, 'views.publish'),
-            push: bindApiCall(this, 'views.push'),
-            update: bindApiCall(this, 'views.update'),
-        };
         this.dialog = {
             open: bindApiCall(this, 'dialog.open'),
         };
@@ -4822,42 +4846,8 @@ class Methods extends eventemitter3_1.EventEmitter {
                 share: bindApiCall(this, 'files.remote.share'),
             },
         };
-        this.groups = {
-            archive: bindApiCall(this, 'groups.archive'),
-            create: bindApiCall(this, 'groups.create'),
-            createChild: bindApiCall(this, 'groups.createChild'),
-            history: bindApiCall(this, 'groups.history'),
-            info: bindApiCall(this, 'groups.info'),
-            invite: bindApiCall(this, 'groups.invite'),
-            kick: bindApiCall(this, 'groups.kick'),
-            leave: bindApiCall(this, 'groups.leave'),
-            list: bindApiCall(this, 'groups.list'),
-            mark: bindApiCall(this, 'groups.mark'),
-            open: bindApiCall(this, 'groups.open'),
-            rename: bindApiCall(this, 'groups.rename'),
-            replies: bindApiCall(this, 'groups.replies'),
-            setPurpose: bindApiCall(this, 'groups.setPurpose'),
-            setTopic: bindApiCall(this, 'groups.setTopic'),
-            unarchive: bindApiCall(this, 'groups.unarchive'),
-        };
-        this.im = {
-            close: bindApiCall(this, 'im.close'),
-            history: bindApiCall(this, 'im.history'),
-            list: bindApiCall(this, 'im.list'),
-            mark: bindApiCall(this, 'im.mark'),
-            open: bindApiCall(this, 'im.open'),
-            replies: bindApiCall(this, 'im.replies'),
-        };
         this.migration = {
             exchange: bindApiCall(this, 'migration.exchange'),
-        };
-        this.mpim = {
-            close: bindApiCall(this, 'mpim.close'),
-            history: bindApiCall(this, 'mpim.history'),
-            list: bindApiCall(this, 'mpim.list'),
-            mark: bindApiCall(this, 'mpim.mark'),
-            open: bindApiCall(this, 'mpim.open'),
-            replies: bindApiCall(this, 'mpim.replies'),
         };
         this.oauth = {
             access: bindApiCall(this, 'oauth.access'),
@@ -4932,10 +4922,70 @@ class Methods extends eventemitter3_1.EventEmitter {
                 set: bindApiCall(this, 'users.profile.set'),
             },
         };
+        this.views = {
+            open: bindApiCall(this, 'views.open'),
+            publish: bindApiCall(this, 'views.publish'),
+            push: bindApiCall(this, 'views.push'),
+            update: bindApiCall(this, 'views.update'),
+        };
         this.workflows = {
             stepCompleted: bindApiCall(this, 'workflows.stepCompleted'),
             stepFailed: bindApiCall(this, 'workflows.stepFailed'),
             updateStep: bindApiCall(this, 'workflows.updateStep'),
+        };
+        // ---------------------------------
+        // Deprecated methods
+        // ---------------------------------
+        this.channels = {
+            archive: bindApiCall(this, 'channels.archive'),
+            create: bindApiCall(this, 'channels.create'),
+            history: bindApiCall(this, 'channels.history'),
+            info: bindApiCall(this, 'channels.info'),
+            invite: bindApiCall(this, 'channels.invite'),
+            join: bindApiCall(this, 'channels.join'),
+            kick: bindApiCall(this, 'channels.kick'),
+            leave: bindApiCall(this, 'channels.leave'),
+            list: bindApiCall(this, 'channels.list'),
+            mark: bindApiCall(this, 'channels.mark'),
+            rename: bindApiCall(this, 'channels.rename'),
+            replies: bindApiCall(this, 'channels.replies'),
+            setPurpose: bindApiCall(this, 'channels.setPurpose'),
+            setTopic: bindApiCall(this, 'channels.setTopic'),
+            unarchive: bindApiCall(this, 'channels.unarchive'),
+        };
+        this.groups = {
+            archive: bindApiCall(this, 'groups.archive'),
+            create: bindApiCall(this, 'groups.create'),
+            createChild: bindApiCall(this, 'groups.createChild'),
+            history: bindApiCall(this, 'groups.history'),
+            info: bindApiCall(this, 'groups.info'),
+            invite: bindApiCall(this, 'groups.invite'),
+            kick: bindApiCall(this, 'groups.kick'),
+            leave: bindApiCall(this, 'groups.leave'),
+            list: bindApiCall(this, 'groups.list'),
+            mark: bindApiCall(this, 'groups.mark'),
+            open: bindApiCall(this, 'groups.open'),
+            rename: bindApiCall(this, 'groups.rename'),
+            replies: bindApiCall(this, 'groups.replies'),
+            setPurpose: bindApiCall(this, 'groups.setPurpose'),
+            setTopic: bindApiCall(this, 'groups.setTopic'),
+            unarchive: bindApiCall(this, 'groups.unarchive'),
+        };
+        this.im = {
+            close: bindApiCall(this, 'im.close'),
+            history: bindApiCall(this, 'im.history'),
+            list: bindApiCall(this, 'im.list'),
+            mark: bindApiCall(this, 'im.mark'),
+            open: bindApiCall(this, 'im.open'),
+            replies: bindApiCall(this, 'im.replies'),
+        };
+        this.mpim = {
+            close: bindApiCall(this, 'mpim.close'),
+            history: bindApiCall(this, 'mpim.history'),
+            list: bindApiCall(this, 'mpim.list'),
+            mark: bindApiCall(this, 'mpim.mark'),
+            open: bindApiCall(this, 'mpim.open'),
+            replies: bindApiCall(this, 'mpim.replies'),
         };
         // Check that the class being created extends from `WebClient` rather than this class
         if (new.target !== WebClient_1.WebClient && !(new.target.prototype instanceof WebClient_1.WebClient)) {
@@ -4983,6 +5033,16 @@ exports.cursorPaginationEnabledMethods.add('users.conversations');
 exports.cursorPaginationEnabledMethods.add('users.list');
 __exportStar(__nccwpck_require__(4380), exports);
 //# sourceMappingURL=methods.js.map
+
+/***/ }),
+
+/***/ 677:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
@@ -26756,6 +26816,34 @@ module.exports = {
     return (h1.equals(h2));
   }
 };
+
+
+/***/ }),
+
+/***/ 7439:
+/***/ ((module) => {
+
+// https://github.com/electron/electron/issues/2288
+function isElectron() {
+    // Renderer process
+    if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer') {
+        return true;
+    }
+
+    // Main process
+    if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron) {
+        return true;
+    }
+
+    // Detect the user agent when the `nodeIntegration` option is set to true
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = isElectron;
 
 
 /***/ }),

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -64063,8 +64063,8 @@ var createPullRequestForJiraIssue_awaiter = (undefined && undefined.__awaiter) |
  * @param {string} userCommand The command given by the user of the Jira issue we will base the pull request on.
  */
 const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestForJiraIssue_awaiter(void 0, void 0, void 0, function* () {
-  const [issueKey, repositoryName] = userCommand.trim().split(/\s+/);
     var _a, _b;
+    const [issueKey, repositoryName] = userCommand.trim().split(/\s+/);
     (0,core.info)(`Creating a pull request for issue ${issueKey} / ${email}`);
     (0,core.info)('Fetching the Jira issue details...');
     const issue = yield getIssue(issueKey);
@@ -64076,6 +64076,8 @@ const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestF
         return;
     }
     const jiraUrl = issueUrl(issue.key);
+    // If no repository is supplied then it will default to the Jira issue repository.
+    const repository = repositoryName || issue.fields.repository;
     (0,core.info)(`The Jira URL is ${jiraUrl}`);
     (0,core.info)('Finding out who the pull request should belong to...');
     if (isNil_default()(issue.fields.assignee)) {
@@ -64100,7 +64102,7 @@ const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestF
         yield sendUserMessage(credentials.slack_id, message);
         return;
     }
-    if (isNil_default()(repositoryName || issue.fields.repository)) {
+    if (isNil_default()(repository)) {
         const message = `No repository is set for issue <${jiraUrl}|${issue.key}>, so no pull request was created`;
         (0,core.error)(message);
         yield sendUserMessage(credentials.slack_id, message);
@@ -64114,7 +64116,7 @@ const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestF
     }
     (0,core.info)('Checking if there is an open pull request for this issue...');
     let pullRequestNumber;
-    const repo = yield getRepository(repositoryName || issue.fields.repository);
+    const repo = yield getRepository(repository);
     const pullRequestNumbers = yield getIssuePullRequestNumbers(issue.id, repo.name);
     if (pullRequestNumbers.length > 0) {
         ;
@@ -64134,13 +64136,13 @@ const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestF
             !((_a = epic.fields.labels) === null || _a === void 0 ? void 0 : _a.includes(JiraLabelSkipPR)) &&
             !((_b = issue.fields.labels) === null || _b === void 0 ? void 0 : _b.includes(JiraLabelSkipPR))) {
             (0,core.info)(`Issue ${issue.key} belongs to epic ${epic.key} - creating an Epic pull request.`);
-            const epicPr = yield createEpicPullRequest(epic, repositoryName || issue.fields.repository);
+            const epicPr = yield createEpicPullRequest(epic, repository);
             baseBranchName = epicPr.head.ref;
         }
         (0,core.info)(`Checking if the branch '${newBranchName}' already exists...`);
         if (isNil_default()(branch)) {
             (0,core.info)(`The branch '${newBranchName}' does not exist yet: creating a new branch...`);
-            yield createBranch(repo.name, baseBranchName, newBranchName, `.meta/${issue.key}.md`, `${jiraUrl}\n\nCreated at ${new Date().toISOString()}`, `[${issue.key}] [skip ci] Create pull request.`);
+            yield createBranch(repo.name, baseBranchName, newBranchName, `.meta/${issue.key}.md`, `${jiraUrl}\n\nCreated at ${new Date().toISOString()}`, `[${issue.key}] [skip ci] [skip netlify] Create pull request.`);
         }
         (0,core.info)('Creating the pull request...');
         const prTitle = `[${issue.key}] ${issue.fields.summary}`;

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -1,15 +1,15 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 9557:
+/***/ 69557:
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.1.0","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.7.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
+module.exports = JSON.parse('{"name":"@slack/web-api","version":"6.2.3","description":"Official library for using the Slack Platform\'s Web API","author":"Slack Technologies, Inc.","license":"MIT","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"main":"dist/index.js","types":"./dist/index.d.ts","files":["dist/**/*"],"engines":{"node":">= 12.13.0","npm":">= 6.12.0"},"repository":"slackapi/node-slack-sdk","homepage":"https://slack.dev/node-slack-sdk/web-api","publishConfig":{"access":"public"},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"scripts":{"prepare":"npm run build","build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","lint":"tslint --project .","test":"npm run build && npm run test:mocha && npm run test:types","test:mocha":"nyc mocha --config .mocharc.json src/*.spec.js","test:types":"tsd","coverage":"codecov -F webapi --root=$PWD","ref-docs:model":"api-extractor run","watch":"npx nodemon --watch \'src\' --ext \'ts\' --exec npm run build"},"dependencies":{"@slack/logger":"^3.0.0","@slack/types":"^2.0.0","@types/is-stream":"^1.1.0","@types/node":">=12.0.0","axios":"^0.21.1","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^6.6.1","p-retry":"^4.0.0","is-electron":"^2.2.0"},"devDependencies":{"@aoberoi/capture-console":"^1.1.0","@microsoft/api-extractor":"^7.3.4","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^9.0.0","tsd":"^0.13.1","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^4.1"},"tsd":{"directory":"test/types"}}');
 
 /***/ }),
 
-/***/ 7351:
+/***/ 87351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -22,7 +22,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(12087));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -95,7 +95,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 2186:
+/***/ 42186:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -117,11 +117,11 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __nccwpck_require__(7351);
+const command_1 = __nccwpck_require__(87351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(12087));
+const path = __importStar(__nccwpck_require__(85622));
 /**
  * The code to exit an action
  */
@@ -357,8 +357,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(35747));
+const os = __importStar(__nccwpck_require__(12087));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -403,15 +403,15 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 4087:
+/***/ 74087:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Context = void 0;
-const fs_1 = __nccwpck_require__(5747);
-const os_1 = __nccwpck_require__(2087);
+const fs_1 = __nccwpck_require__(35747);
+const os_1 = __nccwpck_require__(12087);
 class Context {
     /**
      * Hydrate the context from the environment
@@ -460,7 +460,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 5438:
+/***/ 95438:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -486,8 +486,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokit = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(4087));
-const utils_1 = __nccwpck_require__(3030);
+const Context = __importStar(__nccwpck_require__(74087));
+const utils_1 = __nccwpck_require__(73030);
 exports.context = new Context.Context();
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
@@ -503,7 +503,7 @@ exports.getOctokit = getOctokit;
 
 /***/ }),
 
-/***/ 7914:
+/***/ 47914:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -529,7 +529,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
-const httpClient = __importStar(__nccwpck_require__(9925));
+const httpClient = __importStar(__nccwpck_require__(39925));
 function getAuthString(token, options) {
     if (!token && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -553,7 +553,7 @@ exports.getApiBaseUrl = getApiBaseUrl;
 
 /***/ }),
 
-/***/ 3030:
+/***/ 73030:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -579,12 +579,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(4087));
-const Utils = __importStar(__nccwpck_require__(7914));
+const Context = __importStar(__nccwpck_require__(74087));
+const Utils = __importStar(__nccwpck_require__(47914));
 // octokit + plugins
-const core_1 = __nccwpck_require__(6762);
-const plugin_rest_endpoint_methods_1 = __nccwpck_require__(3044);
-const plugin_paginate_rest_1 = __nccwpck_require__(4193);
+const core_1 = __nccwpck_require__(76762);
+const plugin_rest_endpoint_methods_1 = __nccwpck_require__(83044);
+const plugin_paginate_rest_1 = __nccwpck_require__(64193);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
 const defaults = {
@@ -614,16 +614,16 @@ exports.getOctokitOptions = getOctokitOptions;
 
 /***/ }),
 
-/***/ 9925:
+/***/ 39925:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const url = __nccwpck_require__(8835);
-const http = __nccwpck_require__(8605);
-const https = __nccwpck_require__(7211);
-const pm = __nccwpck_require__(6443);
+const url = __nccwpck_require__(78835);
+const http = __nccwpck_require__(98605);
+const https = __nccwpck_require__(57211);
+const pm = __nccwpck_require__(16443);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1033,7 +1033,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(4294);
+                tunnel = __nccwpck_require__(74294);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1153,13 +1153,13 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 6443:
+/***/ 16443:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const url = __nccwpck_require__(8835);
+const url = __nccwpck_require__(78835);
 function getProxyUrl(reqUrl) {
     let usingSsl = reqUrl.protocol === 'https:';
     let proxyUrl;
@@ -1219,7 +1219,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 7400:
+/***/ 77400:
 /***/ ((module) => {
 
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
@@ -1262,7 +1262,7 @@ module.exports = _asyncToGenerator;
 
 /***/ }),
 
-/***/ 9346:
+/***/ 49346:
 /***/ ((module) => {
 
 function _classCallCheck(instance, Constructor) {
@@ -1275,7 +1275,7 @@ module.exports = _classCallCheck;
 
 /***/ }),
 
-/***/ 8755:
+/***/ 78755:
 /***/ ((module) => {
 
 function _defineProperties(target, props) {
@@ -1298,7 +1298,7 @@ module.exports = _createClass;
 
 /***/ }),
 
-/***/ 3561:
+/***/ 23561:
 /***/ ((module) => {
 
 function _defineProperty(obj, key, value) {
@@ -1320,7 +1320,7 @@ module.exports = _defineProperty;
 
 /***/ }),
 
-/***/ 3298:
+/***/ 93298:
 /***/ ((module) => {
 
 function _interopRequireDefault(obj) {
@@ -1333,15 +1333,15 @@ module.exports = _interopRequireDefault;
 
 /***/ }),
 
-/***/ 9032:
+/***/ 69032:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(4307);
+module.exports = __nccwpck_require__(94307);
 
 
 /***/ }),
 
-/***/ 334:
+/***/ 40334:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1398,7 +1398,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 6762:
+/***/ 76762:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1406,11 +1406,11 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var universalUserAgent = __nccwpck_require__(5030);
-var beforeAfterHook = __nccwpck_require__(3682);
-var request = __nccwpck_require__(6234);
-var graphql = __nccwpck_require__(8467);
-var authToken = __nccwpck_require__(334);
+var universalUserAgent = __nccwpck_require__(45030);
+var beforeAfterHook = __nccwpck_require__(83682);
+var request = __nccwpck_require__(36234);
+var graphql = __nccwpck_require__(88467);
+var authToken = __nccwpck_require__(40334);
 
 function _defineProperty(obj, key, value) {
   if (key in obj) {
@@ -1582,7 +1582,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 9440:
+/***/ 59440:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1590,8 +1590,8 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __nccwpck_require__(558);
-var universalUserAgent = __nccwpck_require__(5030);
+var isPlainObject = __nccwpck_require__(70558);
+var universalUserAgent = __nccwpck_require__(45030);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -1967,7 +1967,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 558:
+/***/ 70558:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2013,7 +2013,7 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 8467:
+/***/ 88467:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2021,8 +2021,8 @@ exports.isPlainObject = isPlainObject;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(6234);
-var universalUserAgent = __nccwpck_require__(5030);
+var request = __nccwpck_require__(36234);
+var universalUserAgent = __nccwpck_require__(45030);
 
 const VERSION = "4.5.6";
 
@@ -2129,7 +2129,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 4193:
+/***/ 64193:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2267,7 +2267,7 @@ exports.paginateRest = paginateRest;
 
 /***/ }),
 
-/***/ 8883:
+/***/ 68883:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2305,7 +2305,7 @@ exports.requestLog = requestLog;
 
 /***/ }),
 
-/***/ 3044:
+/***/ 83044:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3467,7 +3467,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 537:
+/***/ 10537:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3477,7 +3477,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(8932);
+var deprecation = __nccwpck_require__(58932);
 var once = _interopDefault(__nccwpck_require__(1223));
 
 const logOnce = once(deprecation => console.warn(deprecation));
@@ -3530,7 +3530,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 6234:
+/***/ 36234:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3540,11 +3540,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(9440);
-var universalUserAgent = __nccwpck_require__(5030);
-var isPlainObject = __nccwpck_require__(9062);
-var nodeFetch = _interopDefault(__nccwpck_require__(467));
-var requestError = __nccwpck_require__(537);
+var endpoint = __nccwpck_require__(59440);
+var universalUserAgent = __nccwpck_require__(45030);
+var isPlainObject = __nccwpck_require__(49062);
+var nodeFetch = _interopDefault(__nccwpck_require__(80467));
+var requestError = __nccwpck_require__(10537);
 
 const VERSION = "5.4.9";
 
@@ -3686,7 +3686,7 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 9062:
+/***/ 49062:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3732,7 +3732,7 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 5375:
+/***/ 55375:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3741,10 +3741,10 @@ var __webpack_unused_export__;
 
 __webpack_unused_export__ = ({ value: true });
 
-var core = __nccwpck_require__(6762);
-var pluginRequestLog = __nccwpck_require__(8883);
-var pluginPaginateRest = __nccwpck_require__(4193);
-var pluginRestEndpointMethods = __nccwpck_require__(3044);
+var core = __nccwpck_require__(76762);
+var pluginRequestLog = __nccwpck_require__(68883);
+var pluginPaginateRest = __nccwpck_require__(64193);
+var pluginRestEndpointMethods = __nccwpck_require__(83044);
 
 const VERSION = "18.0.9";
 
@@ -3758,12 +3758,13 @@ exports.v = Octokit;
 
 /***/ }),
 
-/***/ 2704:
+/***/ 32704:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ConsoleLogger = exports.LogLevel = void 0;
 /**
  * Severity levels for log entries
  */
@@ -3836,6 +3837,7 @@ class ConsoleLogger {
         return ConsoleLogger.severity[a] >= ConsoleLogger.severity[b];
     }
 }
+exports.ConsoleLogger = ConsoleLogger;
 /** Map of labels for each log level */
 ConsoleLogger.labels = (() => {
     const entries = Object.entries(LogLevel);
@@ -3851,12 +3853,11 @@ ConsoleLogger.severity = {
     [LogLevel.INFO]: 200,
     [LogLevel.DEBUG]: 100,
 };
-exports.ConsoleLogger = ConsoleLogger;
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 4380:
+/***/ 54380:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3866,7 +3867,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 1424:
+/***/ 61424:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -3920,19 +3921,20 @@ exports.WebClientEvent = exports.WebClient = void 0;
 if (Symbol['asyncIterator'] === undefined) {
     (Symbol['asyncIterator']) = Symbol.for('asyncIterator');
 }
-const querystring_1 = __nccwpck_require__(1191);
-const path_1 = __nccwpck_require__(5622);
-const is_stream_1 = __importDefault(__nccwpck_require__(1554));
-const p_queue_1 = __importDefault(__nccwpck_require__(8983)); // tslint:disable-line:import-name
-const p_retry_1 = __importStar(__nccwpck_require__(2548));
-const axios_1 = __importDefault(__nccwpck_require__(6545));
-const form_data_1 = __importDefault(__nccwpck_require__(4334)); // tslint:disable-line:import-name
-const methods_1 = __nccwpck_require__(1571);
-const instrument_1 = __nccwpck_require__(7763);
-const errors_1 = __nccwpck_require__(9781);
-const logger_1 = __nccwpck_require__(1336);
-const retry_policies_1 = __importDefault(__nccwpck_require__(2156));
-const helpers_1 = __nccwpck_require__(2500);
+const querystring_1 = __nccwpck_require__(71191);
+const path_1 = __nccwpck_require__(85622);
+const is_stream_1 = __importDefault(__nccwpck_require__(41554));
+const p_queue_1 = __importDefault(__nccwpck_require__(28983)); // tslint:disable-line:import-name
+const p_retry_1 = __importStar(__nccwpck_require__(82548));
+const axios_1 = __importDefault(__nccwpck_require__(96545));
+const form_data_1 = __importDefault(__nccwpck_require__(64334)); // tslint:disable-line:import-name
+const is_electron_1 = __importDefault(__nccwpck_require__(34293));
+const methods_1 = __nccwpck_require__(31571);
+const instrument_1 = __nccwpck_require__(27763);
+const errors_1 = __nccwpck_require__(79781);
+const logger_1 = __nccwpck_require__(51336);
+const retry_policies_1 = __importDefault(__nccwpck_require__(42156));
+const helpers_1 = __nccwpck_require__(92500);
 /**
  * A client for Slack's Web API
  *
@@ -3943,7 +3945,7 @@ class WebClient extends methods_1.Methods {
     /**
      * @param token - An API token to authenticate/authorize with Slack (usually start with `xoxp`, `xoxb`)
      */
-    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = logger_1.LogLevel.INFO, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
+    constructor(token, { slackApiUrl = 'https://slack.com/api/', logger = undefined, logLevel = undefined, maxRequestConcurrency = 3, retryConfig = retry_policies_1.default.tenRetriesInAboutThirtyMinutes, agent = undefined, tls = undefined, rejectRateLimitedCalls = false, headers = {}, teamId = undefined, } = {}) {
         super();
         this.token = token;
         this.slackApiUrl = slackApiUrl;
@@ -3961,13 +3963,11 @@ class WebClient extends methods_1.Methods {
             }
         }
         else {
-            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel, logger);
+            this.logger = logger_1.getLogger(WebClient.loggerName, logLevel !== null && logLevel !== void 0 ? logLevel : logger_1.LogLevel.INFO, logger);
         }
         this.axios = axios_1.default.create({
             baseURL: slackApiUrl,
-            headers: Object.assign({
-                'User-Agent': instrument_1.getUserAgent(),
-            }, headers),
+            headers: is_electron_1.default() ? headers : Object.assign({ 'User-Agent': instrument_1.getUserAgent() }, headers),
             httpAgent: agent,
             httpsAgent: agent,
             transformRequest: [this.serializeApiCallOptions.bind(this)],
@@ -3992,6 +3992,8 @@ class WebClient extends methods_1.Methods {
     async apiCall(method, options) {
         this.logger.debug(`apiCall('${method}') start`);
         warnDeprecations(method, this.logger);
+        warnIfFallbackIsMissing(method, this.logger, options);
+        warnIfThreadTsIsNotString(method, this.logger, options);
         if (typeof options === 'string' || typeof options === 'number' || typeof options === 'boolean') {
             throw new TypeError(`Expected an options argument but instead received a ${typeof options}`);
         }
@@ -4231,7 +4233,7 @@ class WebClient extends methods_1.Methods {
         }, initialValue));
     }
     /**
-     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevent
+     * Processes an HTTP response into a WebAPICallResult by performing JSON parsing on the body and merging relevant
      * HTTP headers into the object.
      * @param response - an http response
      */
@@ -4325,11 +4327,49 @@ function warnDeprecations(method, logger) {
         logger.warn(`${method} is deprecated. Please check on https://api.slack.com/methods for an alternative.`);
     }
 }
+/**
+ * Log a warning when using chat.postMessage without text argument or attachments with fallback argument
+ * @param method api method being called
+ * @param logger instance of we clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfFallbackIsMissing(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'chat.update'];
+    const isTargetMethod = targetMethods.includes(method);
+    const missingAttachmentFallbackDetected = (args) => Array.isArray(args.attachments)
+        && args.attachments.some(attachment => !attachment.fallback || attachment.fallback.trim() === 0);
+    const isEmptyText = (args) => args.text === undefined || args.text === null || args.text === '';
+    const buildWarningMessage = (missing) => `The \`${missing}\` argument is missing in the request payload for a ${method} call - ` +
+        `It's a best practice to always provide a \`${missing}\` argument when posting a message. ` +
+        `The \`${missing}\` is used in places where the content cannot be rendered such as: ` +
+        'system push notifications, assistive technology such as screen readers, etc.';
+    if (isTargetMethod && typeof options === 'object' && isEmptyText(options)) {
+        if (missingAttachmentFallbackDetected(options)) {
+            logger.warn(buildWarningMessage('fallback'));
+        }
+        else {
+            logger.warn(buildWarningMessage('text'));
+        }
+    }
+}
+/**
+ * Log a warning when thread_ts is not a string
+ * @param method api method being called
+ * @param logger instance of web clients logger
+ * @param options arguments for the Web API method
+ */
+function warnIfThreadTsIsNotString(method, logger, options) {
+    const targetMethods = ['chat.postEphemeral', 'chat.postMessage', 'chat.scheduleMessage', 'files.upload'];
+    const isTargetMethod = targetMethods.includes(method);
+    if (isTargetMethod && (options === null || options === void 0 ? void 0 : options.thread_ts) !== undefined && typeof (options === null || options === void 0 ? void 0 : options.thread_ts) !== 'string') {
+        logger.warn(`The given thread_ts value in the request payload for a ${method} call is a float value. We highly recommend using a string value instead.`);
+    }
+}
 //# sourceMappingURL=WebClient.js.map
 
 /***/ }),
 
-/***/ 9781:
+/***/ 79781:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4402,7 +4442,7 @@ exports.rateLimitedErrorWithDelay = rateLimitedErrorWithDelay;
 
 /***/ }),
 
-/***/ 2500:
+/***/ 92500:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4424,7 +4464,7 @@ exports.delay = delay;
 
 /***/ }),
 
-/***/ 431:
+/***/ 60431:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4445,23 +4485,24 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.addAppMetadata = exports.retryPolicies = exports.ErrorCode = exports.LogLevel = exports.WebClientEvent = exports.WebClient = void 0;
-var WebClient_1 = __nccwpck_require__(1424);
+var WebClient_1 = __nccwpck_require__(61424);
 Object.defineProperty(exports, "WebClient", ({ enumerable: true, get: function () { return WebClient_1.WebClient; } }));
 Object.defineProperty(exports, "WebClientEvent", ({ enumerable: true, get: function () { return WebClient_1.WebClientEvent; } }));
-var logger_1 = __nccwpck_require__(1336);
+var logger_1 = __nccwpck_require__(51336);
 Object.defineProperty(exports, "LogLevel", ({ enumerable: true, get: function () { return logger_1.LogLevel; } }));
-var errors_1 = __nccwpck_require__(9781);
+var errors_1 = __nccwpck_require__(79781);
 Object.defineProperty(exports, "ErrorCode", ({ enumerable: true, get: function () { return errors_1.ErrorCode; } }));
-var retry_policies_1 = __nccwpck_require__(2156);
+var retry_policies_1 = __nccwpck_require__(42156);
 Object.defineProperty(exports, "retryPolicies", ({ enumerable: true, get: function () { return __importDefault(retry_policies_1).default; } }));
-var instrument_1 = __nccwpck_require__(7763);
+var instrument_1 = __nccwpck_require__(27763);
 Object.defineProperty(exports, "addAppMetadata", ({ enumerable: true, get: function () { return instrument_1.addAppMetadata; } }));
-__exportStar(__nccwpck_require__(1571), exports);
+__exportStar(__nccwpck_require__(31571), exports);
+__exportStar(__nccwpck_require__(20677), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 7763:
+/***/ 27763:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4487,8 +4528,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getUserAgent = exports.addAppMetadata = void 0;
-const os = __importStar(__nccwpck_require__(2087));
-const packageJson = __nccwpck_require__(9557); // tslint:disable-line:no-require-imports no-var-requires
+const os = __importStar(__nccwpck_require__(12087));
+const packageJson = __nccwpck_require__(69557); // tslint:disable-line:no-require-imports no-var-requires
 /**
  * Replaces occurrences of '/' with ':' in a string, since '/' is meaningful inside User-Agent strings as a separator.
  */
@@ -4521,15 +4562,15 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 1336:
+/***/ 51336:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getLogger = exports.LogLevel = void 0;
-const logger_1 = __nccwpck_require__(2704);
-var logger_2 = __nccwpck_require__(2704);
+const logger_1 = __nccwpck_require__(32704);
+var logger_2 = __nccwpck_require__(32704);
 Object.defineProperty(exports, "LogLevel", ({ enumerable: true, get: function () { return logger_2.LogLevel; } }));
 let instanceCount = 0;
 /**
@@ -4557,7 +4598,7 @@ exports.getLogger = getLogger;
 
 /***/ }),
 
-/***/ 1571:
+/***/ 31571:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4574,8 +4615,8 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.cursorPaginationEnabledMethods = exports.Methods = void 0;
-const WebClient_1 = __nccwpck_require__(1424);
-const eventemitter3_1 = __nccwpck_require__(1848);
+const WebClient_1 = __nccwpck_require__(61424);
+const eventemitter3_1 = __nccwpck_require__(11848);
 // NOTE: could create a named type alias like data types like `SlackUserID: string`
 /**
  * Binds a certain `method` and its arguments and result types to the `apiCall` method in `WebClient`.
@@ -4599,11 +4640,13 @@ class Methods extends eventemitter3_1.EventEmitter {
     constructor() {
         super();
         this.admin = {
+            // TODO: admin.analytics.getFile
             apps: {
                 approve: bindApiCall(this, 'admin.apps.approve'),
                 approved: {
                     list: bindApiCall(this, 'admin.apps.approved.list'),
                 },
+                clearResolution: bindApiCall(this, 'admin.apps.clearResolution'),
                 requests: {
                     list: bindApiCall(this, 'admin.apps.requests.list'),
                 },
@@ -4611,6 +4654,7 @@ class Methods extends eventemitter3_1.EventEmitter {
                 restricted: {
                     list: bindApiCall(this, 'admin.apps.restricted.list'),
                 },
+                uninstall: bindApiCall(this, 'admin.apps.uninstall'),
             },
             barriers: {
                 create: bindApiCall(this, 'admin.barriers.create'),
@@ -4692,6 +4736,9 @@ class Methods extends eventemitter3_1.EventEmitter {
                     list: bindApiCall(this, 'admin.users.session.list'),
                     reset: bindApiCall(this, 'admin.users.session.reset'),
                     invalidate: bindApiCall(this, 'admin.users.session.invalidate'),
+                    getSettings: bindApiCall(this, 'admin.users.session.getSettings'),
+                    setSettings: bindApiCall(this, 'admin.users.session.setSettings'),
+                    clearSettings: bindApiCall(this, 'admin.users.session.clearSettings'),
                 },
                 setAdmin: bindApiCall(this, 'admin.users.setAdmin'),
                 setExpiration: bindApiCall(this, 'admin.users.setExpiration'),
@@ -4733,23 +4780,6 @@ class Methods extends eventemitter3_1.EventEmitter {
                 remove: bindApiCall(this, 'calls.participants.remove'),
             },
         };
-        this.channels = {
-            archive: bindApiCall(this, 'channels.archive'),
-            create: bindApiCall(this, 'channels.create'),
-            history: bindApiCall(this, 'channels.history'),
-            info: bindApiCall(this, 'channels.info'),
-            invite: bindApiCall(this, 'channels.invite'),
-            join: bindApiCall(this, 'channels.join'),
-            kick: bindApiCall(this, 'channels.kick'),
-            leave: bindApiCall(this, 'channels.leave'),
-            list: bindApiCall(this, 'channels.list'),
-            mark: bindApiCall(this, 'channels.mark'),
-            rename: bindApiCall(this, 'channels.rename'),
-            replies: bindApiCall(this, 'channels.replies'),
-            setPurpose: bindApiCall(this, 'channels.setPurpose'),
-            setTopic: bindApiCall(this, 'channels.setTopic'),
-            unarchive: bindApiCall(this, 'channels.unarchive'),
-        };
         this.chat = {
             delete: bindApiCall(this, 'chat.delete'),
             deleteScheduledMessage: bindApiCall(this, 'chat.deleteScheduledMessage'),
@@ -4784,12 +4814,6 @@ class Methods extends eventemitter3_1.EventEmitter {
             setTopic: bindApiCall(this, 'conversations.setTopic'),
             unarchive: bindApiCall(this, 'conversations.unarchive'),
         };
-        this.views = {
-            open: bindApiCall(this, 'views.open'),
-            publish: bindApiCall(this, 'views.publish'),
-            push: bindApiCall(this, 'views.push'),
-            update: bindApiCall(this, 'views.update'),
-        };
         this.dialog = {
             open: bindApiCall(this, 'dialog.open'),
         };
@@ -4822,42 +4846,8 @@ class Methods extends eventemitter3_1.EventEmitter {
                 share: bindApiCall(this, 'files.remote.share'),
             },
         };
-        this.groups = {
-            archive: bindApiCall(this, 'groups.archive'),
-            create: bindApiCall(this, 'groups.create'),
-            createChild: bindApiCall(this, 'groups.createChild'),
-            history: bindApiCall(this, 'groups.history'),
-            info: bindApiCall(this, 'groups.info'),
-            invite: bindApiCall(this, 'groups.invite'),
-            kick: bindApiCall(this, 'groups.kick'),
-            leave: bindApiCall(this, 'groups.leave'),
-            list: bindApiCall(this, 'groups.list'),
-            mark: bindApiCall(this, 'groups.mark'),
-            open: bindApiCall(this, 'groups.open'),
-            rename: bindApiCall(this, 'groups.rename'),
-            replies: bindApiCall(this, 'groups.replies'),
-            setPurpose: bindApiCall(this, 'groups.setPurpose'),
-            setTopic: bindApiCall(this, 'groups.setTopic'),
-            unarchive: bindApiCall(this, 'groups.unarchive'),
-        };
-        this.im = {
-            close: bindApiCall(this, 'im.close'),
-            history: bindApiCall(this, 'im.history'),
-            list: bindApiCall(this, 'im.list'),
-            mark: bindApiCall(this, 'im.mark'),
-            open: bindApiCall(this, 'im.open'),
-            replies: bindApiCall(this, 'im.replies'),
-        };
         this.migration = {
             exchange: bindApiCall(this, 'migration.exchange'),
-        };
-        this.mpim = {
-            close: bindApiCall(this, 'mpim.close'),
-            history: bindApiCall(this, 'mpim.history'),
-            list: bindApiCall(this, 'mpim.list'),
-            mark: bindApiCall(this, 'mpim.mark'),
-            open: bindApiCall(this, 'mpim.open'),
-            replies: bindApiCall(this, 'mpim.replies'),
         };
         this.oauth = {
             access: bindApiCall(this, 'oauth.access'),
@@ -4932,10 +4922,70 @@ class Methods extends eventemitter3_1.EventEmitter {
                 set: bindApiCall(this, 'users.profile.set'),
             },
         };
+        this.views = {
+            open: bindApiCall(this, 'views.open'),
+            publish: bindApiCall(this, 'views.publish'),
+            push: bindApiCall(this, 'views.push'),
+            update: bindApiCall(this, 'views.update'),
+        };
         this.workflows = {
             stepCompleted: bindApiCall(this, 'workflows.stepCompleted'),
             stepFailed: bindApiCall(this, 'workflows.stepFailed'),
             updateStep: bindApiCall(this, 'workflows.updateStep'),
+        };
+        // ---------------------------------
+        // Deprecated methods
+        // ---------------------------------
+        this.channels = {
+            archive: bindApiCall(this, 'channels.archive'),
+            create: bindApiCall(this, 'channels.create'),
+            history: bindApiCall(this, 'channels.history'),
+            info: bindApiCall(this, 'channels.info'),
+            invite: bindApiCall(this, 'channels.invite'),
+            join: bindApiCall(this, 'channels.join'),
+            kick: bindApiCall(this, 'channels.kick'),
+            leave: bindApiCall(this, 'channels.leave'),
+            list: bindApiCall(this, 'channels.list'),
+            mark: bindApiCall(this, 'channels.mark'),
+            rename: bindApiCall(this, 'channels.rename'),
+            replies: bindApiCall(this, 'channels.replies'),
+            setPurpose: bindApiCall(this, 'channels.setPurpose'),
+            setTopic: bindApiCall(this, 'channels.setTopic'),
+            unarchive: bindApiCall(this, 'channels.unarchive'),
+        };
+        this.groups = {
+            archive: bindApiCall(this, 'groups.archive'),
+            create: bindApiCall(this, 'groups.create'),
+            createChild: bindApiCall(this, 'groups.createChild'),
+            history: bindApiCall(this, 'groups.history'),
+            info: bindApiCall(this, 'groups.info'),
+            invite: bindApiCall(this, 'groups.invite'),
+            kick: bindApiCall(this, 'groups.kick'),
+            leave: bindApiCall(this, 'groups.leave'),
+            list: bindApiCall(this, 'groups.list'),
+            mark: bindApiCall(this, 'groups.mark'),
+            open: bindApiCall(this, 'groups.open'),
+            rename: bindApiCall(this, 'groups.rename'),
+            replies: bindApiCall(this, 'groups.replies'),
+            setPurpose: bindApiCall(this, 'groups.setPurpose'),
+            setTopic: bindApiCall(this, 'groups.setTopic'),
+            unarchive: bindApiCall(this, 'groups.unarchive'),
+        };
+        this.im = {
+            close: bindApiCall(this, 'im.close'),
+            history: bindApiCall(this, 'im.history'),
+            list: bindApiCall(this, 'im.list'),
+            mark: bindApiCall(this, 'im.mark'),
+            open: bindApiCall(this, 'im.open'),
+            replies: bindApiCall(this, 'im.replies'),
+        };
+        this.mpim = {
+            close: bindApiCall(this, 'mpim.close'),
+            history: bindApiCall(this, 'mpim.history'),
+            list: bindApiCall(this, 'mpim.list'),
+            mark: bindApiCall(this, 'mpim.mark'),
+            open: bindApiCall(this, 'mpim.open'),
+            replies: bindApiCall(this, 'mpim.replies'),
         };
         // Check that the class being created extends from `WebClient` rather than this class
         if (new.target !== WebClient_1.WebClient && !(new.target.prototype instanceof WebClient_1.WebClient)) {
@@ -4981,12 +5031,22 @@ exports.cursorPaginationEnabledMethods.add('reactions.list');
 exports.cursorPaginationEnabledMethods.add('stars.list');
 exports.cursorPaginationEnabledMethods.add('users.conversations');
 exports.cursorPaginationEnabledMethods.add('users.list');
-__exportStar(__nccwpck_require__(4380), exports);
+__exportStar(__nccwpck_require__(54380), exports);
 //# sourceMappingURL=methods.js.map
 
 /***/ }),
 
-/***/ 2156:
+/***/ 20677:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 42156:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5027,21 +5087,21 @@ exports.default = policies;
 
 /***/ }),
 
-/***/ 4941:
+/***/ 64941:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 var compileSchema = __nccwpck_require__(875)
-  , resolve = __nccwpck_require__(3896)
-  , Cache = __nccwpck_require__(3679)
-  , SchemaObject = __nccwpck_require__(7605)
-  , stableStringify = __nccwpck_require__(969)
-  , formats = __nccwpck_require__(6627)
-  , rules = __nccwpck_require__(8561)
-  , $dataMetaSchema = __nccwpck_require__(1412)
-  , util = __nccwpck_require__(6578);
+  , resolve = __nccwpck_require__(63896)
+  , Cache = __nccwpck_require__(93679)
+  , SchemaObject = __nccwpck_require__(37605)
+  , stableStringify = __nccwpck_require__(30969)
+  , formats = __nccwpck_require__(66627)
+  , rules = __nccwpck_require__(68561)
+  , $dataMetaSchema = __nccwpck_require__(21412)
+  , util = __nccwpck_require__(76578);
 
 module.exports = Ajv;
 
@@ -5058,14 +5118,14 @@ Ajv.prototype.errorsText = errorsText;
 Ajv.prototype._addSchema = _addSchema;
 Ajv.prototype._compile = _compile;
 
-Ajv.prototype.compileAsync = __nccwpck_require__(890);
-var customKeyword = __nccwpck_require__(3297);
+Ajv.prototype.compileAsync = __nccwpck_require__(80890);
+var customKeyword = __nccwpck_require__(53297);
 Ajv.prototype.addKeyword = customKeyword.add;
 Ajv.prototype.getKeyword = customKeyword.get;
 Ajv.prototype.removeKeyword = customKeyword.remove;
 Ajv.prototype.validateKeyword = customKeyword.validate;
 
-var errorClasses = __nccwpck_require__(5726);
+var errorClasses = __nccwpck_require__(25726);
 Ajv.ValidationError = errorClasses.Validation;
 Ajv.MissingRefError = errorClasses.MissingRef;
 Ajv.$dataMetaSchema = $dataMetaSchema;
@@ -5474,11 +5534,11 @@ function addFormat(name, format) {
 function addDefaultMetaSchema(self) {
   var $dataSchema;
   if (self._opts.$data) {
-    $dataSchema = __nccwpck_require__(6835);
+    $dataSchema = __nccwpck_require__(66835);
     self.addMetaSchema($dataSchema, $dataSchema.$id, true);
   }
   if (self._opts.meta === false) return;
-  var metaSchema = __nccwpck_require__(38);
+  var metaSchema = __nccwpck_require__(40038);
   if (self._opts.$data) metaSchema = $dataMetaSchema(metaSchema, META_SUPPORT_DATA);
   self.addMetaSchema(metaSchema, META_SCHEMA_ID, true);
   self._refs['http://json-schema.org/schema'] = META_SCHEMA_ID;
@@ -5541,7 +5601,7 @@ function noop() {}
 
 /***/ }),
 
-/***/ 3679:
+/***/ 93679:
 /***/ ((module) => {
 
 "use strict";
@@ -5575,13 +5635,13 @@ Cache.prototype.clear = function Cache_clear() {
 
 /***/ }),
 
-/***/ 890:
+/***/ 80890:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var MissingRefError = __nccwpck_require__(5726).MissingRef;
+var MissingRefError = __nccwpck_require__(25726).MissingRef;
 
 module.exports = compileAsync;
 
@@ -5673,13 +5733,13 @@ function compileAsync(schema, meta, callback) {
 
 /***/ }),
 
-/***/ 5726:
+/***/ 25726:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var resolve = __nccwpck_require__(3896);
+var resolve = __nccwpck_require__(63896);
 
 module.exports = {
   Validation: errorSubclass(ValidationError),
@@ -5715,13 +5775,13 @@ function errorSubclass(Subclass) {
 
 /***/ }),
 
-/***/ 6627:
+/***/ 66627:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var util = __nccwpck_require__(6578);
+var util = __nccwpck_require__(76578);
 
 var DATE = /^(\d\d\d\d)-(\d\d)-(\d\d)$/;
 var DAYS = [0,31,28,31,30,31,30,31,31,30,31,30,31];
@@ -5871,19 +5931,19 @@ function regex(str) {
 "use strict";
 
 
-var resolve = __nccwpck_require__(3896)
-  , util = __nccwpck_require__(6578)
-  , errorClasses = __nccwpck_require__(5726)
-  , stableStringify = __nccwpck_require__(969);
+var resolve = __nccwpck_require__(63896)
+  , util = __nccwpck_require__(76578)
+  , errorClasses = __nccwpck_require__(25726)
+  , stableStringify = __nccwpck_require__(30969);
 
-var validateGenerator = __nccwpck_require__(9585);
+var validateGenerator = __nccwpck_require__(49585);
 
 /**
  * Functions below are used inside compiled validations function
  */
 
 var ucs2length = util.ucs2length;
-var equal = __nccwpck_require__(8206);
+var equal = __nccwpck_require__(28206);
 
 // this error is thrown by async schemas to return validation errors via exception
 var ValidationError = errorClasses.Validation;
@@ -6260,17 +6320,17 @@ function vars(arr, statement) {
 
 /***/ }),
 
-/***/ 3896:
+/***/ 63896:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var URI = __nccwpck_require__(20)
-  , equal = __nccwpck_require__(8206)
-  , util = __nccwpck_require__(6578)
-  , SchemaObject = __nccwpck_require__(7605)
-  , traverse = __nccwpck_require__(2533);
+var URI = __nccwpck_require__(70020)
+  , equal = __nccwpck_require__(28206)
+  , util = __nccwpck_require__(76578)
+  , SchemaObject = __nccwpck_require__(37605)
+  , traverse = __nccwpck_require__(52533);
 
 module.exports = resolve;
 
@@ -6538,14 +6598,14 @@ function resolveIds(schema) {
 
 /***/ }),
 
-/***/ 8561:
+/***/ 68561:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var ruleModules = __nccwpck_require__(5810)
-  , toHash = __nccwpck_require__(6578).toHash;
+var ruleModules = __nccwpck_require__(85810)
+  , toHash = __nccwpck_require__(76578).toHash;
 
 module.exports = function rules() {
   var RULES = [
@@ -6612,13 +6672,13 @@ module.exports = function rules() {
 
 /***/ }),
 
-/***/ 7605:
+/***/ 37605:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var util = __nccwpck_require__(6578);
+var util = __nccwpck_require__(76578);
 
 module.exports = SchemaObject;
 
@@ -6629,7 +6689,7 @@ function SchemaObject(obj) {
 
 /***/ }),
 
-/***/ 4580:
+/***/ 64580:
 /***/ ((module) => {
 
 "use strict";
@@ -6657,7 +6717,7 @@ module.exports = function ucs2length(str) {
 
 /***/ }),
 
-/***/ 6578:
+/***/ 76578:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6672,8 +6732,8 @@ module.exports = {
   toHash: toHash,
   getProperty: getProperty,
   escapeQuotes: escapeQuotes,
-  equal: __nccwpck_require__(8206),
-  ucs2length: __nccwpck_require__(4580),
+  equal: __nccwpck_require__(28206),
+  ucs2length: __nccwpck_require__(64580),
   varOccurences: varOccurences,
   varReplace: varReplace,
   schemaHasRules: schemaHasRules,
@@ -6904,7 +6964,7 @@ function unescapeJsonPointer(str) {
 
 /***/ }),
 
-/***/ 1412:
+/***/ 21412:
 /***/ ((module) => {
 
 "use strict";
@@ -6961,13 +7021,13 @@ module.exports = function (metaSchema, keywordsJsonPointers) {
 
 /***/ }),
 
-/***/ 458:
+/***/ 10458:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var metaSchema = __nccwpck_require__(38);
+var metaSchema = __nccwpck_require__(40038);
 
 module.exports = {
   $id: 'https://github.com/ajv-validator/ajv/blob/master/lib/definition_schema.js',
@@ -7177,7 +7237,7 @@ module.exports = function generate__limit(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 4683:
+/***/ 64683:
 /***/ ((module) => {
 
 "use strict";
@@ -7265,7 +7325,7 @@ module.exports = function generate__limitItems(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 8048:
+/***/ 52114:
 /***/ ((module) => {
 
 "use strict";
@@ -7358,7 +7418,7 @@ module.exports = function generate__limitLength(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 1142:
+/***/ 71142:
 /***/ ((module) => {
 
 "use strict";
@@ -7446,7 +7506,7 @@ module.exports = function generate__limitProperties(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 9443:
+/***/ 89443:
 /***/ ((module) => {
 
 "use strict";
@@ -7496,7 +7556,7 @@ module.exports = function generate_allOf(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 3093:
+/***/ 63093:
 /***/ ((module) => {
 
 "use strict";
@@ -7577,7 +7637,7 @@ module.exports = function generate_anyOf(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 134:
+/***/ 30134:
 /***/ ((module) => {
 
 "use strict";
@@ -7663,7 +7723,7 @@ module.exports = function generate_const(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 5964:
+/***/ 55964:
 /***/ ((module) => {
 
 "use strict";
@@ -8164,7 +8224,7 @@ module.exports = function generate_dependencies(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 163:
+/***/ 10163:
 /***/ ((module) => {
 
 "use strict";
@@ -8238,7 +8298,7 @@ module.exports = function generate_enum(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 3847:
+/***/ 63847:
 /***/ ((module) => {
 
 "use strict";
@@ -8396,7 +8456,7 @@ module.exports = function generate_format(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 862:
+/***/ 80862:
 /***/ ((module) => {
 
 "use strict";
@@ -8507,7 +8567,7 @@ module.exports = function generate_if(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 5810:
+/***/ 85810:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -8515,40 +8575,40 @@ module.exports = function generate_if(it, $keyword, $ruleType) {
 
 //all requires must be explicit because browserify won't work with dynamic requires
 module.exports = {
-  '$ref': __nccwpck_require__(2393),
-  allOf: __nccwpck_require__(9443),
-  anyOf: __nccwpck_require__(3093),
-  '$comment': __nccwpck_require__(134),
+  '$ref': __nccwpck_require__(42393),
+  allOf: __nccwpck_require__(89443),
+  anyOf: __nccwpck_require__(63093),
+  '$comment': __nccwpck_require__(30134),
   const: __nccwpck_require__(1661),
-  contains: __nccwpck_require__(5964),
+  contains: __nccwpck_require__(55964),
   dependencies: __nccwpck_require__(2591),
-  'enum': __nccwpck_require__(163),
-  format: __nccwpck_require__(3847),
-  'if': __nccwpck_require__(862),
-  items: __nccwpck_require__(4408),
+  'enum': __nccwpck_require__(10163),
+  format: __nccwpck_require__(63847),
+  'if': __nccwpck_require__(80862),
+  items: __nccwpck_require__(54408),
   maximum: __nccwpck_require__(7404),
   minimum: __nccwpck_require__(7404),
-  maxItems: __nccwpck_require__(4683),
-  minItems: __nccwpck_require__(4683),
-  maxLength: __nccwpck_require__(8048),
-  minLength: __nccwpck_require__(8048),
-  maxProperties: __nccwpck_require__(1142),
-  minProperties: __nccwpck_require__(1142),
-  multipleOf: __nccwpck_require__(9772),
-  not: __nccwpck_require__(750),
+  maxItems: __nccwpck_require__(64683),
+  minItems: __nccwpck_require__(64683),
+  maxLength: __nccwpck_require__(52114),
+  minLength: __nccwpck_require__(52114),
+  maxProperties: __nccwpck_require__(71142),
+  minProperties: __nccwpck_require__(71142),
+  multipleOf: __nccwpck_require__(39772),
+  not: __nccwpck_require__(60750),
   oneOf: __nccwpck_require__(6106),
-  pattern: __nccwpck_require__(818),
-  properties: __nccwpck_require__(2924),
-  propertyNames: __nccwpck_require__(9195),
+  pattern: __nccwpck_require__(13912),
+  properties: __nccwpck_require__(52924),
+  propertyNames: __nccwpck_require__(19195),
   required: __nccwpck_require__(8420),
-  uniqueItems: __nccwpck_require__(4995),
-  validate: __nccwpck_require__(9585)
+  uniqueItems: __nccwpck_require__(24995),
+  validate: __nccwpck_require__(49585)
 };
 
 
 /***/ }),
 
-/***/ 4408:
+/***/ 54408:
 /***/ ((module) => {
 
 "use strict";
@@ -8696,7 +8756,7 @@ module.exports = function generate_items(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 9772:
+/***/ 39772:
 /***/ ((module) => {
 
 "use strict";
@@ -8784,7 +8844,7 @@ module.exports = function generate_multipleOf(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 750:
+/***/ 60750:
 /***/ ((module) => {
 
 "use strict";
@@ -8957,7 +9017,7 @@ module.exports = function generate_oneOf(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 818:
+/***/ 13912:
 /***/ ((module) => {
 
 "use strict";
@@ -9040,7 +9100,7 @@ module.exports = function generate_pattern(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 2924:
+/***/ 52924:
 /***/ ((module) => {
 
 "use strict";
@@ -9383,7 +9443,7 @@ module.exports = function generate_properties(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 9195:
+/***/ 19195:
 /***/ ((module) => {
 
 "use strict";
@@ -9472,7 +9532,7 @@ module.exports = function generate_propertyNames(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 2393:
+/***/ 42393:
 /***/ ((module) => {
 
 "use strict";
@@ -9882,7 +9942,7 @@ module.exports = function generate_required(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 4995:
+/***/ 24995:
 /***/ ((module) => {
 
 "use strict";
@@ -9976,7 +10036,7 @@ module.exports = function generate_uniqueItems(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 9585:
+/***/ 49585:
 /***/ ((module) => {
 
 "use strict";
@@ -10466,7 +10526,7 @@ module.exports = function generate_validate(it, $keyword, $ruleType) {
 
 /***/ }),
 
-/***/ 3297:
+/***/ 53297:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10474,7 +10534,7 @@ module.exports = function generate_validate(it, $keyword, $ruleType) {
 
 var IDENTIFIER = /^[a-z_$][a-z0-9_$-]*$/i;
 var customRuleCode = __nccwpck_require__(5912);
-var definitionSchema = __nccwpck_require__(458);
+var definitionSchema = __nccwpck_require__(10458);
 
 module.exports = {
   add: addKeyword,
@@ -10620,7 +10680,7 @@ function validateKeyword(definition, throwError) {
 
 /***/ }),
 
-/***/ 9348:
+/***/ 99348:
 /***/ ((module) => {
 
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
@@ -10645,11 +10705,11 @@ module.exports = {
 
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
 
-var errors = __nccwpck_require__(9348);
-var types = __nccwpck_require__(2473);
+var errors = __nccwpck_require__(99348);
+var types = __nccwpck_require__(42473);
 
-var Reader = __nccwpck_require__(290);
-var Writer = __nccwpck_require__(3200);
+var Reader = __nccwpck_require__(20290);
+var Writer = __nccwpck_require__(43200);
 
 
 // --- Exports
@@ -10674,16 +10734,16 @@ for (var e in errors) {
 
 /***/ }),
 
-/***/ 290:
+/***/ 20290:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
 
-var assert = __nccwpck_require__(2357);
-var Buffer = __nccwpck_require__(5118).Buffer;
+var assert = __nccwpck_require__(42357);
+var Buffer = __nccwpck_require__(15118).Buffer;
 
-var ASN1 = __nccwpck_require__(2473);
-var errors = __nccwpck_require__(9348);
+var ASN1 = __nccwpck_require__(42473);
+var errors = __nccwpck_require__(99348);
 
 
 // --- Globals
@@ -10943,7 +11003,7 @@ module.exports = Reader;
 
 /***/ }),
 
-/***/ 2473:
+/***/ 42473:
 /***/ ((module) => {
 
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
@@ -10986,15 +11046,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3200:
+/***/ 43200:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
 
-var assert = __nccwpck_require__(2357);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var ASN1 = __nccwpck_require__(2473);
-var errors = __nccwpck_require__(9348);
+var assert = __nccwpck_require__(42357);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var ASN1 = __nccwpck_require__(42473);
+var errors = __nccwpck_require__(99348);
 
 
 // --- Globals
@@ -11310,7 +11370,7 @@ module.exports = Writer;
 
 /***/ }),
 
-/***/ 970:
+/***/ 80970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
@@ -11337,15 +11397,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6631:
+/***/ 66631:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright (c) 2012, Mark Cavage. All rights reserved.
 // Copyright 2015 Joyent, Inc.
 
-var assert = __nccwpck_require__(2357);
-var Stream = __nccwpck_require__(2413).Stream;
-var util = __nccwpck_require__(1669);
+var assert = __nccwpck_require__(42357);
+var Stream = __nccwpck_require__(92413).Stream;
+var util = __nccwpck_require__(31669);
 
 
 ///--- Globals
@@ -11555,13 +11615,13 @@ module.exports = _setExports(process.env.NODE_NDEBUG);
 
 /***/ }),
 
-/***/ 4812:
+/***/ 14812:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports =
 {
   parallel      : __nccwpck_require__(8210),
-  serial        : __nccwpck_require__(445),
+  serial        : __nccwpck_require__(50445),
   serialOrdered : __nccwpck_require__(3578)
 };
 
@@ -11604,10 +11664,10 @@ function clean(key)
 
 /***/ }),
 
-/***/ 2794:
+/***/ 72794:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var defer = __nccwpck_require__(5295);
+var defer = __nccwpck_require__(15295);
 
 // API
 module.exports = async;
@@ -11645,7 +11705,7 @@ function async(callback)
 
 /***/ }),
 
-/***/ 5295:
+/***/ 15295:
 /***/ ((module) => {
 
 module.exports = defer;
@@ -11681,7 +11741,7 @@ function defer(fn)
 /***/ 9023:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var async = __nccwpck_require__(2794)
+var async = __nccwpck_require__(72794)
   , abort = __nccwpck_require__(1700)
   ;
 
@@ -11760,7 +11820,7 @@ function runJob(iterator, key, item, callback)
 
 /***/ }),
 
-/***/ 2474:
+/***/ 42474:
 /***/ ((module) => {
 
 // API
@@ -11804,11 +11864,11 @@ function state(list, sortMethod)
 
 /***/ }),
 
-/***/ 7942:
+/***/ 37942:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var abort = __nccwpck_require__(1700)
-  , async = __nccwpck_require__(2794)
+  , async = __nccwpck_require__(72794)
   ;
 
 // API
@@ -11844,8 +11904,8 @@ function terminator(callback)
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var iterate    = __nccwpck_require__(9023)
-  , initState  = __nccwpck_require__(2474)
-  , terminator = __nccwpck_require__(7942)
+  , initState  = __nccwpck_require__(42474)
+  , terminator = __nccwpck_require__(37942)
   ;
 
 // Public API
@@ -11890,7 +11950,7 @@ function parallel(list, iterator, callback)
 
 /***/ }),
 
-/***/ 445:
+/***/ 50445:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var serialOrdered = __nccwpck_require__(3578);
@@ -11918,8 +11978,8 @@ function serial(list, iterator, callback)
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var iterate    = __nccwpck_require__(9023)
-  , initState  = __nccwpck_require__(2474)
-  , terminator = __nccwpck_require__(7942)
+  , initState  = __nccwpck_require__(42474)
+  , terminator = __nccwpck_require__(37942)
   ;
 
 // Public API
@@ -11996,7 +12056,7 @@ function descending(a, b)
 
 /***/ }),
 
-/***/ 6342:
+/***/ 96342:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -12020,8 +12080,8 @@ function descending(a, b)
  * Module dependencies.
  */
 
-var crypto = __nccwpck_require__(6417)
-  , parse = __nccwpck_require__(8835).parse
+var crypto = __nccwpck_require__(76417)
+  , parse = __nccwpck_require__(78835).parse
   ;
 
 /**
@@ -12215,14 +12275,14 @@ module.exports.canonicalizeResource = canonicalizeResource
 
 /***/ }),
 
-/***/ 6071:
+/***/ 16071:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 var aws4 = exports,
-    url = __nccwpck_require__(8835),
-    querystring = __nccwpck_require__(1191),
-    crypto = __nccwpck_require__(6417),
-    lru = __nccwpck_require__(4225),
+    url = __nccwpck_require__(78835),
+    querystring = __nccwpck_require__(71191),
+    crypto = __nccwpck_require__(76417),
+    lru = __nccwpck_require__(74225),
     credentialsCache = lru(1000)
 
 // http://docs.amazonwebservices.com/general/latest/gr/signature-version-4.html
@@ -12579,7 +12639,7 @@ aws4.sign = function(request, credentials) {
 
 /***/ }),
 
-/***/ 4225:
+/***/ 74225:
 /***/ ((module) => {
 
 module.exports = function(size) {
@@ -12682,32 +12742,32 @@ function DoublyLinkedNode(key, val) {
 
 /***/ }),
 
-/***/ 6545:
+/***/ 96545:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(2618);
+module.exports = __nccwpck_require__(52618);
 
 /***/ }),
 
-/***/ 8104:
+/***/ 68104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var settle = __nccwpck_require__(3211);
-var buildFullPath = __nccwpck_require__(1934);
-var buildURL = __nccwpck_require__(646);
-var http = __nccwpck_require__(8605);
-var https = __nccwpck_require__(7211);
-var httpFollow = __nccwpck_require__(7707).http;
-var httpsFollow = __nccwpck_require__(7707).https;
-var url = __nccwpck_require__(8835);
-var zlib = __nccwpck_require__(8761);
-var pkg = __nccwpck_require__(696);
-var createError = __nccwpck_require__(5226);
-var enhanceError = __nccwpck_require__(1516);
+var utils = __nccwpck_require__(20328);
+var settle = __nccwpck_require__(13211);
+var buildFullPath = __nccwpck_require__(41934);
+var buildURL = __nccwpck_require__(30646);
+var http = __nccwpck_require__(98605);
+var https = __nccwpck_require__(57211);
+var httpFollow = __nccwpck_require__(67707).http;
+var httpsFollow = __nccwpck_require__(67707).https;
+var url = __nccwpck_require__(78835);
+var zlib = __nccwpck_require__(78761);
+var pkg = __nccwpck_require__(20696);
+var createError = __nccwpck_require__(15226);
+var enhanceError = __nccwpck_require__(21516);
 
 var isHttps = /https:?/;
 
@@ -13006,14 +13066,14 @@ module.exports = function httpAdapter(config) {
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var settle = __nccwpck_require__(3211);
-var cookies = __nccwpck_require__(1545);
-var buildURL = __nccwpck_require__(646);
-var buildFullPath = __nccwpck_require__(1934);
-var parseHeaders = __nccwpck_require__(6455);
-var isURLSameOrigin = __nccwpck_require__(3608);
-var createError = __nccwpck_require__(5226);
+var utils = __nccwpck_require__(20328);
+var settle = __nccwpck_require__(13211);
+var cookies = __nccwpck_require__(21545);
+var buildURL = __nccwpck_require__(30646);
+var buildFullPath = __nccwpck_require__(41934);
+var parseHeaders = __nccwpck_require__(86455);
+var isURLSameOrigin = __nccwpck_require__(33608);
+var createError = __nccwpck_require__(15226);
 
 module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
@@ -13187,17 +13247,17 @@ module.exports = function xhrAdapter(config) {
 
 /***/ }),
 
-/***/ 2618:
+/***/ 52618:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var bind = __nccwpck_require__(7065);
-var Axios = __nccwpck_require__(8178);
-var mergeConfig = __nccwpck_require__(4831);
-var defaults = __nccwpck_require__(8190);
+var utils = __nccwpck_require__(20328);
+var bind = __nccwpck_require__(77065);
+var Axios = __nccwpck_require__(98178);
+var mergeConfig = __nccwpck_require__(74831);
+var defaults = __nccwpck_require__(98190);
 
 /**
  * Create an instance of Axios
@@ -13230,18 +13290,18 @@ axios.create = function create(instanceConfig) {
 };
 
 // Expose Cancel & CancelToken
-axios.Cancel = __nccwpck_require__(8875);
-axios.CancelToken = __nccwpck_require__(1587);
-axios.isCancel = __nccwpck_require__(4057);
+axios.Cancel = __nccwpck_require__(98875);
+axios.CancelToken = __nccwpck_require__(71587);
+axios.isCancel = __nccwpck_require__(64057);
 
 // Expose all/spread
 axios.all = function all(promises) {
   return Promise.all(promises);
 };
-axios.spread = __nccwpck_require__(4850);
+axios.spread = __nccwpck_require__(74850);
 
 // Expose isAxiosError
-axios.isAxiosError = __nccwpck_require__(650);
+axios.isAxiosError = __nccwpck_require__(60650);
 
 module.exports = axios;
 
@@ -13251,7 +13311,7 @@ module.exports.default = axios;
 
 /***/ }),
 
-/***/ 8875:
+/***/ 98875:
 /***/ ((module) => {
 
 "use strict";
@@ -13278,13 +13338,13 @@ module.exports = Cancel;
 
 /***/ }),
 
-/***/ 1587:
+/***/ 71587:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Cancel = __nccwpck_require__(8875);
+var Cancel = __nccwpck_require__(98875);
 
 /**
  * A `CancelToken` is an object that can be used to request cancellation of an operation.
@@ -13343,7 +13403,7 @@ module.exports = CancelToken;
 
 /***/ }),
 
-/***/ 4057:
+/***/ 64057:
 /***/ ((module) => {
 
 "use strict";
@@ -13356,17 +13416,17 @@ module.exports = function isCancel(value) {
 
 /***/ }),
 
-/***/ 8178:
+/***/ 98178:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var buildURL = __nccwpck_require__(646);
+var utils = __nccwpck_require__(20328);
+var buildURL = __nccwpck_require__(30646);
 var InterceptorManager = __nccwpck_require__(3214);
-var dispatchRequest = __nccwpck_require__(5062);
-var mergeConfig = __nccwpck_require__(4831);
+var dispatchRequest = __nccwpck_require__(85062);
+var mergeConfig = __nccwpck_require__(74831);
 
 /**
  * Create a new instance of Axios
@@ -13465,7 +13525,7 @@ module.exports = Axios;
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 function InterceptorManager() {
   this.handlers = [];
@@ -13519,14 +13579,14 @@ module.exports = InterceptorManager;
 
 /***/ }),
 
-/***/ 1934:
+/***/ 41934:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var isAbsoluteURL = __nccwpck_require__(1301);
-var combineURLs = __nccwpck_require__(7189);
+var isAbsoluteURL = __nccwpck_require__(41301);
+var combineURLs = __nccwpck_require__(57189);
 
 /**
  * Creates a new URL by combining the baseURL with the requestedURL,
@@ -13547,13 +13607,13 @@ module.exports = function buildFullPath(baseURL, requestedURL) {
 
 /***/ }),
 
-/***/ 5226:
+/***/ 15226:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var enhanceError = __nccwpck_require__(1516);
+var enhanceError = __nccwpck_require__(21516);
 
 /**
  * Create an Error with the specified message, config, error code, request and response.
@@ -13573,16 +13633,16 @@ module.exports = function createError(message, config, code, request, response) 
 
 /***/ }),
 
-/***/ 5062:
+/***/ 85062:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var transformData = __nccwpck_require__(9812);
-var isCancel = __nccwpck_require__(4057);
-var defaults = __nccwpck_require__(8190);
+var utils = __nccwpck_require__(20328);
+var transformData = __nccwpck_require__(19812);
+var isCancel = __nccwpck_require__(64057);
+var defaults = __nccwpck_require__(98190);
 
 /**
  * Throws a `Cancel` if cancellation has been requested.
@@ -13660,7 +13720,7 @@ module.exports = function dispatchRequest(config) {
 
 /***/ }),
 
-/***/ 1516:
+/***/ 21516:
 /***/ ((module) => {
 
 "use strict";
@@ -13710,13 +13770,13 @@ module.exports = function enhanceError(error, config, code, request, response) {
 
 /***/ }),
 
-/***/ 4831:
+/***/ 74831:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 /**
  * Config-specific merge-function which creates a new config-object
@@ -13805,13 +13865,13 @@ module.exports = function mergeConfig(config1, config2) {
 
 /***/ }),
 
-/***/ 3211:
+/***/ 13211:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var createError = __nccwpck_require__(5226);
+var createError = __nccwpck_require__(15226);
 
 /**
  * Resolve or reject a Promise based on response status.
@@ -13838,13 +13898,13 @@ module.exports = function settle(resolve, reject, response) {
 
 /***/ }),
 
-/***/ 9812:
+/***/ 19812:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 /**
  * Transform the data for a request or a response
@@ -13866,14 +13926,14 @@ module.exports = function transformData(data, headers, fns) {
 
 /***/ }),
 
-/***/ 8190:
+/***/ 98190:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
-var normalizeHeaderName = __nccwpck_require__(6240);
+var utils = __nccwpck_require__(20328);
+var normalizeHeaderName = __nccwpck_require__(36240);
 
 var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
@@ -13892,7 +13952,7 @@ function getDefaultAdapter() {
     adapter = __nccwpck_require__(3454);
   } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
     // For node use HTTP adapter
-    adapter = __nccwpck_require__(8104);
+    adapter = __nccwpck_require__(68104);
   }
   return adapter;
 }
@@ -13972,7 +14032,7 @@ module.exports = defaults;
 
 /***/ }),
 
-/***/ 7065:
+/***/ 77065:
 /***/ ((module) => {
 
 "use strict";
@@ -13991,13 +14051,13 @@ module.exports = function bind(fn, thisArg) {
 
 /***/ }),
 
-/***/ 646:
+/***/ 30646:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 function encode(val) {
   return encodeURIComponent(val).
@@ -14069,7 +14129,7 @@ module.exports = function buildURL(url, params, paramsSerializer) {
 
 /***/ }),
 
-/***/ 7189:
+/***/ 57189:
 /***/ ((module) => {
 
 "use strict";
@@ -14091,13 +14151,13 @@ module.exports = function combineURLs(baseURL, relativeURL) {
 
 /***/ }),
 
-/***/ 1545:
+/***/ 21545:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 module.exports = (
   utils.isStandardBrowserEnv() ?
@@ -14152,7 +14212,7 @@ module.exports = (
 
 /***/ }),
 
-/***/ 1301:
+/***/ 41301:
 /***/ ((module) => {
 
 "use strict";
@@ -14174,7 +14234,7 @@ module.exports = function isAbsoluteURL(url) {
 
 /***/ }),
 
-/***/ 650:
+/***/ 60650:
 /***/ ((module) => {
 
 "use strict";
@@ -14193,13 +14253,13 @@ module.exports = function isAxiosError(payload) {
 
 /***/ }),
 
-/***/ 3608:
+/***/ 33608:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 module.exports = (
   utils.isStandardBrowserEnv() ?
@@ -14269,13 +14329,13 @@ module.exports = (
 
 /***/ }),
 
-/***/ 6240:
+/***/ 36240:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 module.exports = function normalizeHeaderName(headers, normalizedName) {
   utils.forEach(headers, function processHeader(value, name) {
@@ -14289,13 +14349,13 @@ module.exports = function normalizeHeaderName(headers, normalizedName) {
 
 /***/ }),
 
-/***/ 6455:
+/***/ 86455:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(328);
+var utils = __nccwpck_require__(20328);
 
 // Headers whose duplicates are ignored by node
 // c.f. https://nodejs.org/api/http.html#http_message_headers
@@ -14350,7 +14410,7 @@ module.exports = function parseHeaders(headers) {
 
 /***/ }),
 
-/***/ 4850:
+/***/ 74850:
 /***/ ((module) => {
 
 "use strict";
@@ -14385,13 +14445,13 @@ module.exports = function spread(callback) {
 
 /***/ }),
 
-/***/ 328:
+/***/ 20328:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var bind = __nccwpck_require__(7065);
+var bind = __nccwpck_require__(77065);
 
 /*global toString:true*/
 
@@ -14744,13 +14804,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 958:
+/***/ 45447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var crypto_hash_sha512 = __nccwpck_require__(8729).lowlevel.crypto_hash;
+var crypto_hash_sha512 = __nccwpck_require__(68729).lowlevel.crypto_hash;
 
 /*
  * This file is a 1:1 port from the OpenBSD blowfish.c and bcrypt_pbkdf.c. As a
@@ -15308,10 +15368,10 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3682:
+/***/ 83682:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(4670)
+var register = __nccwpck_require__(44670)
 var addHook = __nccwpck_require__(5549)
 var removeHook = __nccwpck_require__(6819)
 
@@ -15425,7 +15485,7 @@ function addHook (state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 4670:
+/***/ 44670:
 /***/ ((module) => {
 
 module.exports = register
@@ -15484,7 +15544,7 @@ function removeHook (state, name, method) {
 
 /***/ }),
 
-/***/ 5490:
+/***/ 35490:
 /***/ ((module) => {
 
 "use strict";
@@ -15513,15 +15573,15 @@ Promise.prototype.any = function () {
 
 /***/ }),
 
-/***/ 8061:
+/***/ 38061:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 var firstLineError;
 try {throw new Error(); } catch (e) {firstLineError = e;}
-var schedule = __nccwpck_require__(6203);
-var Queue = __nccwpck_require__(878);
+var schedule = __nccwpck_require__(76203);
+var Queue = __nccwpck_require__(30878);
 
 function Async() {
     this._customScheduler = false;
@@ -15641,7 +15701,7 @@ module.exports.firstLineError = firstLineError;
 
 /***/ }),
 
-/***/ 3767:
+/***/ 13767:
 /***/ ((module) => {
 
 "use strict";
@@ -15716,7 +15776,7 @@ Promise.bind = function (thisArg, value) {
 
 /***/ }),
 
-/***/ 8710:
+/***/ 78710:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15728,14 +15788,14 @@ function noConflict() {
     catch (e) {}
     return bluebird;
 }
-var bluebird = __nccwpck_require__(3694)();
+var bluebird = __nccwpck_require__(63694)();
 bluebird.noConflict = noConflict;
 module.exports = bluebird;
 
 
 /***/ }),
 
-/***/ 924:
+/***/ 70924:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15748,7 +15808,7 @@ if (cr) {
 }
 
 module.exports = function(Promise) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var canEvaluate = util.canEvaluate;
 var isIdentifier = util.isIdentifier;
 
@@ -15872,7 +15932,7 @@ Promise.prototype.get = function (propertyName) {
 "use strict";
 
 module.exports = function(Promise, PromiseArray, apiRejection, debug) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var tryCatch = util.tryCatch;
 var errorObj = util.errorObj;
 var async = Promise._async;
@@ -16009,8 +16069,8 @@ Promise.prototype._resultCancelled = function() {
 "use strict";
 
 module.exports = function(NEXT_FILTER) {
-var util = __nccwpck_require__(7448);
-var getKeys = __nccwpck_require__(3062).keys;
+var util = __nccwpck_require__(37448);
+var getKeys = __nccwpck_require__(43062).keys;
 var tryCatch = util.tryCatch;
 var errorObj = util.errorObj;
 
@@ -16053,7 +16113,7 @@ return catchFilter;
 
 /***/ }),
 
-/***/ 5422:
+/***/ 65422:
 /***/ ((module) => {
 
 "use strict";
@@ -16130,7 +16190,7 @@ return Context;
 
 /***/ }),
 
-/***/ 6004:
+/***/ 26004:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16138,9 +16198,9 @@ return Context;
 module.exports = function(Promise, Context,
     enableAsyncHooks, disableAsyncHooks) {
 var async = Promise._async;
-var Warning = __nccwpck_require__(5816).Warning;
-var util = __nccwpck_require__(7448);
-var es5 = __nccwpck_require__(3062);
+var Warning = __nccwpck_require__(35816).Warning;
+var util = __nccwpck_require__(37448);
+var es5 = __nccwpck_require__(43062);
 var canAttachTrace = util.canAttachTrace;
 var unhandledRejectionHandled;
 var possiblyUnhandledRejection;
@@ -17201,7 +17261,7 @@ Promise.prototype.catchReturn = function (value) {
 
 /***/ }),
 
-/***/ 838:
+/***/ 90838:
 /***/ ((module) => {
 
 "use strict";
@@ -17239,14 +17299,14 @@ Promise.mapSeries = PromiseMapSeries;
 
 /***/ }),
 
-/***/ 5816:
+/***/ 35816:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-var es5 = __nccwpck_require__(3062);
+var es5 = __nccwpck_require__(43062);
 var Objectfreeze = es5.freeze;
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var inherits = util.inherits;
 var notEnumerableProp = util.notEnumerableProp;
 
@@ -17363,7 +17423,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3062:
+/***/ 43062:
 /***/ ((module) => {
 
 var isES5 = (function(){
@@ -17450,7 +17510,7 @@ if (isES5) {
 
 /***/ }),
 
-/***/ 2223:
+/***/ 42223:
 /***/ ((module) => {
 
 "use strict";
@@ -17470,13 +17530,13 @@ Promise.filter = function (promises, fn, options) {
 
 /***/ }),
 
-/***/ 7304:
+/***/ 57304:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(Promise, tryConvertToPromise, NEXT_FILTER) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var CancellationError = Promise.CancellationError;
 var errorObj = util.errorObj;
 var catchFilter = __nccwpck_require__(8985)(NEXT_FILTER);
@@ -17624,7 +17684,7 @@ return PassThroughHandlerContext;
 
 /***/ }),
 
-/***/ 8619:
+/***/ 28619:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17635,9 +17695,9 @@ module.exports = function(Promise,
                           tryConvertToPromise,
                           Proxyable,
                           debug) {
-var errors = __nccwpck_require__(5816);
+var errors = __nccwpck_require__(35816);
 var TypeError = errors.TypeError;
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var errorObj = util.errorObj;
 var tryCatch = util.tryCatch;
 var yieldHandlers = [];
@@ -17855,14 +17915,14 @@ Promise.spawn = function (generatorFunction) {
 
 /***/ }),
 
-/***/ 5248:
+/***/ 25248:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports =
 function(Promise, PromiseArray, tryConvertToPromise, INTERNAL, async) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var canEvaluate = util.canEvaluate;
 var tryCatch = util.tryCatch;
 var errorObj = util.errorObj;
@@ -18028,7 +18088,7 @@ Promise.join = function () {
 
 /***/ }),
 
-/***/ 8150:
+/***/ 98150:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18039,7 +18099,7 @@ module.exports = function(Promise,
                           tryConvertToPromise,
                           INTERNAL,
                           debug) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var tryCatch = util.tryCatch;
 var errorObj = util.errorObj;
 var async = Promise._async;
@@ -18211,14 +18271,14 @@ Promise.map = function (promises, fn, options, _filter) {
 
 /***/ }),
 
-/***/ 7415:
+/***/ 97415:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports =
 function(Promise, INTERNAL, tryConvertToPromise, apiRejection, debug) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var tryCatch = util.tryCatch;
 
 Promise.method = function (fn) {
@@ -18279,11 +18339,11 @@ Promise.prototype._resolveFromSyncValue = function (value) {
 
 "use strict";
 
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var maybeWrapAsError = util.maybeWrapAsError;
-var errors = __nccwpck_require__(5816);
+var errors = __nccwpck_require__(35816);
 var OperationalError = errors.OperationalError;
-var es5 = __nccwpck_require__(3062);
+var es5 = __nccwpck_require__(43062);
 
 function isUntypedError(obj) {
     return obj instanceof Error &&
@@ -18333,13 +18393,13 @@ module.exports = nodebackForPromise;
 
 /***/ }),
 
-/***/ 5447:
+/***/ 35447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(Promise) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var async = Promise._async;
 var tryCatch = util.tryCatch;
 var errorObj = util.errorObj;
@@ -18399,7 +18459,7 @@ Promise.prototype.asCallback = Promise.prototype.nodeify = function (nodeback,
 
 /***/ }),
 
-/***/ 3694:
+/***/ 63694:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18416,7 +18476,7 @@ var apiRejection = function(msg) {
 };
 function Proxyable() {}
 var UNDEFINED_BINDING = {};
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 util.setReflectHandler(reflectHandler);
 
 var getDomain = function() {
@@ -18436,7 +18496,7 @@ var getContextDomain = function() {
     };
 };
 var AsyncResource = util.isNode && util.nodeSupportsAsyncResource ?
-    __nccwpck_require__(7303).AsyncResource : null;
+    __nccwpck_require__(77303).AsyncResource : null;
 var getContextAsyncHooks = function() {
     return {
         domain: getDomain(),
@@ -18454,11 +18514,11 @@ var disableAsyncHooks = function() {
     util.notEnumerableProp(Promise, "_getContext", getContextDomain);
 };
 
-var es5 = __nccwpck_require__(3062);
-var Async = __nccwpck_require__(8061);
+var es5 = __nccwpck_require__(43062);
+var Async = __nccwpck_require__(38061);
 var async = new Async();
 es5.defineProperty(Promise, "_async", {value: async});
-var errors = __nccwpck_require__(5816);
+var errors = __nccwpck_require__(35816);
 var TypeError = Promise.TypeError = errors.TypeError;
 Promise.RangeError = errors.RangeError;
 var CancellationError = Promise.CancellationError = errors.CancellationError;
@@ -18469,19 +18529,19 @@ Promise.AggregateError = errors.AggregateError;
 var INTERNAL = function(){};
 var APPLY = {};
 var NEXT_FILTER = {};
-var tryConvertToPromise = __nccwpck_require__(9787)(Promise, INTERNAL);
+var tryConvertToPromise = __nccwpck_require__(29787)(Promise, INTERNAL);
 var PromiseArray =
-    __nccwpck_require__(5307)(Promise, INTERNAL,
+    __nccwpck_require__(85307)(Promise, INTERNAL,
                                tryConvertToPromise, apiRejection, Proxyable);
-var Context = __nccwpck_require__(5422)(Promise);
+var Context = __nccwpck_require__(65422)(Promise);
  /*jshint unused:false*/
 var createContext = Context.create;
 
-var debug = __nccwpck_require__(6004)(Promise, Context,
+var debug = __nccwpck_require__(26004)(Promise, Context,
     enableAsyncHooks, disableAsyncHooks);
 var CapturedTrace = debug.CapturedTrace;
 var PassThroughHandlerContext =
-    __nccwpck_require__(7304)(Promise, tryConvertToPromise, NEXT_FILTER);
+    __nccwpck_require__(57304)(Promise, tryConvertToPromise, NEXT_FILTER);
 var catchFilter = __nccwpck_require__(8985)(NEXT_FILTER);
 var nodebackForPromise = __nccwpck_require__(4315);
 var errorObj = util.errorObj;
@@ -19173,31 +19233,31 @@ util.notEnumerableProp(Promise,
                        "_makeSelfResolutionError",
                        makeSelfResolutionError);
 
-__nccwpck_require__(7415)(Promise, INTERNAL, tryConvertToPromise, apiRejection,
+__nccwpck_require__(97415)(Promise, INTERNAL, tryConvertToPromise, apiRejection,
     debug);
-__nccwpck_require__(3767)(Promise, INTERNAL, tryConvertToPromise, debug);
+__nccwpck_require__(13767)(Promise, INTERNAL, tryConvertToPromise, debug);
 __nccwpck_require__(6616)(Promise, PromiseArray, apiRejection, debug);
 __nccwpck_require__(8277)(Promise);
-__nccwpck_require__(6653)(Promise);
-__nccwpck_require__(5248)(
+__nccwpck_require__(46653)(Promise);
+__nccwpck_require__(25248)(
     Promise, PromiseArray, tryConvertToPromise, INTERNAL, async);
 Promise.Promise = Promise;
 Promise.version = "3.7.2";
-__nccwpck_require__(924)(Promise);
-__nccwpck_require__(8619)(Promise, apiRejection, INTERNAL, tryConvertToPromise, Proxyable, debug);
-__nccwpck_require__(8150)(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
-__nccwpck_require__(5447)(Promise);
-__nccwpck_require__(3047)(Promise, INTERNAL);
-__nccwpck_require__(5261)(Promise, PromiseArray, tryConvertToPromise, apiRejection);
-__nccwpck_require__(256)(Promise, INTERNAL, tryConvertToPromise, apiRejection);
-__nccwpck_require__(8959)(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
-__nccwpck_require__(6087)(Promise, PromiseArray, debug);
-__nccwpck_require__(1156)(Promise, PromiseArray, apiRejection);
-__nccwpck_require__(2114)(Promise, INTERNAL, debug);
+__nccwpck_require__(70924)(Promise);
+__nccwpck_require__(28619)(Promise, apiRejection, INTERNAL, tryConvertToPromise, Proxyable, debug);
+__nccwpck_require__(98150)(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
+__nccwpck_require__(35447)(Promise);
+__nccwpck_require__(33047)(Promise, INTERNAL);
+__nccwpck_require__(95261)(Promise, PromiseArray, tryConvertToPromise, apiRejection);
+__nccwpck_require__(10256)(Promise, INTERNAL, tryConvertToPromise, apiRejection);
+__nccwpck_require__(48959)(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
+__nccwpck_require__(76087)(Promise, PromiseArray, debug);
+__nccwpck_require__(21156)(Promise, PromiseArray, apiRejection);
+__nccwpck_require__(32114)(Promise, INTERNAL, debug);
 __nccwpck_require__(880)(Promise, apiRejection, tryConvertToPromise, createContext, INTERNAL, debug);
-__nccwpck_require__(5490)(Promise);
-__nccwpck_require__(838)(Promise, INTERNAL);
-__nccwpck_require__(2223)(Promise, INTERNAL);
+__nccwpck_require__(35490)(Promise);
+__nccwpck_require__(90838)(Promise, INTERNAL);
+__nccwpck_require__(42223)(Promise, INTERNAL);
                                                          
     util.toFastProperties(Promise);                                          
     util.toFastProperties(Promise.prototype);                                
@@ -19226,14 +19286,14 @@ __nccwpck_require__(2223)(Promise, INTERNAL);
 
 /***/ }),
 
-/***/ 5307:
+/***/ 85307:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(Promise, INTERNAL, tryConvertToPromise,
     apiRejection, Proxyable) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var isArray = util.isArray;
 
 function toResolutionValue(val) {
@@ -19420,19 +19480,19 @@ return PromiseArray;
 
 /***/ }),
 
-/***/ 3047:
+/***/ 33047:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(Promise, INTERNAL) {
 var THIS = {};
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var nodebackForPromise = __nccwpck_require__(4315);
 var withAppended = util.withAppended;
 var maybeWrapAsError = util.maybeWrapAsError;
 var canEvaluate = util.canEvaluate;
-var TypeError = __nccwpck_require__(5816).TypeError;
+var TypeError = __nccwpck_require__(35816).TypeError;
 var defaultSuffix = "Async";
 var defaultPromisified = {__isPromisified__: true};
 var noCopyProps = [
@@ -19742,16 +19802,16 @@ Promise.promisifyAll = function (target, options) {
 
 /***/ }),
 
-/***/ 5261:
+/***/ 95261:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(
     Promise, PromiseArray, tryConvertToPromise, apiRejection) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var isObject = util.isObject;
-var es5 = __nccwpck_require__(3062);
+var es5 = __nccwpck_require__(43062);
 var Es6Map;
 if (typeof Map === "function") Es6Map = Map;
 
@@ -19868,7 +19928,7 @@ Promise.props = function (promises) {
 
 /***/ }),
 
-/***/ 878:
+/***/ 30878:
 /***/ ((module) => {
 
 "use strict";
@@ -19949,14 +20009,14 @@ module.exports = Queue;
 
 /***/ }),
 
-/***/ 256:
+/***/ 10256:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(
     Promise, INTERNAL, tryConvertToPromise, apiRejection) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 
 var raceLater = function (promise) {
     return promise.then(function(array) {
@@ -20006,7 +20066,7 @@ Promise.prototype.race = function () {
 
 /***/ }),
 
-/***/ 8959:
+/***/ 48959:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20017,7 +20077,7 @@ module.exports = function(Promise,
                           tryConvertToPromise,
                           INTERNAL,
                           debug) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var tryCatch = util.tryCatch;
 
 function ReductionPromiseArray(promises, fn, initialValue, _each) {
@@ -20197,12 +20257,12 @@ function gotValue(value) {
 
 /***/ }),
 
-/***/ 6203:
+/***/ 76203:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var schedule;
 var noAsyncScheduler = function() {
     throw new Error("No async scheduler available\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
@@ -20267,7 +20327,7 @@ module.exports = schedule;
 
 /***/ }),
 
-/***/ 6087:
+/***/ 76087:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20275,7 +20335,7 @@ module.exports = schedule;
 module.exports =
     function(Promise, PromiseArray, debug) {
 var PromiseInspection = Promise.PromiseInspection;
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 
 function SettledPromiseArray(values) {
     this.constructor$(values);
@@ -20322,16 +20382,16 @@ Promise.prototype.settle = function () {
 
 /***/ }),
 
-/***/ 1156:
+/***/ 21156:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports =
 function(Promise, PromiseArray, apiRejection) {
-var util = __nccwpck_require__(7448);
-var RangeError = __nccwpck_require__(5816).RangeError;
-var AggregateError = __nccwpck_require__(5816).AggregateError;
+var util = __nccwpck_require__(37448);
+var RangeError = __nccwpck_require__(35816).RangeError;
+var AggregateError = __nccwpck_require__(35816).AggregateError;
 var isArray = util.isArray;
 var CANCELLATION = {};
 
@@ -20478,7 +20538,7 @@ Promise._SomePromiseArray = SomePromiseArray;
 
 /***/ }),
 
-/***/ 6653:
+/***/ 46653:
 /***/ ((module) => {
 
 "use strict";
@@ -20589,13 +20649,13 @@ Promise.PromiseInspection = PromiseInspection;
 
 /***/ }),
 
-/***/ 9787:
+/***/ 29787:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(Promise, INTERNAL) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var errorObj = util.errorObj;
 var isObject = util.isObject;
 
@@ -20683,13 +20743,13 @@ return tryConvertToPromise;
 
 /***/ }),
 
-/***/ 2114:
+/***/ 32114:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 module.exports = function(Promise, INTERNAL, debug) {
-var util = __nccwpck_require__(7448);
+var util = __nccwpck_require__(37448);
 var TimeoutError = Promise.TimeoutError;
 
 function HandleWrapper(handle)  {
@@ -20791,9 +20851,9 @@ Promise.prototype.timeout = function (ms, message) {
 
 module.exports = function (Promise, apiRejection, tryConvertToPromise,
     createContext, INTERNAL, debug) {
-    var util = __nccwpck_require__(7448);
-    var TypeError = __nccwpck_require__(5816).TypeError;
-    var inherits = __nccwpck_require__(7448).inherits;
+    var util = __nccwpck_require__(37448);
+    var TypeError = __nccwpck_require__(35816).TypeError;
+    var inherits = __nccwpck_require__(37448).inherits;
     var errorObj = util.errorObj;
     var tryCatch = util.tryCatch;
     var NULL = {};
@@ -21018,12 +21078,12 @@ module.exports = function (Promise, apiRejection, tryConvertToPromise,
 
 /***/ }),
 
-/***/ 7448:
+/***/ 37448:
 /***/ (function(module, __unused_webpack_exports, __nccwpck_require__) {
 
 "use strict";
 
-var es5 = __nccwpck_require__(3062);
+var es5 = __nccwpck_require__(43062);
 var canEvaluate = typeof navigator == "undefined";
 
 var errorObj = {e: {}};
@@ -21431,7 +21491,7 @@ ret.isRecentNode = ret.isNode && (function() {
 ret.nodeSupportsAsyncResource = ret.isNode && (function() {
     var supportsAsync = false;
     try {
-        var res = __nccwpck_require__(7303).AsyncResource;
+        var res = __nccwpck_require__(77303).AsyncResource;
         supportsAsync = typeof res.prototype.runInAsyncScope === "function";
     } catch (e) {
         supportsAsync = false;
@@ -21447,7 +21507,7 @@ module.exports = ret;
 
 /***/ }),
 
-/***/ 5684:
+/***/ 35684:
 /***/ ((module) => {
 
 function Caseless (dict) {
@@ -21521,12 +21581,12 @@ module.exports.httpify = function (resp, headers) {
 
 /***/ }),
 
-/***/ 5443:
+/***/ 85443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var util = __nccwpck_require__(1669);
-var Stream = __nccwpck_require__(2413).Stream;
-var DelayedStream = __nccwpck_require__(8611);
+var util = __nccwpck_require__(31669);
+var Stream = __nccwpck_require__(92413).Stream;
+var DelayedStream = __nccwpck_require__(18611);
 
 module.exports = CombinedStream;
 function CombinedStream() {
@@ -21736,7 +21796,7 @@ CombinedStream.prototype._emitError = function(err) {
 
 /***/ }),
 
-/***/ 5898:
+/***/ 95898:
 /***/ ((__unused_webpack_module, exports) => {
 
 var __webpack_unused_export__;
@@ -21851,7 +21911,7 @@ function objectToString(o) {
 
 /***/ }),
 
-/***/ 1512:
+/***/ 51512:
 /***/ ((module, exports) => {
 
 "use strict";
@@ -21859,7 +21919,7 @@ function _typeof(obj){"@babel/helpers - typeof";if(typeof Symbol==="function"&&t
 
 /***/ }),
 
-/***/ 8222:
+/***/ 28222:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -22116,7 +22176,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(6243)(exports);
+module.exports = __nccwpck_require__(46243)(exports);
 
 const {formatters} = module.exports;
 
@@ -22135,7 +22195,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 6243:
+/***/ 46243:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -22151,7 +22211,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(900);
+	createDebug.humanize = __nccwpck_require__(80900);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -22403,7 +22463,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 8237:
+/***/ 38237:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /**
@@ -22412,23 +22472,23 @@ module.exports = setup;
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(8222);
+	module.exports = __nccwpck_require__(28222);
 } else {
-	module.exports = __nccwpck_require__(5332);
+	module.exports = __nccwpck_require__(35332);
 }
 
 
 /***/ }),
 
-/***/ 5332:
+/***/ 35332:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
  * Module dependencies.
  */
 
-const tty = __nccwpck_require__(3867);
-const util = __nccwpck_require__(1669);
+const tty = __nccwpck_require__(33867);
+const util = __nccwpck_require__(31669);
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -22454,7 +22514,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(9318);
+	const supportsColor = __nccwpck_require__(59318);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -22662,7 +22722,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(6243)(exports);
+module.exports = __nccwpck_require__(46243)(exports);
 
 const {formatters} = module.exports;
 
@@ -22690,11 +22750,11 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 8611:
+/***/ 18611:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Stream = __nccwpck_require__(2413).Stream;
-var util = __nccwpck_require__(1669);
+var Stream = __nccwpck_require__(92413).Stream;
+var util = __nccwpck_require__(31669);
 
 module.exports = DelayedStream;
 function DelayedStream() {
@@ -22804,7 +22864,7 @@ DelayedStream.prototype._checkIfMaxDataSizeExceeded = function() {
 
 /***/ }),
 
-/***/ 8932:
+/***/ 58932:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22832,14 +22892,14 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 9865:
+/***/ 49865:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
-var crypto = __nccwpck_require__(6417);
-var BigInteger = __nccwpck_require__(5587).BigInteger;
+var crypto = __nccwpck_require__(76417);
+var BigInteger = __nccwpck_require__(85587).BigInteger;
 var ECPointFp = __nccwpck_require__(3943).ECPointFp;
-var Buffer = __nccwpck_require__(5118).Buffer;
-exports.ECCurves = __nccwpck_require__(1452);
+var Buffer = __nccwpck_require__(15118).Buffer;
+exports.ECCurves = __nccwpck_require__(41452);
 
 // zero prepad
 function unstupid(hex,len)
@@ -22905,7 +22965,7 @@ exports.ECKey = function(curve, key, isPublic)
 // Only Fp curves implemented for now
 
 // Requires jsbn.js and jsbn2.js
-var BigInteger = __nccwpck_require__(5587).BigInteger
+var BigInteger = __nccwpck_require__(85587).BigInteger
 var Barrett = BigInteger.prototype.Barrett
 
 // ----------------
@@ -23465,13 +23525,13 @@ module.exports = exports
 
 /***/ }),
 
-/***/ 1452:
+/***/ 41452:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Named EC curves
 
 // Requires ec.js, jsbn.js, and jsbn2.js
-var BigInteger = __nccwpck_require__(5587).BigInteger
+var BigInteger = __nccwpck_require__(85587).BigInteger
 var ECCurveFp = __nccwpck_require__(3943).ECCurveFp
 
 
@@ -23642,7 +23702,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1848:
+/***/ 11848:
 /***/ ((module) => {
 
 "use strict";
@@ -23986,7 +24046,7 @@ if (true) {
 
 /***/ }),
 
-/***/ 8171:
+/***/ 38171:
 /***/ ((module) => {
 
 "use strict";
@@ -24111,15 +24171,15 @@ module.exports = function extend() {
 
 /***/ }),
 
-/***/ 7264:
+/***/ 87264:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 /*
  * extsprintf.js: extended POSIX-style sprintf
  */
 
-var mod_assert = __nccwpck_require__(2357);
-var mod_util = __nccwpck_require__(1669);
+var mod_assert = __nccwpck_require__(42357);
+var mod_util = __nccwpck_require__(31669);
 
 /*
  * Public interface
@@ -24301,7 +24361,7 @@ function dumpException(ex)
 
 /***/ }),
 
-/***/ 8206:
+/***/ 28206:
 /***/ ((module) => {
 
 "use strict";
@@ -24355,7 +24415,7 @@ module.exports = function equal(a, b) {
 
 /***/ }),
 
-/***/ 969:
+/***/ 30969:
 /***/ ((module) => {
 
 "use strict";
@@ -24422,13 +24482,13 @@ module.exports = function (data, opts) {
 
 /***/ }),
 
-/***/ 1133:
+/***/ 31133:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var debug;
 try {
   /* eslint global-require: off */
-  debug = __nccwpck_require__(8237)("follow-redirects");
+  debug = __nccwpck_require__(38237)("follow-redirects");
 }
 catch (error) {
   debug = function () { /* */ };
@@ -24438,16 +24498,16 @@ module.exports = debug;
 
 /***/ }),
 
-/***/ 7707:
+/***/ 67707:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var url = __nccwpck_require__(8835);
+var url = __nccwpck_require__(78835);
 var URL = url.URL;
-var http = __nccwpck_require__(8605);
-var https = __nccwpck_require__(7211);
-var Writable = __nccwpck_require__(2413).Writable;
-var assert = __nccwpck_require__(2357);
-var debug = __nccwpck_require__(1133);
+var http = __nccwpck_require__(98605);
+var https = __nccwpck_require__(57211);
+var Writable = __nccwpck_require__(92413).Writable;
+var assert = __nccwpck_require__(42357);
+var debug = __nccwpck_require__(31133);
 
 // Create handlers that pass events from native requests
 var eventHandlers = Object.create(null);
@@ -24949,17 +25009,17 @@ module.exports.wrap = wrap;
 
 /***/ }),
 
-/***/ 7568:
+/***/ 47568:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = ForeverAgent
 ForeverAgent.SSL = ForeverAgentSSL
 
-var util = __nccwpck_require__(1669)
-  , Agent = __nccwpck_require__(8605).Agent
-  , net = __nccwpck_require__(1631)
+var util = __nccwpck_require__(31669)
+  , Agent = __nccwpck_require__(98605).Agent
+  , net = __nccwpck_require__(11631)
   , tls = __nccwpck_require__(4016)
-  , AgentSSL = __nccwpck_require__(7211).Agent
+  , AgentSSL = __nccwpck_require__(57211).Agent
   
 function getConnectionName(host, port) {  
   var name = ''
@@ -25094,19 +25154,19 @@ function createConnectionSSL (port, host, options) {
 
 /***/ }),
 
-/***/ 4334:
+/***/ 64334:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var CombinedStream = __nccwpck_require__(5443);
-var util = __nccwpck_require__(1669);
-var path = __nccwpck_require__(5622);
-var http = __nccwpck_require__(8605);
-var https = __nccwpck_require__(7211);
-var parseUrl = __nccwpck_require__(8835).parse;
-var fs = __nccwpck_require__(5747);
-var mime = __nccwpck_require__(3583);
-var asynckit = __nccwpck_require__(4812);
-var populate = __nccwpck_require__(7142);
+var CombinedStream = __nccwpck_require__(85443);
+var util = __nccwpck_require__(31669);
+var path = __nccwpck_require__(85622);
+var http = __nccwpck_require__(98605);
+var https = __nccwpck_require__(57211);
+var parseUrl = __nccwpck_require__(78835).parse;
+var fs = __nccwpck_require__(35747);
+var mime = __nccwpck_require__(43583);
+var asynckit = __nccwpck_require__(14812);
+var populate = __nccwpck_require__(17142);
 
 // Public API
 module.exports = FormData;
@@ -25584,7 +25644,7 @@ FormData.prototype.toString = function () {
 
 /***/ }),
 
-/***/ 7142:
+/***/ 17142:
 /***/ ((module) => {
 
 // populates missing values
@@ -25601,37 +25661,37 @@ module.exports = function(dst, src) {
 
 /***/ }),
 
-/***/ 5390:
+/***/ 13679:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 module.exports = {
-  afterRequest: __nccwpck_require__(4391),
-  beforeRequest: __nccwpck_require__(4440),
-  browser: __nccwpck_require__(9850),
-  cache: __nccwpck_require__(7654),
-  content: __nccwpck_require__(3656),
-  cookie: __nccwpck_require__(7948),
-  creator: __nccwpck_require__(3412),
-  entry: __nccwpck_require__(2525),
-  har: __nccwpck_require__(4943),
-  header: __nccwpck_require__(8344),
-  log: __nccwpck_require__(9142),
-  page: __nccwpck_require__(9075),
-  pageTimings: __nccwpck_require__(5096),
-  postData: __nccwpck_require__(3697),
-  query: __nccwpck_require__(877),
-  request: __nccwpck_require__(2084),
-  response: __nccwpck_require__(702),
-  timings: __nccwpck_require__(6941)
+  afterRequest: __nccwpck_require__(24391),
+  beforeRequest: __nccwpck_require__(94440),
+  browser: __nccwpck_require__(99850),
+  cache: __nccwpck_require__(77654),
+  content: __nccwpck_require__(73656),
+  cookie: __nccwpck_require__(67948),
+  creator: __nccwpck_require__(33412),
+  entry: __nccwpck_require__(32525),
+  har: __nccwpck_require__(84943),
+  header: __nccwpck_require__(68344),
+  log: __nccwpck_require__(69142),
+  page: __nccwpck_require__(29075),
+  pageTimings: __nccwpck_require__(15096),
+  postData: __nccwpck_require__(73697),
+  query: __nccwpck_require__(70877),
+  request: __nccwpck_require__(92084),
+  response: __nccwpck_require__(20702),
+  timings: __nccwpck_require__(36941)
 }
 
 
 /***/ }),
 
-/***/ 4944:
+/***/ 74944:
 /***/ ((module) => {
 
 function HARError (errors) {
@@ -25655,12 +25715,12 @@ module.exports = HARError
 
 /***/ }),
 
-/***/ 5697:
+/***/ 75697:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
-var Ajv = __nccwpck_require__(4941)
-var HARError = __nccwpck_require__(4944)
-var schemas = __nccwpck_require__(5390)
+var Ajv = __nccwpck_require__(64941)
+var HARError = __nccwpck_require__(74944)
+var schemas = __nccwpck_require__(13679)
 
 var ajv
 
@@ -25668,7 +25728,7 @@ function createAjvInstance () {
   var ajv = new Ajv({
     allErrors: true
   })
-  ajv.addMetaSchema(__nccwpck_require__(1030))
+  ajv.addMetaSchema(__nccwpck_require__(81030))
   ajv.addSchema(schemas)
 
   return ajv
@@ -25764,7 +25824,7 @@ exports.timings = function (data) {
 
 /***/ }),
 
-/***/ 1621:
+/***/ 31621:
 /***/ ((module) => {
 
 "use strict";
@@ -25780,15 +25840,15 @@ module.exports = (flag, argv = process.argv) => {
 
 /***/ }),
 
-/***/ 2479:
+/***/ 42479:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
 
-var parser = __nccwpck_require__(5086);
-var signer = __nccwpck_require__(8143);
-var verify = __nccwpck_require__(1227);
-var utils = __nccwpck_require__(5689);
+var parser = __nccwpck_require__(95086);
+var signer = __nccwpck_require__(38143);
+var verify = __nccwpck_require__(51227);
+var utils = __nccwpck_require__(65689);
 
 
 
@@ -25816,14 +25876,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5086:
+/***/ 95086:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2012 Joyent, Inc.  All rights reserved.
 
-var assert = __nccwpck_require__(6631);
-var util = __nccwpck_require__(1669);
-var utils = __nccwpck_require__(5689);
+var assert = __nccwpck_require__(66631);
+var util = __nccwpck_require__(31669);
+var utils = __nccwpck_require__(65689);
 
 
 
@@ -26138,20 +26198,20 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8143:
+/***/ 38143:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2012 Joyent, Inc.  All rights reserved.
 
-var assert = __nccwpck_require__(6631);
-var crypto = __nccwpck_require__(6417);
-var http = __nccwpck_require__(8605);
-var util = __nccwpck_require__(1669);
-var sshpk = __nccwpck_require__(7022);
+var assert = __nccwpck_require__(66631);
+var crypto = __nccwpck_require__(76417);
+var http = __nccwpck_require__(98605);
+var util = __nccwpck_require__(31669);
+var sshpk = __nccwpck_require__(87022);
 var jsprim = __nccwpck_require__(6287);
-var utils = __nccwpck_require__(5689);
+var utils = __nccwpck_require__(65689);
 
-var sprintf = __nccwpck_require__(1669).format;
+var sprintf = __nccwpck_require__(31669).format;
 
 var HASH_ALGOS = utils.HASH_ALGOS;
 var PK_ALGOS = utils.PK_ALGOS;
@@ -26546,14 +26606,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5689:
+/***/ 65689:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2012 Joyent, Inc.  All rights reserved.
 
-var assert = __nccwpck_require__(6631);
-var sshpk = __nccwpck_require__(7022);
-var util = __nccwpck_require__(1669);
+var assert = __nccwpck_require__(66631);
+var sshpk = __nccwpck_require__(87022);
+var util = __nccwpck_require__(31669);
 
 var HASH_ALGOS = {
   'sha1': true,
@@ -26665,15 +26725,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1227:
+/***/ 51227:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
 
-var assert = __nccwpck_require__(6631);
-var crypto = __nccwpck_require__(6417);
-var sshpk = __nccwpck_require__(7022);
-var utils = __nccwpck_require__(5689);
+var assert = __nccwpck_require__(66631);
+var crypto = __nccwpck_require__(76417);
+var sshpk = __nccwpck_require__(87022);
+var utils = __nccwpck_require__(65689);
 
 var HASH_ALGOS = utils.HASH_ALGOS;
 var PK_ALGOS = utils.PK_ALGOS;
@@ -26760,7 +26820,35 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1554:
+/***/ 34293:
+/***/ ((module) => {
+
+// https://github.com/electron/electron/issues/2288
+function isElectron() {
+    // Renderer process
+    if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer') {
+        return true;
+    }
+
+    // Main process
+    if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron) {
+        return true;
+    }
+
+    // Detect the user agent when the `nodeIntegration` option is set to true
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = isElectron;
+
+
+/***/ }),
+
+/***/ 41554:
 /***/ ((module) => {
 
 "use strict";
@@ -26789,7 +26877,7 @@ isStream.transform = function (stream) {
 
 /***/ }),
 
-/***/ 657:
+/***/ 10657:
 /***/ ((module) => {
 
 module.exports      = isTypedArray
@@ -26837,10 +26925,10 @@ function isLooseTypedArray(arr) {
 
 /***/ }),
 
-/***/ 3362:
+/***/ 83362:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var stream = __nccwpck_require__(2413)
+var stream = __nccwpck_require__(92413)
 
 
 function isStream (obj) {
@@ -26871,32 +26959,32 @@ module.exports.isDuplex   = isDuplex
 
 /***/ }),
 
-/***/ 6411:
+/***/ 26411:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var _interopRequireDefault = __nccwpck_require__(3298);
+var _interopRequireDefault = __nccwpck_require__(93298);
 
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
 exports.default = void 0;
 
-var _regenerator = _interopRequireDefault(__nccwpck_require__(9032));
+var _regenerator = _interopRequireDefault(__nccwpck_require__(69032));
 
-var _asyncToGenerator2 = _interopRequireDefault(__nccwpck_require__(7400));
+var _asyncToGenerator2 = _interopRequireDefault(__nccwpck_require__(77400));
 
-var _defineProperty2 = _interopRequireDefault(__nccwpck_require__(3561));
+var _defineProperty2 = _interopRequireDefault(__nccwpck_require__(23561));
 
-var _classCallCheck2 = _interopRequireDefault(__nccwpck_require__(9346));
+var _classCallCheck2 = _interopRequireDefault(__nccwpck_require__(49346));
 
-var _createClass2 = _interopRequireDefault(__nccwpck_require__(8755));
+var _createClass2 = _interopRequireDefault(__nccwpck_require__(78755));
 
-var _requestPromise = _interopRequireDefault(__nccwpck_require__(8313));
+var _requestPromise = _interopRequireDefault(__nccwpck_require__(38313));
 
-var _url = _interopRequireDefault(__nccwpck_require__(8835));
+var _url = _interopRequireDefault(__nccwpck_require__(78835));
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -29418,7 +29506,7 @@ module.exports = exports.default;
 
 /***/ }),
 
-/***/ 5587:
+/***/ 85587:
 /***/ (function(module, exports) {
 
 (function(){
@@ -30779,7 +30867,7 @@ module.exports = exports.default;
 
 /***/ }),
 
-/***/ 2533:
+/***/ 52533:
 /***/ ((module) => {
 
 "use strict";
@@ -30876,7 +30964,7 @@ function escapeJsonPtr(str) {
 
 /***/ }),
 
-/***/ 1328:
+/***/ 21328:
 /***/ (function(module) {
 
 /**
@@ -31156,7 +31244,7 @@ return exports;
 
 /***/ }),
 
-/***/ 7073:
+/***/ 57073:
 /***/ ((module, exports) => {
 
 exports = module.exports = stringify
@@ -31197,12 +31285,12 @@ function serializer(replacer, cycleReplacer) {
  * lib/jsprim.js: utilities for primitive JavaScript types
  */
 
-var mod_assert = __nccwpck_require__(6631);
-var mod_util = __nccwpck_require__(1669);
+var mod_assert = __nccwpck_require__(66631);
+var mod_util = __nccwpck_require__(31669);
 
-var mod_extsprintf = __nccwpck_require__(7264);
-var mod_verror = __nccwpck_require__(1692);
-var mod_jsonschema = __nccwpck_require__(1328);
+var mod_extsprintf = __nccwpck_require__(87264);
+var mod_verror = __nccwpck_require__(81692);
+var mod_jsonschema = __nccwpck_require__(21328);
 
 /*
  * Public interface
@@ -31932,11 +32020,11 @@ function mergeObjects(provided, overrides, defaults)
 
 /***/ }),
 
-/***/ 1857:
+/***/ 71857:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getNative = __nccwpck_require__(4479),
-    root = __nccwpck_require__(9882);
+var getNative = __nccwpck_require__(24479),
+    root = __nccwpck_require__(89882);
 
 /* Built-in method references that are verified to be native. */
 var DataView = getNative(root, 'DataView');
@@ -31946,14 +32034,14 @@ module.exports = DataView;
 
 /***/ }),
 
-/***/ 5902:
+/***/ 35902:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var hashClear = __nccwpck_require__(1789),
-    hashDelete = __nccwpck_require__(712),
-    hashGet = __nccwpck_require__(5395),
-    hashHas = __nccwpck_require__(5232),
-    hashSet = __nccwpck_require__(7320);
+var hashClear = __nccwpck_require__(11789),
+    hashDelete = __nccwpck_require__(60712),
+    hashGet = __nccwpck_require__(45395),
+    hashHas = __nccwpck_require__(35232),
+    hashSet = __nccwpck_require__(47320);
 
 /**
  * Creates a hash object.
@@ -31985,14 +32073,14 @@ module.exports = Hash;
 
 /***/ }),
 
-/***/ 6608:
+/***/ 96608:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var listCacheClear = __nccwpck_require__(9792),
-    listCacheDelete = __nccwpck_require__(7716),
-    listCacheGet = __nccwpck_require__(5789),
-    listCacheHas = __nccwpck_require__(9386),
-    listCacheSet = __nccwpck_require__(7399);
+var listCacheClear = __nccwpck_require__(69792),
+    listCacheDelete = __nccwpck_require__(97716),
+    listCacheGet = __nccwpck_require__(45789),
+    listCacheHas = __nccwpck_require__(59386),
+    listCacheSet = __nccwpck_require__(17399);
 
 /**
  * Creates an list cache object.
@@ -32024,11 +32112,11 @@ module.exports = ListCache;
 
 /***/ }),
 
-/***/ 881:
+/***/ 80881:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getNative = __nccwpck_require__(4479),
-    root = __nccwpck_require__(9882);
+var getNative = __nccwpck_require__(24479),
+    root = __nccwpck_require__(89882);
 
 /* Built-in method references that are verified to be native. */
 var Map = getNative(root, 'Map');
@@ -32038,14 +32126,14 @@ module.exports = Map;
 
 /***/ }),
 
-/***/ 938:
+/***/ 80938:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var mapCacheClear = __nccwpck_require__(1610),
-    mapCacheDelete = __nccwpck_require__(6657),
-    mapCacheGet = __nccwpck_require__(1372),
-    mapCacheHas = __nccwpck_require__(609),
-    mapCacheSet = __nccwpck_require__(5582);
+    mapCacheDelete = __nccwpck_require__(56657),
+    mapCacheGet = __nccwpck_require__(81372),
+    mapCacheHas = __nccwpck_require__(40609),
+    mapCacheSet = __nccwpck_require__(45582);
 
 /**
  * Creates a map cache object to store key-value pairs.
@@ -32077,11 +32165,11 @@ module.exports = MapCache;
 
 /***/ }),
 
-/***/ 4671:
+/***/ 34671:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getNative = __nccwpck_require__(4479),
-    root = __nccwpck_require__(9882);
+var getNative = __nccwpck_require__(24479),
+    root = __nccwpck_require__(89882);
 
 /* Built-in method references that are verified to be native. */
 var Promise = getNative(root, 'Promise');
@@ -32091,11 +32179,11 @@ module.exports = Promise;
 
 /***/ }),
 
-/***/ 5793:
+/***/ 35793:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getNative = __nccwpck_require__(4479),
-    root = __nccwpck_require__(9882);
+var getNative = __nccwpck_require__(24479),
+    root = __nccwpck_require__(89882);
 
 /* Built-in method references that are verified to be native. */
 var Set = getNative(root, 'Set');
@@ -32105,12 +32193,12 @@ module.exports = Set;
 
 /***/ }),
 
-/***/ 2158:
+/***/ 72158:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var MapCache = __nccwpck_require__(938),
-    setCacheAdd = __nccwpck_require__(6895),
-    setCacheHas = __nccwpck_require__(804);
+var MapCache = __nccwpck_require__(80938),
+    setCacheAdd = __nccwpck_require__(16895),
+    setCacheHas = __nccwpck_require__(60804);
 
 /**
  *
@@ -32142,12 +32230,12 @@ module.exports = SetCache;
 /***/ 5323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var ListCache = __nccwpck_require__(6608),
-    stackClear = __nccwpck_require__(2843),
-    stackDelete = __nccwpck_require__(4717),
-    stackGet = __nccwpck_require__(21),
+var ListCache = __nccwpck_require__(96608),
+    stackClear = __nccwpck_require__(62843),
+    stackDelete = __nccwpck_require__(14717),
+    stackGet = __nccwpck_require__(80021),
     stackHas = __nccwpck_require__(3910),
-    stackSet = __nccwpck_require__(9955);
+    stackSet = __nccwpck_require__(69955);
 
 /**
  * Creates a stack cache object to store key-value pairs.
@@ -32173,10 +32261,10 @@ module.exports = Stack;
 
 /***/ }),
 
-/***/ 9213:
+/***/ 19213:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var root = __nccwpck_require__(9882);
+var root = __nccwpck_require__(89882);
 
 /** Built-in value references. */
 var Symbol = root.Symbol;
@@ -32186,10 +32274,10 @@ module.exports = Symbol;
 
 /***/ }),
 
-/***/ 3261:
+/***/ 93261:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var root = __nccwpck_require__(9882);
+var root = __nccwpck_require__(89882);
 
 /** Built-in value references. */
 var Uint8Array = root.Uint8Array;
@@ -32199,11 +32287,11 @@ module.exports = Uint8Array;
 
 /***/ }),
 
-/***/ 3915:
+/***/ 43915:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getNative = __nccwpck_require__(4479),
-    root = __nccwpck_require__(9882);
+var getNative = __nccwpck_require__(24479),
+    root = __nccwpck_require__(89882);
 
 /* Built-in method references that are verified to be native. */
 var WeakMap = getNative(root, 'WeakMap');
@@ -32213,7 +32301,7 @@ module.exports = WeakMap;
 
 /***/ }),
 
-/***/ 8388:
+/***/ 48388:
 /***/ ((module) => {
 
 /**
@@ -32245,14 +32333,14 @@ module.exports = arrayFilter;
 
 /***/ }),
 
-/***/ 2237:
+/***/ 32237:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseTimes = __nccwpck_require__(7765),
-    isArguments = __nccwpck_require__(8495),
-    isArray = __nccwpck_require__(4869),
-    isBuffer = __nccwpck_require__(4190),
-    isIndex = __nccwpck_require__(2936),
+var baseTimes = __nccwpck_require__(37765),
+    isArguments = __nccwpck_require__(78495),
+    isArray = __nccwpck_require__(44869),
+    isBuffer = __nccwpck_require__(74190),
+    isIndex = __nccwpck_require__(32936),
     isTypedArray = __nccwpck_require__(2496);
 
 /** Used for built-in method references. */
@@ -32301,7 +32389,7 @@ module.exports = arrayLikeKeys;
 
 /***/ }),
 
-/***/ 4356:
+/***/ 94356:
 /***/ ((module) => {
 
 /**
@@ -32329,7 +32417,7 @@ module.exports = arrayMap;
 
 /***/ }),
 
-/***/ 82:
+/***/ 60082:
 /***/ ((module) => {
 
 /**
@@ -32356,7 +32444,7 @@ module.exports = arrayPush;
 
 /***/ }),
 
-/***/ 8018:
+/***/ 98018:
 /***/ ((module) => {
 
 /**
@@ -32419,10 +32507,10 @@ module.exports = arraySome;
 
 /***/ }),
 
-/***/ 8041:
+/***/ 98041:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseProperty = __nccwpck_require__(6829);
+var baseProperty = __nccwpck_require__(96829);
 
 /**
  * Gets the size of an ASCII `string`.
@@ -32438,7 +32526,7 @@ module.exports = asciiSize;
 
 /***/ }),
 
-/***/ 2187:
+/***/ 22187:
 /***/ ((module) => {
 
 /**
@@ -32457,7 +32545,7 @@ module.exports = asciiToArray;
 
 /***/ }),
 
-/***/ 2560:
+/***/ 42560:
 /***/ ((module) => {
 
 /** Used to match words composed of alphanumeric characters. */
@@ -32479,10 +32567,10 @@ module.exports = asciiWords;
 
 /***/ }),
 
-/***/ 6752:
+/***/ 96752:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var eq = __nccwpck_require__(1901);
+var eq = __nccwpck_require__(61901);
 
 /**
  * Gets the index at which the `key` is found in `array` of key-value pairs.
@@ -32507,10 +32595,10 @@ module.exports = assocIndexOf;
 
 /***/ }),
 
-/***/ 1540:
+/***/ 41540:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isSymbol = __nccwpck_require__(6403);
+var isSymbol = __nccwpck_require__(66403);
 
 /**
  * The base implementation of methods like `_.max` and `_.min` which accepts a
@@ -32546,11 +32634,11 @@ module.exports = baseExtremum;
 
 /***/ }),
 
-/***/ 5758:
+/***/ 75758:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var castPath = __nccwpck_require__(2688),
-    toKey = __nccwpck_require__(9071);
+    toKey = __nccwpck_require__(69071);
 
 /**
  * The base implementation of `_.get` without support for default values.
@@ -32577,11 +32665,11 @@ module.exports = baseGet;
 
 /***/ }),
 
-/***/ 5951:
+/***/ 85951:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var arrayPush = __nccwpck_require__(82),
-    isArray = __nccwpck_require__(4869);
+var arrayPush = __nccwpck_require__(60082),
+    isArray = __nccwpck_require__(44869);
 
 /**
  * The base implementation of `getAllKeys` and `getAllKeysIn` which uses
@@ -32604,12 +32692,12 @@ module.exports = baseGetAllKeys;
 
 /***/ }),
 
-/***/ 7497:
+/***/ 97497:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Symbol = __nccwpck_require__(9213),
-    getRawTag = __nccwpck_require__(923),
-    objectToString = __nccwpck_require__(4200);
+var Symbol = __nccwpck_require__(19213),
+    getRawTag = __nccwpck_require__(80923),
+    objectToString = __nccwpck_require__(14200);
 
 /** `Object#toString` result references. */
 var nullTag = '[object Null]',
@@ -32639,7 +32727,7 @@ module.exports = baseGetTag;
 
 /***/ }),
 
-/***/ 4129:
+/***/ 84129:
 /***/ ((module) => {
 
 /**
@@ -32659,11 +32747,11 @@ module.exports = baseHasIn;
 
 /***/ }),
 
-/***/ 2177:
+/***/ 92177:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGetTag = __nccwpck_require__(7497),
-    isObjectLike = __nccwpck_require__(5926);
+var baseGetTag = __nccwpck_require__(97497),
+    isObjectLike = __nccwpck_require__(85926);
 
 /** `Object#toString` result references. */
 var argsTag = '[object Arguments]';
@@ -32684,11 +32772,11 @@ module.exports = baseIsArguments;
 
 /***/ }),
 
-/***/ 8494:
+/***/ 88494:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsEqualDeep = __nccwpck_require__(3987),
-    isObjectLike = __nccwpck_require__(5926);
+var baseIsEqualDeep = __nccwpck_require__(43987),
+    isObjectLike = __nccwpck_require__(85926);
 
 /**
  * The base implementation of `_.isEqual` which supports partial comparisons
@@ -32719,16 +32807,16 @@ module.exports = baseIsEqual;
 
 /***/ }),
 
-/***/ 3987:
+/***/ 43987:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var Stack = __nccwpck_require__(5323),
-    equalArrays = __nccwpck_require__(6305),
-    equalByTag = __nccwpck_require__(9106),
-    equalObjects = __nccwpck_require__(101),
-    getTag = __nccwpck_require__(941),
-    isArray = __nccwpck_require__(4869),
-    isBuffer = __nccwpck_require__(4190),
+    equalArrays = __nccwpck_require__(86305),
+    equalByTag = __nccwpck_require__(29106),
+    equalObjects = __nccwpck_require__(70101),
+    getTag = __nccwpck_require__(50941),
+    isArray = __nccwpck_require__(44869),
+    isBuffer = __nccwpck_require__(74190),
     isTypedArray = __nccwpck_require__(2496);
 
 /** Used to compose bitmasks for value comparisons. */
@@ -32809,11 +32897,11 @@ module.exports = baseIsEqualDeep;
 
 /***/ }),
 
-/***/ 9124:
+/***/ 79124:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var Stack = __nccwpck_require__(5323),
-    baseIsEqual = __nccwpck_require__(8494);
+    baseIsEqual = __nccwpck_require__(88494);
 
 /** Used to compose bitmasks for value comparisons. */
 var COMPARE_PARTIAL_FLAG = 1,
@@ -32878,13 +32966,13 @@ module.exports = baseIsMatch;
 
 /***/ }),
 
-/***/ 411:
+/***/ 50411:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isFunction = __nccwpck_require__(7799),
-    isMasked = __nccwpck_require__(9058),
-    isObject = __nccwpck_require__(3334),
-    toSource = __nccwpck_require__(6928);
+var isFunction = __nccwpck_require__(17799),
+    isMasked = __nccwpck_require__(29058),
+    isObject = __nccwpck_require__(33334),
+    toSource = __nccwpck_require__(96928);
 
 /**
  * Used to match `RegExp`
@@ -32932,11 +33020,11 @@ module.exports = baseIsNative;
 
 /***/ }),
 
-/***/ 6461:
+/***/ 76461:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGetTag = __nccwpck_require__(7497),
-    isObjectLike = __nccwpck_require__(5926);
+var baseGetTag = __nccwpck_require__(97497),
+    isObjectLike = __nccwpck_require__(85926);
 
 /** `Object#toString` result references. */
 var regexpTag = '[object RegExp]';
@@ -32957,12 +33045,12 @@ module.exports = baseIsRegExp;
 
 /***/ }),
 
-/***/ 1528:
+/***/ 11528:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGetTag = __nccwpck_require__(7497),
-    isLength = __nccwpck_require__(4530),
-    isObjectLike = __nccwpck_require__(5926);
+var baseGetTag = __nccwpck_require__(97497),
+    isLength = __nccwpck_require__(64530),
+    isObjectLike = __nccwpck_require__(85926);
 
 /** `Object#toString` result references. */
 var argsTag = '[object Arguments]',
@@ -33024,14 +33112,14 @@ module.exports = baseIsTypedArray;
 
 /***/ }),
 
-/***/ 427:
+/***/ 60427:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseMatches = __nccwpck_require__(599),
-    baseMatchesProperty = __nccwpck_require__(7591),
-    identity = __nccwpck_require__(7822),
-    isArray = __nccwpck_require__(4869),
-    property = __nccwpck_require__(7261);
+var baseMatches = __nccwpck_require__(50599),
+    baseMatchesProperty = __nccwpck_require__(37591),
+    identity = __nccwpck_require__(57822),
+    isArray = __nccwpck_require__(44869),
+    property = __nccwpck_require__(17261);
 
 /**
  * The base implementation of `_.iteratee`.
@@ -33062,11 +33150,11 @@ module.exports = baseIteratee;
 
 /***/ }),
 
-/***/ 7164:
+/***/ 67164:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isPrototype = __nccwpck_require__(10),
-    nativeKeys = __nccwpck_require__(5778);
+var isPrototype = __nccwpck_require__(60010),
+    nativeKeys = __nccwpck_require__(35778);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -33099,7 +33187,7 @@ module.exports = baseKeys;
 
 /***/ }),
 
-/***/ 1438:
+/***/ 71438:
 /***/ ((module) => {
 
 /**
@@ -33120,12 +33208,12 @@ module.exports = baseLt;
 
 /***/ }),
 
-/***/ 599:
+/***/ 50599:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsMatch = __nccwpck_require__(9124),
-    getMatchData = __nccwpck_require__(2458),
-    matchesStrictComparable = __nccwpck_require__(3509);
+var baseIsMatch = __nccwpck_require__(79124),
+    getMatchData = __nccwpck_require__(62458),
+    matchesStrictComparable = __nccwpck_require__(93509);
 
 /**
  * The base implementation of `_.matches` which doesn't clone `source`.
@@ -33149,16 +33237,16 @@ module.exports = baseMatches;
 
 /***/ }),
 
-/***/ 7591:
+/***/ 37591:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsEqual = __nccwpck_require__(8494),
-    get = __nccwpck_require__(6908),
-    hasIn = __nccwpck_require__(9409),
-    isKey = __nccwpck_require__(9084),
-    isStrictComparable = __nccwpck_require__(9789),
-    matchesStrictComparable = __nccwpck_require__(3509),
-    toKey = __nccwpck_require__(9071);
+var baseIsEqual = __nccwpck_require__(88494),
+    get = __nccwpck_require__(56908),
+    hasIn = __nccwpck_require__(59409),
+    isKey = __nccwpck_require__(69084),
+    isStrictComparable = __nccwpck_require__(19789),
+    matchesStrictComparable = __nccwpck_require__(93509),
+    toKey = __nccwpck_require__(69071);
 
 /** Used to compose bitmasks for value comparisons. */
 var COMPARE_PARTIAL_FLAG = 1,
@@ -33189,7 +33277,7 @@ module.exports = baseMatchesProperty;
 
 /***/ }),
 
-/***/ 6829:
+/***/ 96829:
 /***/ ((module) => {
 
 /**
@@ -33210,10 +33298,10 @@ module.exports = baseProperty;
 
 /***/ }),
 
-/***/ 7685:
+/***/ 70974:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGet = __nccwpck_require__(5758);
+var baseGet = __nccwpck_require__(75758);
 
 /**
  * A specialized version of `baseProperty` which supports deep paths.
@@ -33233,7 +33321,7 @@ module.exports = basePropertyDeep;
 
 /***/ }),
 
-/***/ 6610:
+/***/ 46610:
 /***/ ((module) => {
 
 /**
@@ -33292,7 +33380,7 @@ module.exports = baseSlice;
 
 /***/ }),
 
-/***/ 7765:
+/***/ 37765:
 /***/ ((module) => {
 
 /**
@@ -33319,13 +33407,13 @@ module.exports = baseTimes;
 
 /***/ }),
 
-/***/ 6792:
+/***/ 96792:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Symbol = __nccwpck_require__(9213),
-    arrayMap = __nccwpck_require__(4356),
-    isArray = __nccwpck_require__(4869),
-    isSymbol = __nccwpck_require__(6403);
+var Symbol = __nccwpck_require__(19213),
+    arrayMap = __nccwpck_require__(94356),
+    isArray = __nccwpck_require__(44869),
+    isSymbol = __nccwpck_require__(66403);
 
 /** Used as references for various `Number` constants. */
 var INFINITY = 1 / 0;
@@ -33363,10 +33451,10 @@ module.exports = baseToString;
 
 /***/ }),
 
-/***/ 9528:
+/***/ 69528:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var trimmedEndIndex = __nccwpck_require__(7010);
+var trimmedEndIndex = __nccwpck_require__(57010);
 
 /** Used to match leading whitespace. */
 var reTrimStart = /^\s+/;
@@ -33389,7 +33477,7 @@ module.exports = baseTrim;
 
 /***/ }),
 
-/***/ 9258:
+/***/ 59258:
 /***/ ((module) => {
 
 /**
@@ -33410,7 +33498,7 @@ module.exports = baseUnary;
 
 /***/ }),
 
-/***/ 2675:
+/***/ 72675:
 /***/ ((module) => {
 
 /**
@@ -33433,10 +33521,10 @@ module.exports = cacheHas;
 /***/ 2688:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isArray = __nccwpck_require__(4869),
-    isKey = __nccwpck_require__(9084),
-    stringToPath = __nccwpck_require__(1853),
-    toString = __nccwpck_require__(2931);
+var isArray = __nccwpck_require__(44869),
+    isKey = __nccwpck_require__(69084),
+    stringToPath = __nccwpck_require__(61853),
+    toString = __nccwpck_require__(32931);
 
 /**
  * Casts `value` to a path array if it's not one.
@@ -33458,7 +33546,7 @@ module.exports = castPath;
 
 /***/ }),
 
-/***/ 5557:
+/***/ 95557:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var baseSlice = __nccwpck_require__(8758);
@@ -33483,10 +33571,10 @@ module.exports = castSlice;
 
 /***/ }),
 
-/***/ 8380:
+/***/ 78380:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var root = __nccwpck_require__(9882);
+var root = __nccwpck_require__(89882);
 
 /** Used to detect overreaching core-js shims. */
 var coreJsData = root['__core-js_shared__'];
@@ -33496,13 +33584,13 @@ module.exports = coreJsData;
 
 /***/ }),
 
-/***/ 7294:
+/***/ 55898:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var castSlice = __nccwpck_require__(5557),
-    hasUnicode = __nccwpck_require__(9489),
+var castSlice = __nccwpck_require__(95557),
+    hasUnicode = __nccwpck_require__(69489),
     stringToArray = __nccwpck_require__(1296),
-    toString = __nccwpck_require__(2931);
+    toString = __nccwpck_require__(32931);
 
 /**
  * Creates a function like `_.lowerFirst`.
@@ -33536,12 +33624,12 @@ module.exports = createCaseFirst;
 
 /***/ }),
 
-/***/ 3702:
+/***/ 53702:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var arrayReduce = __nccwpck_require__(8018),
+var arrayReduce = __nccwpck_require__(98018),
     deburr = __nccwpck_require__(833),
-    words = __nccwpck_require__(6454);
+    words = __nccwpck_require__(76454);
 
 /** Used to compose unicode capture groups. */
 var rsApos = "['\u2019]";
@@ -33567,10 +33655,10 @@ module.exports = createCompounder;
 
 /***/ }),
 
-/***/ 1683:
+/***/ 91683:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var basePropertyOf = __nccwpck_require__(6610);
+var basePropertyOf = __nccwpck_require__(46610);
 
 /** Used to map Latin Unicode letters to basic Latin letters. */
 var deburredLetters = {
@@ -33645,12 +33733,12 @@ module.exports = deburrLetter;
 
 /***/ }),
 
-/***/ 6305:
+/***/ 86305:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var SetCache = __nccwpck_require__(2158),
+var SetCache = __nccwpck_require__(72158),
     arraySome = __nccwpck_require__(9410),
-    cacheHas = __nccwpck_require__(2675);
+    cacheHas = __nccwpck_require__(72675);
 
 /** Used to compose bitmasks for value comparisons. */
 var COMPARE_PARTIAL_FLAG = 1,
@@ -33736,15 +33824,15 @@ module.exports = equalArrays;
 
 /***/ }),
 
-/***/ 9106:
+/***/ 29106:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Symbol = __nccwpck_require__(9213),
-    Uint8Array = __nccwpck_require__(3261),
-    eq = __nccwpck_require__(1901),
-    equalArrays = __nccwpck_require__(6305),
+var Symbol = __nccwpck_require__(19213),
+    Uint8Array = __nccwpck_require__(93261),
+    eq = __nccwpck_require__(61901),
+    equalArrays = __nccwpck_require__(86305),
     mapToArray = __nccwpck_require__(5853),
-    setToArray = __nccwpck_require__(9553);
+    setToArray = __nccwpck_require__(49553);
 
 /** Used to compose bitmasks for value comparisons. */
 var COMPARE_PARTIAL_FLAG = 1,
@@ -33855,10 +33943,10 @@ module.exports = equalByTag;
 
 /***/ }),
 
-/***/ 101:
+/***/ 70101:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getAllKeys = __nccwpck_require__(8009);
+var getAllKeys = __nccwpck_require__(28009);
 
 /** Used to compose bitmasks for value comparisons. */
 var COMPARE_PARTIAL_FLAG = 1;
@@ -33952,7 +34040,7 @@ module.exports = equalObjects;
 
 /***/ }),
 
-/***/ 2085:
+/***/ 52085:
 /***/ ((module) => {
 
 /** Detect free variable `global` from Node.js. */
@@ -33963,12 +34051,12 @@ module.exports = freeGlobal;
 
 /***/ }),
 
-/***/ 8009:
+/***/ 28009:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGetAllKeys = __nccwpck_require__(5951),
-    getSymbols = __nccwpck_require__(6802),
-    keys = __nccwpck_require__(7645);
+var baseGetAllKeys = __nccwpck_require__(85951),
+    getSymbols = __nccwpck_require__(56802),
+    keys = __nccwpck_require__(87645);
 
 /**
  * Creates an array of own enumerable property names and symbols of `object`.
@@ -33986,10 +34074,10 @@ module.exports = getAllKeys;
 
 /***/ }),
 
-/***/ 9980:
+/***/ 69980:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isKeyable = __nccwpck_require__(3308);
+var isKeyable = __nccwpck_require__(13308);
 
 /**
  * Gets the data for `map`.
@@ -34011,11 +34099,11 @@ module.exports = getMapData;
 
 /***/ }),
 
-/***/ 2458:
+/***/ 62458:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isStrictComparable = __nccwpck_require__(9789),
-    keys = __nccwpck_require__(7645);
+var isStrictComparable = __nccwpck_require__(19789),
+    keys = __nccwpck_require__(87645);
 
 /**
  * Gets the property names, values, and compare flags of `object`.
@@ -34042,11 +34130,11 @@ module.exports = getMatchData;
 
 /***/ }),
 
-/***/ 4479:
+/***/ 24479:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsNative = __nccwpck_require__(411),
-    getValue = __nccwpck_require__(3542);
+var baseIsNative = __nccwpck_require__(50411),
+    getValue = __nccwpck_require__(13542);
 
 /**
  * Gets the native function at `key` of `object`.
@@ -34066,10 +34154,10 @@ module.exports = getNative;
 
 /***/ }),
 
-/***/ 923:
+/***/ 80923:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Symbol = __nccwpck_require__(9213);
+var Symbol = __nccwpck_require__(19213);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -34119,10 +34207,10 @@ module.exports = getRawTag;
 
 /***/ }),
 
-/***/ 6802:
+/***/ 56802:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var arrayFilter = __nccwpck_require__(8388),
+var arrayFilter = __nccwpck_require__(48388),
     stubArray = __nccwpck_require__(8634);
 
 /** Used for built-in method references. */
@@ -34156,16 +34244,16 @@ module.exports = getSymbols;
 
 /***/ }),
 
-/***/ 941:
+/***/ 50941:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var DataView = __nccwpck_require__(1857),
-    Map = __nccwpck_require__(881),
-    Promise = __nccwpck_require__(4671),
-    Set = __nccwpck_require__(5793),
-    WeakMap = __nccwpck_require__(3915),
-    baseGetTag = __nccwpck_require__(7497),
-    toSource = __nccwpck_require__(6928);
+var DataView = __nccwpck_require__(71857),
+    Map = __nccwpck_require__(80881),
+    Promise = __nccwpck_require__(34671),
+    Set = __nccwpck_require__(35793),
+    WeakMap = __nccwpck_require__(43915),
+    baseGetTag = __nccwpck_require__(97497),
+    toSource = __nccwpck_require__(96928);
 
 /** `Object#toString` result references. */
 var mapTag = '[object Map]',
@@ -34221,7 +34309,7 @@ module.exports = getTag;
 
 /***/ }),
 
-/***/ 3542:
+/***/ 13542:
 /***/ ((module) => {
 
 /**
@@ -34241,15 +34329,15 @@ module.exports = getValue;
 
 /***/ }),
 
-/***/ 7658:
+/***/ 77658:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var castPath = __nccwpck_require__(2688),
-    isArguments = __nccwpck_require__(8495),
-    isArray = __nccwpck_require__(4869),
-    isIndex = __nccwpck_require__(2936),
-    isLength = __nccwpck_require__(4530),
-    toKey = __nccwpck_require__(9071);
+    isArguments = __nccwpck_require__(78495),
+    isArray = __nccwpck_require__(44869),
+    isIndex = __nccwpck_require__(32936),
+    isLength = __nccwpck_require__(64530),
+    toKey = __nccwpck_require__(69071);
 
 /**
  * Checks if `path` exists on `object`.
@@ -34287,7 +34375,7 @@ module.exports = hasPath;
 
 /***/ }),
 
-/***/ 9489:
+/***/ 69489:
 /***/ ((module) => {
 
 /** Used to compose unicode character classes. */
@@ -34320,7 +34408,7 @@ module.exports = hasUnicode;
 
 /***/ }),
 
-/***/ 4632:
+/***/ 54632:
 /***/ ((module) => {
 
 /** Used to detect strings that need a more robust regexp to match words. */
@@ -34342,10 +34430,10 @@ module.exports = hasUnicodeWord;
 
 /***/ }),
 
-/***/ 1789:
+/***/ 11789:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var nativeCreate = __nccwpck_require__(3041);
+var nativeCreate = __nccwpck_require__(93041);
 
 /**
  * Removes all key-value entries from the hash.
@@ -34364,7 +34452,7 @@ module.exports = hashClear;
 
 /***/ }),
 
-/***/ 712:
+/***/ 60712:
 /***/ ((module) => {
 
 /**
@@ -34388,10 +34476,10 @@ module.exports = hashDelete;
 
 /***/ }),
 
-/***/ 5395:
+/***/ 45395:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var nativeCreate = __nccwpck_require__(3041);
+var nativeCreate = __nccwpck_require__(93041);
 
 /** Used to stand-in for `undefined` hash values. */
 var HASH_UNDEFINED = '__lodash_hash_undefined__';
@@ -34425,10 +34513,10 @@ module.exports = hashGet;
 
 /***/ }),
 
-/***/ 5232:
+/***/ 35232:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var nativeCreate = __nccwpck_require__(3041);
+var nativeCreate = __nccwpck_require__(93041);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -34455,10 +34543,10 @@ module.exports = hashHas;
 
 /***/ }),
 
-/***/ 7320:
+/***/ 47320:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var nativeCreate = __nccwpck_require__(3041);
+var nativeCreate = __nccwpck_require__(93041);
 
 /** Used to stand-in for `undefined` hash values. */
 var HASH_UNDEFINED = '__lodash_hash_undefined__';
@@ -34485,7 +34573,7 @@ module.exports = hashSet;
 
 /***/ }),
 
-/***/ 2936:
+/***/ 32936:
 /***/ ((module) => {
 
 /** Used as references for various `Number` constants. */
@@ -34517,11 +34605,11 @@ module.exports = isIndex;
 
 /***/ }),
 
-/***/ 9084:
+/***/ 69084:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isArray = __nccwpck_require__(4869),
-    isSymbol = __nccwpck_require__(6403);
+var isArray = __nccwpck_require__(44869),
+    isSymbol = __nccwpck_require__(66403);
 
 /** Used to match property names within property paths. */
 var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
@@ -34553,7 +34641,7 @@ module.exports = isKey;
 
 /***/ }),
 
-/***/ 3308:
+/***/ 13308:
 /***/ ((module) => {
 
 /**
@@ -34575,10 +34663,10 @@ module.exports = isKeyable;
 
 /***/ }),
 
-/***/ 9058:
+/***/ 29058:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var coreJsData = __nccwpck_require__(8380);
+var coreJsData = __nccwpck_require__(78380);
 
 /** Used to detect methods masquerading as native. */
 var maskSrcKey = (function() {
@@ -34602,7 +34690,7 @@ module.exports = isMasked;
 
 /***/ }),
 
-/***/ 10:
+/***/ 60010:
 /***/ ((module) => {
 
 /** Used for built-in method references. */
@@ -34627,10 +34715,10 @@ module.exports = isPrototype;
 
 /***/ }),
 
-/***/ 9789:
+/***/ 19789:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isObject = __nccwpck_require__(3334);
+var isObject = __nccwpck_require__(33334);
 
 /**
  * Checks if `value` is suitable for strict equality comparisons, i.e. `===`.
@@ -34649,7 +34737,7 @@ module.exports = isStrictComparable;
 
 /***/ }),
 
-/***/ 9792:
+/***/ 69792:
 /***/ ((module) => {
 
 /**
@@ -34669,10 +34757,10 @@ module.exports = listCacheClear;
 
 /***/ }),
 
-/***/ 7716:
+/***/ 97716:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var assocIndexOf = __nccwpck_require__(6752);
+var assocIndexOf = __nccwpck_require__(96752);
 
 /** Used for built-in method references. */
 var arrayProto = Array.prototype;
@@ -34711,10 +34799,10 @@ module.exports = listCacheDelete;
 
 /***/ }),
 
-/***/ 5789:
+/***/ 45789:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var assocIndexOf = __nccwpck_require__(6752);
+var assocIndexOf = __nccwpck_require__(96752);
 
 /**
  * Gets the list cache value for `key`.
@@ -34737,10 +34825,10 @@ module.exports = listCacheGet;
 
 /***/ }),
 
-/***/ 9386:
+/***/ 59386:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var assocIndexOf = __nccwpck_require__(6752);
+var assocIndexOf = __nccwpck_require__(96752);
 
 /**
  * Checks if a list cache value for `key` exists.
@@ -34760,10 +34848,10 @@ module.exports = listCacheHas;
 
 /***/ }),
 
-/***/ 7399:
+/***/ 17399:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var assocIndexOf = __nccwpck_require__(6752);
+var assocIndexOf = __nccwpck_require__(96752);
 
 /**
  * Sets the list cache `key` to `value`.
@@ -34796,9 +34884,9 @@ module.exports = listCacheSet;
 /***/ 1610:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Hash = __nccwpck_require__(5902),
-    ListCache = __nccwpck_require__(6608),
-    Map = __nccwpck_require__(881);
+var Hash = __nccwpck_require__(35902),
+    ListCache = __nccwpck_require__(96608),
+    Map = __nccwpck_require__(80881);
 
 /**
  * Removes all key-value entries from the map.
@@ -34821,10 +34909,10 @@ module.exports = mapCacheClear;
 
 /***/ }),
 
-/***/ 6657:
+/***/ 56657:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getMapData = __nccwpck_require__(9980);
+var getMapData = __nccwpck_require__(69980);
 
 /**
  * Removes `key` and its value from the map.
@@ -34846,10 +34934,10 @@ module.exports = mapCacheDelete;
 
 /***/ }),
 
-/***/ 1372:
+/***/ 81372:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getMapData = __nccwpck_require__(9980);
+var getMapData = __nccwpck_require__(69980);
 
 /**
  * Gets the map value for `key`.
@@ -34869,10 +34957,10 @@ module.exports = mapCacheGet;
 
 /***/ }),
 
-/***/ 609:
+/***/ 40609:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getMapData = __nccwpck_require__(9980);
+var getMapData = __nccwpck_require__(69980);
 
 /**
  * Checks if a map value for `key` exists.
@@ -34892,10 +34980,10 @@ module.exports = mapCacheHas;
 
 /***/ }),
 
-/***/ 5582:
+/***/ 45582:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getMapData = __nccwpck_require__(9980);
+var getMapData = __nccwpck_require__(69980);
 
 /**
  * Sets the map `key` to `value`.
@@ -34946,7 +35034,7 @@ module.exports = mapToArray;
 
 /***/ }),
 
-/***/ 3509:
+/***/ 93509:
 /***/ ((module) => {
 
 /**
@@ -34973,10 +35061,10 @@ module.exports = matchesStrictComparable;
 
 /***/ }),
 
-/***/ 9422:
+/***/ 29422:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var memoize = __nccwpck_require__(9885);
+var memoize = __nccwpck_require__(19885);
 
 /** Used as the maximum memoize cache size. */
 var MAX_MEMOIZE_SIZE = 500;
@@ -35006,10 +35094,10 @@ module.exports = memoizeCapped;
 
 /***/ }),
 
-/***/ 3041:
+/***/ 93041:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var getNative = __nccwpck_require__(4479);
+var getNative = __nccwpck_require__(24479);
 
 /* Built-in method references that are verified to be native. */
 var nativeCreate = getNative(Object, 'create');
@@ -35019,7 +35107,7 @@ module.exports = nativeCreate;
 
 /***/ }),
 
-/***/ 5778:
+/***/ 35778:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var overArg = __nccwpck_require__(6320);
@@ -35032,11 +35120,11 @@ module.exports = nativeKeys;
 
 /***/ }),
 
-/***/ 4643:
+/***/ 34643:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* module decorator */ module = __nccwpck_require__.nmd(module);
-var freeGlobal = __nccwpck_require__(2085);
+var freeGlobal = __nccwpck_require__(52085);
 
 /** Detect free variable `exports`. */
 var freeExports =  true && exports && !exports.nodeType && exports;
@@ -35070,7 +35158,7 @@ module.exports = nodeUtil;
 
 /***/ }),
 
-/***/ 4200:
+/***/ 14200:
 /***/ ((module) => {
 
 /** Used for built-in method references. */
@@ -35121,10 +35209,10 @@ module.exports = overArg;
 
 /***/ }),
 
-/***/ 9882:
+/***/ 89882:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var freeGlobal = __nccwpck_require__(2085);
+var freeGlobal = __nccwpck_require__(52085);
 
 /** Detect free variable `self`. */
 var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
@@ -35137,7 +35225,7 @@ module.exports = root;
 
 /***/ }),
 
-/***/ 6895:
+/***/ 16895:
 /***/ ((module) => {
 
 /** Used to stand-in for `undefined` hash values. */
@@ -35163,7 +35251,7 @@ module.exports = setCacheAdd;
 
 /***/ }),
 
-/***/ 804:
+/***/ 60804:
 /***/ ((module) => {
 
 /**
@@ -35184,7 +35272,7 @@ module.exports = setCacheHas;
 
 /***/ }),
 
-/***/ 9553:
+/***/ 49553:
 /***/ ((module) => {
 
 /**
@@ -35209,10 +35297,10 @@ module.exports = setToArray;
 
 /***/ }),
 
-/***/ 2843:
+/***/ 62843:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var ListCache = __nccwpck_require__(6608);
+var ListCache = __nccwpck_require__(96608);
 
 /**
  * Removes all key-value entries from the stack.
@@ -35231,7 +35319,7 @@ module.exports = stackClear;
 
 /***/ }),
 
-/***/ 4717:
+/***/ 14717:
 /***/ ((module) => {
 
 /**
@@ -35256,7 +35344,7 @@ module.exports = stackDelete;
 
 /***/ }),
 
-/***/ 21:
+/***/ 80021:
 /***/ ((module) => {
 
 /**
@@ -35298,12 +35386,12 @@ module.exports = stackHas;
 
 /***/ }),
 
-/***/ 9955:
+/***/ 69955:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var ListCache = __nccwpck_require__(6608),
-    Map = __nccwpck_require__(881),
-    MapCache = __nccwpck_require__(938);
+var ListCache = __nccwpck_require__(96608),
+    Map = __nccwpck_require__(80881),
+    MapCache = __nccwpck_require__(80938);
 
 /** Used as the size to enable large array optimizations. */
 var LARGE_ARRAY_SIZE = 200;
@@ -35339,12 +35427,12 @@ module.exports = stackSet;
 
 /***/ }),
 
-/***/ 4868:
+/***/ 44868:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var asciiSize = __nccwpck_require__(8041),
-    hasUnicode = __nccwpck_require__(9489),
-    unicodeSize = __nccwpck_require__(8580);
+var asciiSize = __nccwpck_require__(98041),
+    hasUnicode = __nccwpck_require__(69489),
+    unicodeSize = __nccwpck_require__(88580);
 
 /**
  * Gets the number of symbols in `string`.
@@ -35367,9 +35455,9 @@ module.exports = stringSize;
 /***/ 1296:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var asciiToArray = __nccwpck_require__(2187),
-    hasUnicode = __nccwpck_require__(9489),
-    unicodeToArray = __nccwpck_require__(1990);
+var asciiToArray = __nccwpck_require__(22187),
+    hasUnicode = __nccwpck_require__(69489),
+    unicodeToArray = __nccwpck_require__(41990);
 
 /**
  * Converts `string` to an array.
@@ -35389,10 +35477,10 @@ module.exports = stringToArray;
 
 /***/ }),
 
-/***/ 1853:
+/***/ 61853:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var memoizeCapped = __nccwpck_require__(9422);
+var memoizeCapped = __nccwpck_require__(29422);
 
 /** Used to match property names within property paths. */
 var rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
@@ -35423,10 +35511,10 @@ module.exports = stringToPath;
 
 /***/ }),
 
-/***/ 9071:
+/***/ 69071:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isSymbol = __nccwpck_require__(6403);
+var isSymbol = __nccwpck_require__(66403);
 
 /** Used as references for various `Number` constants. */
 var INFINITY = 1 / 0;
@@ -35451,7 +35539,7 @@ module.exports = toKey;
 
 /***/ }),
 
-/***/ 6928:
+/***/ 96928:
 /***/ ((module) => {
 
 /** Used for built-in method references. */
@@ -35484,7 +35572,7 @@ module.exports = toSource;
 
 /***/ }),
 
-/***/ 7010:
+/***/ 57010:
 /***/ ((module) => {
 
 /** Used to match a single whitespace character. */
@@ -35510,7 +35598,7 @@ module.exports = trimmedEndIndex;
 
 /***/ }),
 
-/***/ 8580:
+/***/ 88580:
 /***/ ((module) => {
 
 /** Used to compose unicode character classes. */
@@ -35561,7 +35649,7 @@ module.exports = unicodeSize;
 
 /***/ }),
 
-/***/ 1990:
+/***/ 41990:
 /***/ ((module) => {
 
 /** Used to compose unicode character classes. */
@@ -35608,7 +35696,7 @@ module.exports = unicodeToArray;
 
 /***/ }),
 
-/***/ 5423:
+/***/ 85423:
 /***/ ((module) => {
 
 /** Used to compose unicode character classes. */
@@ -35687,8 +35775,8 @@ module.exports = unicodeWords;
 /***/ 833:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var deburrLetter = __nccwpck_require__(1683),
-    toString = __nccwpck_require__(2931);
+var deburrLetter = __nccwpck_require__(91683),
+    toString = __nccwpck_require__(32931);
 
 /** Used to match Latin Unicode letters (excluding mathematical operators). */
 var reLatin = /[\xc0-\xd6\xd8-\xf6\xf8-\xff\u0100-\u017f]/g;
@@ -35736,7 +35824,7 @@ module.exports = deburr;
 
 /***/ }),
 
-/***/ 1901:
+/***/ 61901:
 /***/ ((module) => {
 
 /**
@@ -35780,10 +35868,10 @@ module.exports = eq;
 
 /***/ }),
 
-/***/ 8415:
+/***/ 98415:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var toString = __nccwpck_require__(2931);
+var toString = __nccwpck_require__(32931);
 
 /**
  * Used to match `RegExp`
@@ -35819,10 +35907,10 @@ module.exports = escapeRegExp;
 
 /***/ }),
 
-/***/ 6908:
+/***/ 56908:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGet = __nccwpck_require__(5758);
+var baseGet = __nccwpck_require__(75758);
 
 /**
  * Gets the value at `path` of `object`. If the resolved value is
@@ -35859,11 +35947,11 @@ module.exports = get;
 
 /***/ }),
 
-/***/ 9409:
+/***/ 59409:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseHasIn = __nccwpck_require__(4129),
-    hasPath = __nccwpck_require__(7658);
+var baseHasIn = __nccwpck_require__(84129),
+    hasPath = __nccwpck_require__(77658);
 
 /**
  * Checks if `path` is a direct or inherited property of `object`.
@@ -35900,7 +35988,7 @@ module.exports = hasIn;
 
 /***/ }),
 
-/***/ 7822:
+/***/ 57822:
 /***/ ((module) => {
 
 /**
@@ -35928,11 +36016,11 @@ module.exports = identity;
 
 /***/ }),
 
-/***/ 8495:
+/***/ 78495:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsArguments = __nccwpck_require__(2177),
-    isObjectLike = __nccwpck_require__(5926);
+var baseIsArguments = __nccwpck_require__(92177),
+    isObjectLike = __nccwpck_require__(85926);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -35971,7 +36059,7 @@ module.exports = isArguments;
 
 /***/ }),
 
-/***/ 4869:
+/***/ 44869:
 /***/ ((module) => {
 
 /**
@@ -36004,11 +36092,11 @@ module.exports = isArray;
 
 /***/ }),
 
-/***/ 8017:
+/***/ 18017:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var isFunction = __nccwpck_require__(7799),
-    isLength = __nccwpck_require__(4530);
+var isFunction = __nccwpck_require__(17799),
+    isLength = __nccwpck_require__(64530);
 
 /**
  * Checks if `value` is array-like. A value is considered array-like if it's
@@ -36044,12 +36132,12 @@ module.exports = isArrayLike;
 
 /***/ }),
 
-/***/ 4190:
+/***/ 74190:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* module decorator */ module = __nccwpck_require__.nmd(module);
-var root = __nccwpck_require__(9882),
-    stubFalse = __nccwpck_require__(7744);
+var root = __nccwpck_require__(89882),
+    stubFalse = __nccwpck_require__(67744);
 
 /** Detect free variable `exports`. */
 var freeExports =  true && exports && !exports.nodeType && exports;
@@ -36090,16 +36178,16 @@ module.exports = isBuffer;
 
 /***/ }),
 
-/***/ 2384:
+/***/ 53912:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseKeys = __nccwpck_require__(7164),
-    getTag = __nccwpck_require__(941),
-    isArguments = __nccwpck_require__(8495),
-    isArray = __nccwpck_require__(4869),
-    isArrayLike = __nccwpck_require__(8017),
-    isBuffer = __nccwpck_require__(4190),
-    isPrototype = __nccwpck_require__(10),
+var baseKeys = __nccwpck_require__(67164),
+    getTag = __nccwpck_require__(50941),
+    isArguments = __nccwpck_require__(78495),
+    isArray = __nccwpck_require__(44869),
+    isArrayLike = __nccwpck_require__(18017),
+    isBuffer = __nccwpck_require__(74190),
+    isPrototype = __nccwpck_require__(60010),
     isTypedArray = __nccwpck_require__(2496);
 
 /** `Object#toString` result references. */
@@ -36174,10 +36262,10 @@ module.exports = isEmpty;
 
 /***/ }),
 
-/***/ 52:
+/***/ 20052:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsEqual = __nccwpck_require__(8494);
+var baseIsEqual = __nccwpck_require__(88494);
 
 /**
  * Performs a deep comparison between two values to determine if they are
@@ -36216,11 +36304,11 @@ module.exports = isEqual;
 
 /***/ }),
 
-/***/ 7799:
+/***/ 17799:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGetTag = __nccwpck_require__(7497),
-    isObject = __nccwpck_require__(3334);
+var baseGetTag = __nccwpck_require__(97497),
+    isObject = __nccwpck_require__(33334);
 
 /** `Object#toString` result references. */
 var asyncTag = '[object AsyncFunction]',
@@ -36260,7 +36348,7 @@ module.exports = isFunction;
 
 /***/ }),
 
-/***/ 4530:
+/***/ 64530:
 /***/ ((module) => {
 
 /** Used as references for various `Number` constants. */
@@ -36302,7 +36390,7 @@ module.exports = isLength;
 
 /***/ }),
 
-/***/ 4977:
+/***/ 84977:
 /***/ ((module) => {
 
 /**
@@ -36334,7 +36422,7 @@ module.exports = isNil;
 
 /***/ }),
 
-/***/ 3334:
+/***/ 33334:
 /***/ ((module) => {
 
 /**
@@ -36372,7 +36460,7 @@ module.exports = isObject;
 
 /***/ }),
 
-/***/ 5926:
+/***/ 85926:
 /***/ ((module) => {
 
 /**
@@ -36408,12 +36496,12 @@ module.exports = isObjectLike;
 
 /***/ }),
 
-/***/ 1535:
+/***/ 91535:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsRegExp = __nccwpck_require__(6461),
-    baseUnary = __nccwpck_require__(9258),
-    nodeUtil = __nccwpck_require__(4643);
+var baseIsRegExp = __nccwpck_require__(76461),
+    baseUnary = __nccwpck_require__(59258),
+    nodeUtil = __nccwpck_require__(34643);
 
 /* Node.js helper references. */
 var nodeIsRegExp = nodeUtil && nodeUtil.isRegExp;
@@ -36442,12 +36530,12 @@ module.exports = isRegExp;
 
 /***/ }),
 
-/***/ 5704:
+/***/ 65704:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGetTag = __nccwpck_require__(7497),
-    isArray = __nccwpck_require__(4869),
-    isObjectLike = __nccwpck_require__(5926);
+var baseGetTag = __nccwpck_require__(97497),
+    isArray = __nccwpck_require__(44869),
+    isObjectLike = __nccwpck_require__(85926);
 
 /** `Object#toString` result references. */
 var stringTag = '[object String]';
@@ -36479,11 +36567,11 @@ module.exports = isString;
 
 /***/ }),
 
-/***/ 6403:
+/***/ 66403:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseGetTag = __nccwpck_require__(7497),
-    isObjectLike = __nccwpck_require__(5926);
+var baseGetTag = __nccwpck_require__(97497),
+    isObjectLike = __nccwpck_require__(85926);
 
 /** `Object#toString` result references. */
 var symbolTag = '[object Symbol]';
@@ -36518,9 +36606,9 @@ module.exports = isSymbol;
 /***/ 2496:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseIsTypedArray = __nccwpck_require__(1528),
-    baseUnary = __nccwpck_require__(9258),
-    nodeUtil = __nccwpck_require__(4643);
+var baseIsTypedArray = __nccwpck_require__(11528),
+    baseUnary = __nccwpck_require__(59258),
+    nodeUtil = __nccwpck_require__(34643);
 
 /* Node.js helper references. */
 var nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray;
@@ -36578,12 +36666,12 @@ module.exports = isUndefined;
 
 /***/ }),
 
-/***/ 7645:
+/***/ 87645:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var arrayLikeKeys = __nccwpck_require__(2237),
-    baseKeys = __nccwpck_require__(7164),
-    isArrayLike = __nccwpck_require__(8017);
+var arrayLikeKeys = __nccwpck_require__(32237),
+    baseKeys = __nccwpck_require__(67164),
+    isArrayLike = __nccwpck_require__(18017);
 
 /**
  * Creates an array of the own enumerable property names of `object`.
@@ -36622,10 +36710,10 @@ module.exports = keys;
 
 /***/ }),
 
-/***/ 9885:
+/***/ 19885:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var MapCache = __nccwpck_require__(938);
+var MapCache = __nccwpck_require__(80938);
 
 /** Error message constants. */
 var FUNC_ERROR_TEXT = 'Expected a function';
@@ -36705,9 +36793,9 @@ module.exports = memoize;
 /***/ 6369:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseExtremum = __nccwpck_require__(1540),
-    baseIteratee = __nccwpck_require__(427),
-    baseLt = __nccwpck_require__(1438);
+var baseExtremum = __nccwpck_require__(41540),
+    baseIteratee = __nccwpck_require__(60427),
+    baseLt = __nccwpck_require__(71438);
 
 /**
  * This method is like `_.min` except that it accepts `iteratee` which is
@@ -36743,13 +36831,13 @@ module.exports = minBy;
 
 /***/ }),
 
-/***/ 7261:
+/***/ 17261:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseProperty = __nccwpck_require__(6829),
-    basePropertyDeep = __nccwpck_require__(7685),
-    isKey = __nccwpck_require__(9084),
-    toKey = __nccwpck_require__(9071);
+var baseProperty = __nccwpck_require__(96829),
+    basePropertyDeep = __nccwpck_require__(70974),
+    isKey = __nccwpck_require__(69084),
+    toKey = __nccwpck_require__(69071);
 
 /**
  * Creates a function that returns the value at `path` of a given object.
@@ -36782,10 +36870,10 @@ module.exports = property;
 
 /***/ }),
 
-/***/ 1419:
+/***/ 31419:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var createCompounder = __nccwpck_require__(3702);
+var createCompounder = __nccwpck_require__(53702);
 
 /**
  * Converts `string` to
@@ -36817,11 +36905,11 @@ module.exports = snakeCase;
 
 /***/ }),
 
-/***/ 9274:
+/***/ 69274:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var createCompounder = __nccwpck_require__(3702),
-    upperFirst = __nccwpck_require__(2598);
+var createCompounder = __nccwpck_require__(53702),
+    upperFirst = __nccwpck_require__(72598);
 
 /**
  * Converts `string` to
@@ -36883,7 +36971,7 @@ module.exports = stubArray;
 
 /***/ }),
 
-/***/ 7744:
+/***/ 67744:
 /***/ ((module) => {
 
 /**
@@ -36908,10 +36996,10 @@ module.exports = stubFalse;
 
 /***/ }),
 
-/***/ 9323:
+/***/ 19323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var toNumber = __nccwpck_require__(1235);
+var toNumber = __nccwpck_require__(91235);
 
 /** Used as references for various `Number` constants. */
 var INFINITY = 1 / 0,
@@ -36957,10 +37045,10 @@ module.exports = toFinite;
 
 /***/ }),
 
-/***/ 2722:
+/***/ 22722:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var toFinite = __nccwpck_require__(9323);
+var toFinite = __nccwpck_require__(19323);
 
 /**
  * Converts `value` to an integer.
@@ -37000,12 +37088,12 @@ module.exports = toInteger;
 
 /***/ }),
 
-/***/ 1235:
+/***/ 91235:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseTrim = __nccwpck_require__(9528),
-    isObject = __nccwpck_require__(3334),
-    isSymbol = __nccwpck_require__(6403);
+var baseTrim = __nccwpck_require__(69528),
+    isObject = __nccwpck_require__(33334),
+    isSymbol = __nccwpck_require__(66403);
 
 /** Used as references for various `Number` constants. */
 var NAN = 0 / 0;
@@ -37071,10 +37159,10 @@ module.exports = toNumber;
 
 /***/ }),
 
-/***/ 2931:
+/***/ 32931:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseToString = __nccwpck_require__(6792);
+var baseToString = __nccwpck_require__(96792);
 
 /**
  * Converts `value` to a string. An empty string is returned for `null`
@@ -37106,18 +37194,18 @@ module.exports = toString;
 
 /***/ }),
 
-/***/ 5010:
+/***/ 35010:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var baseToString = __nccwpck_require__(6792),
-    castSlice = __nccwpck_require__(5557),
-    hasUnicode = __nccwpck_require__(9489),
-    isObject = __nccwpck_require__(3334),
-    isRegExp = __nccwpck_require__(1535),
-    stringSize = __nccwpck_require__(4868),
+var baseToString = __nccwpck_require__(96792),
+    castSlice = __nccwpck_require__(95557),
+    hasUnicode = __nccwpck_require__(69489),
+    isObject = __nccwpck_require__(33334),
+    isRegExp = __nccwpck_require__(91535),
+    stringSize = __nccwpck_require__(44868),
     stringToArray = __nccwpck_require__(1296),
-    toInteger = __nccwpck_require__(2722),
-    toString = __nccwpck_require__(2931);
+    toInteger = __nccwpck_require__(22722),
+    toString = __nccwpck_require__(32931);
 
 /** Used as default options for `_.truncate`. */
 var DEFAULT_TRUNC_LENGTH = 30,
@@ -37224,10 +37312,10 @@ module.exports = truncate;
 
 /***/ }),
 
-/***/ 2598:
+/***/ 72598:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var createCaseFirst = __nccwpck_require__(7294);
+var createCaseFirst = __nccwpck_require__(55898);
 
 /**
  * Converts the first character of `string` to upper case.
@@ -37253,13 +37341,13 @@ module.exports = upperFirst;
 
 /***/ }),
 
-/***/ 6454:
+/***/ 76454:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var asciiWords = __nccwpck_require__(2560),
-    hasUnicodeWord = __nccwpck_require__(4632),
-    toString = __nccwpck_require__(2931),
-    unicodeWords = __nccwpck_require__(5423);
+var asciiWords = __nccwpck_require__(42560),
+    hasUnicodeWord = __nccwpck_require__(54632),
+    toString = __nccwpck_require__(32931),
+    unicodeWords = __nccwpck_require__(85423);
 
 /**
  * Splits `string` into an array of its words.
@@ -37295,7 +37383,7 @@ module.exports = words;
 
 /***/ }),
 
-/***/ 7426:
+/***/ 47426:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /*!
@@ -37308,12 +37396,12 @@ module.exports = words;
  * Module exports.
  */
 
-module.exports = __nccwpck_require__(3313)
+module.exports = __nccwpck_require__(73313)
 
 
 /***/ }),
 
-/***/ 3583:
+/***/ 43583:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -37331,8 +37419,8 @@ module.exports = __nccwpck_require__(3313)
  * @private
  */
 
-var db = __nccwpck_require__(7426)
-var extname = __nccwpck_require__(5622).extname
+var db = __nccwpck_require__(47426)
+var extname = __nccwpck_require__(85622).extname
 
 /**
  * Module variables.
@@ -37509,7 +37597,7 @@ function populateMaps (extensions, types) {
 
 /***/ }),
 
-/***/ 900:
+/***/ 80900:
 /***/ ((module) => {
 
 /**
@@ -37678,7 +37766,7 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 467:
+/***/ 80467:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -37688,11 +37776,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var Stream = _interopDefault(__nccwpck_require__(2413));
-var http = _interopDefault(__nccwpck_require__(8605));
-var Url = _interopDefault(__nccwpck_require__(8835));
-var https = _interopDefault(__nccwpck_require__(7211));
-var zlib = _interopDefault(__nccwpck_require__(8761));
+var Stream = _interopDefault(__nccwpck_require__(92413));
+var http = _interopDefault(__nccwpck_require__(98605));
+var Url = _interopDefault(__nccwpck_require__(78835));
+var https = _interopDefault(__nccwpck_require__(57211));
+var zlib = _interopDefault(__nccwpck_require__(78761));
 
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 
@@ -37843,7 +37931,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = __nccwpck_require__(2877).convert;
+	convert = __nccwpck_require__(22877).convert;
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -39335,10 +39423,10 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 8468:
+/***/ 43248:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
-var crypto = __nccwpck_require__(6417)
+var crypto = __nccwpck_require__(76417)
 
 function sha (key, body, algorithm) {
   return crypto.createHmac(algorithm, key).update(body).digest('base64')
@@ -39490,7 +39578,7 @@ exports.generateBase = generateBase
 /***/ 1223:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(2940)
+var wrappy = __nccwpck_require__(62940)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -39536,7 +39624,7 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 1330:
+/***/ 31330:
 /***/ ((module) => {
 
 "use strict";
@@ -39559,14 +39647,14 @@ module.exports = (promise, onFinally) => {
 
 /***/ }),
 
-/***/ 8983:
+/***/ 28983:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const EventEmitter = __nccwpck_require__(4924);
-const p_timeout_1 = __nccwpck_require__(6424);
+const EventEmitter = __nccwpck_require__(44924);
+const p_timeout_1 = __nccwpck_require__(86424);
 const priority_queue_1 = __nccwpck_require__(8492);
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const empty = () => { };
@@ -39846,7 +39934,7 @@ exports.default = PQueue;
 
 /***/ }),
 
-/***/ 2291:
+/***/ 62291:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -39881,7 +39969,7 @@ exports.default = lowerBound;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const lower_bound_1 = __nccwpck_require__(2291);
+const lower_bound_1 = __nccwpck_require__(62291);
 class PriorityQueue {
     constructor() {
         this._queue = [];
@@ -39915,7 +40003,7 @@ exports.default = PriorityQueue;
 
 /***/ }),
 
-/***/ 4924:
+/***/ 44924:
 /***/ ((module) => {
 
 "use strict";
@@ -40259,12 +40347,12 @@ if (true) {
 
 /***/ }),
 
-/***/ 2548:
+/***/ 82548:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const retry = __nccwpck_require__(4347);
+const retry = __nccwpck_require__(24347);
 
 class AbortError extends Error {
 	constructor(message) {
@@ -40343,13 +40431,13 @@ module.exports.AbortError = AbortError;
 
 /***/ }),
 
-/***/ 6424:
+/***/ 86424:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const pFinally = __nccwpck_require__(1330);
+const pFinally = __nccwpck_require__(31330);
 
 class TimeoutError extends Error {
 	constructor(message) {
@@ -40408,7 +40496,7 @@ module.exports.TimeoutError = TimeoutError;
 
 /***/ }),
 
-/***/ 5644:
+/***/ 85644:
 /***/ (function(module) {
 
 // Generated by CoffeeScript 1.12.2
@@ -40451,7 +40539,7 @@ module.exports.TimeoutError = TimeoutError;
 
 /***/ }),
 
-/***/ 9975:
+/***/ 29975:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -40459,7 +40547,7 @@ module.exports.TimeoutError = TimeoutError;
 
 
 
-var Punycode = __nccwpck_require__(4213);
+var Punycode = __nccwpck_require__(94213);
 
 
 var internals = {};
@@ -40468,7 +40556,7 @@ var internals = {};
 //
 // Read rules from file.
 //
-internals.rules = __nccwpck_require__(7574).map(function (rule) {
+internals.rules = __nccwpck_require__(2156).map(function (rule) {
 
   return {
     rule: rule,
@@ -40728,7 +40816,7 @@ exports.isValid = function (domain) {
 
 /***/ }),
 
-/***/ 4907:
+/***/ 74907:
 /***/ ((module) => {
 
 "use strict";
@@ -40754,15 +40842,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2760:
+/***/ 22760:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var stringify = __nccwpck_require__(9954);
-var parse = __nccwpck_require__(3912);
-var formats = __nccwpck_require__(4907);
+var stringify = __nccwpck_require__(79954);
+var parse = __nccwpck_require__(33912);
+var formats = __nccwpck_require__(74907);
 
 module.exports = {
     formats: formats,
@@ -40773,13 +40861,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3912:
+/***/ 33912:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(2360);
+var utils = __nccwpck_require__(72360);
 
 var has = Object.prototype.hasOwnProperty;
 
@@ -40955,14 +41043,14 @@ module.exports = function (str, opts) {
 
 /***/ }),
 
-/***/ 9954:
+/***/ 79954:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(2360);
-var formats = __nccwpck_require__(4907);
+var utils = __nccwpck_require__(72360);
+var formats = __nccwpck_require__(74907);
 
 var arrayPrefixGenerators = {
     brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
@@ -41173,7 +41261,7 @@ module.exports = function (object, opts) {
 
 /***/ }),
 
-/***/ 2360:
+/***/ 72360:
 /***/ ((module) => {
 
 "use strict";
@@ -41394,7 +41482,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4307:
+/***/ 94307:
 /***/ ((module) => {
 
 /**
@@ -42149,16 +42237,16 @@ try {
 
 /***/ }),
 
-/***/ 7825:
+/***/ 37825:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var core = __nccwpck_require__(637),
-    isArray = __nccwpck_require__(4869),
-    isFunction = __nccwpck_require__(7799),
-    isObjectLike = __nccwpck_require__(5926);
+var core = __nccwpck_require__(30637),
+    isArray = __nccwpck_require__(44869),
+    isFunction = __nccwpck_require__(17799),
+    isObjectLike = __nccwpck_require__(85926);
 
 
 module.exports = function (options) {
@@ -42231,7 +42319,7 @@ module.exports = function (options) {
 
 /***/ }),
 
-/***/ 3690:
+/***/ 23690:
 /***/ ((module) => {
 
 "use strict";
@@ -42301,16 +42389,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 637:
+/***/ 30637:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var errors = __nccwpck_require__(3690),
-    isFunction = __nccwpck_require__(7799),
-    isObjectLike = __nccwpck_require__(5926),
-    isString = __nccwpck_require__(5704),
+var errors = __nccwpck_require__(23690),
+    isFunction = __nccwpck_require__(17799),
+    isObjectLike = __nccwpck_require__(85926),
+    isString = __nccwpck_require__(65704),
     isUndefined = __nccwpck_require__(2825);
 
 
@@ -42476,30 +42564,30 @@ module.exports = function (options) {
 
 /***/ }),
 
-/***/ 8313:
+/***/ 38313:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 /* module decorator */ module = __nccwpck_require__.nmd(module);
 
 
-var Bluebird = __nccwpck_require__(8710).getNewLibraryCopy(),
-    configure = __nccwpck_require__(7825),
-    stealthyRequire = __nccwpck_require__(42);
+var Bluebird = __nccwpck_require__(78710).getNewLibraryCopy(),
+    configure = __nccwpck_require__(37825),
+    stealthyRequire = __nccwpck_require__(90042);
 
 try {
 
     // Load Request freshly - so that users can require an unaltered request instance!
     var request = stealthyRequire(require.cache, function () {
-        return __nccwpck_require__(8699);
+        return __nccwpck_require__(48699);
     },
     function () {
-        __nccwpck_require__(7372);
+        __nccwpck_require__(47372);
     }, module);
 
 } catch (err) {
     /* istanbul ignore next */
-    var EOL = __nccwpck_require__(2087).EOL;
+    var EOL = __nccwpck_require__(12087).EOL;
     /* istanbul ignore next */
     console.error(EOL + '###' + EOL + '### The "request" library is not installed automatically anymore.' + EOL + '### But is a dependency of "request-promise".' + EOL + '### Please install it with:' + EOL + '### npm install request --save' + EOL + '###' + EOL);
     /* istanbul ignore next */
@@ -42537,7 +42625,7 @@ module.exports = request;
 
 /***/ }),
 
-/***/ 8699:
+/***/ 48699:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -42557,9 +42645,9 @@ module.exports = request;
 
 
 
-var extend = __nccwpck_require__(8171)
-var cookies = __nccwpck_require__(976)
-var helpers = __nccwpck_require__(4845)
+var extend = __nccwpck_require__(38171)
+var cookies = __nccwpck_require__(50976)
+var helpers = __nccwpck_require__(74845)
 
 var paramsHaveRequestBody = helpers.paramsHaveRequestBody
 
@@ -42683,7 +42771,7 @@ request.forever = function (agentOptions, optionsArg) {
 // Exports
 
 module.exports = request
-request.Request = __nccwpck_require__(304)
+request.Request = __nccwpck_require__(70304)
 request.initParams = initParams
 
 // Backwards compatibility for request.debug
@@ -42700,15 +42788,15 @@ Object.defineProperty(request, 'debug', {
 
 /***/ }),
 
-/***/ 6996:
+/***/ 76996:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var caseless = __nccwpck_require__(5684)
-var uuid = __nccwpck_require__(824)
-var helpers = __nccwpck_require__(4845)
+var caseless = __nccwpck_require__(35684)
+var uuid = __nccwpck_require__(80824)
+var helpers = __nccwpck_require__(74845)
 
 var md5 = helpers.md5
 var toBase64 = helpers.toBase64
@@ -42875,13 +42963,13 @@ exports.g = Auth
 
 /***/ }),
 
-/***/ 976:
+/***/ 50976:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var tough = __nccwpck_require__(7372)
+var tough = __nccwpck_require__(47372)
 
 var Cookie = tough.Cookie
 var CookieJar = tough.CookieJar
@@ -42921,7 +43009,7 @@ exports.jar = function (store) {
 
 /***/ }),
 
-/***/ 5654:
+/***/ 75654:
 /***/ ((module) => {
 
 "use strict";
@@ -43014,10 +43102,10 @@ module.exports = getProxyFromURI
 "use strict";
 
 
-var fs = __nccwpck_require__(5747)
-var qs = __nccwpck_require__(1191)
-var validate = __nccwpck_require__(5697)
-var extend = __nccwpck_require__(8171)
+var fs = __nccwpck_require__(35747)
+var qs = __nccwpck_require__(71191)
+var validate = __nccwpck_require__(75697)
+var extend = __nccwpck_require__(38171)
 
 function Har (request) {
   this.request = request
@@ -43221,13 +43309,13 @@ exports.t = Har
 
 /***/ }),
 
-/***/ 4473:
+/***/ 34473:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var crypto = __nccwpck_require__(6417)
+var crypto = __nccwpck_require__(76417)
 
 function randomString (size) {
   var bits = (size + 1) * 6
@@ -43318,15 +43406,15 @@ exports.header = function (uri, method, opts) {
 
 /***/ }),
 
-/***/ 4845:
+/***/ 74845:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var jsonSafeStringify = __nccwpck_require__(7073)
-var crypto = __nccwpck_require__(6417)
-var Buffer = __nccwpck_require__(1867).Buffer
+var jsonSafeStringify = __nccwpck_require__(57073)
+var crypto = __nccwpck_require__(76417)
+var Buffer = __nccwpck_require__(21867).Buffer
 
 var defer = typeof setImmediate === 'undefined'
   ? process.nextTick
@@ -43392,16 +43480,16 @@ exports.defer = defer
 
 /***/ }),
 
-/***/ 7810:
+/***/ 87810:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var uuid = __nccwpck_require__(824)
-var CombinedStream = __nccwpck_require__(5443)
-var isstream = __nccwpck_require__(3362)
-var Buffer = __nccwpck_require__(1867).Buffer
+var uuid = __nccwpck_require__(80824)
+var CombinedStream = __nccwpck_require__(85443)
+var isstream = __nccwpck_require__(83362)
+var Buffer = __nccwpck_require__(21867).Buffer
 
 function Multipart (request) {
   this.request = request
@@ -43512,19 +43600,19 @@ exports.$ = Multipart
 
 /***/ }),
 
-/***/ 1174:
+/***/ 41174:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var url = __nccwpck_require__(8835)
-var qs = __nccwpck_require__(2760)
-var caseless = __nccwpck_require__(5684)
-var uuid = __nccwpck_require__(824)
-var oauth = __nccwpck_require__(8468)
-var crypto = __nccwpck_require__(6417)
-var Buffer = __nccwpck_require__(1867).Buffer
+var url = __nccwpck_require__(78835)
+var qs = __nccwpck_require__(22760)
+var caseless = __nccwpck_require__(35684)
+var uuid = __nccwpck_require__(80824)
+var oauth = __nccwpck_require__(43248)
+var crypto = __nccwpck_require__(76417)
+var Buffer = __nccwpck_require__(21867).Buffer
 
 function OAuth (request) {
   this.request = request
@@ -43668,14 +43756,14 @@ exports.f = OAuth
 
 /***/ }),
 
-/***/ 6476:
+/***/ 66476:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var qs = __nccwpck_require__(2760)
-var querystring = __nccwpck_require__(1191)
+var qs = __nccwpck_require__(22760)
+var querystring = __nccwpck_require__(71191)
 
 function Querystring (request) {
   this.request = request
@@ -43732,7 +43820,7 @@ exports.h = Querystring
 "use strict";
 
 
-var url = __nccwpck_require__(8835)
+var url = __nccwpck_require__(78835)
 var isUrl = /^https?:/
 
 function Redirect (request) {
@@ -43888,14 +43976,14 @@ exports.l = Redirect
 
 /***/ }),
 
-/***/ 7619:
+/***/ 17619:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var url = __nccwpck_require__(8835)
-var tunnel = __nccwpck_require__(1137)
+var url = __nccwpck_require__(78835)
+var tunnel = __nccwpck_require__(11137)
 
 var defaultProxyHeaderWhiteList = [
   'accept',
@@ -44071,19 +44159,19 @@ exports.n = Tunnel
 
 /***/ }),
 
-/***/ 1377:
+/***/ 11377:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var CombinedStream = __nccwpck_require__(5443);
-var util = __nccwpck_require__(1669);
-var path = __nccwpck_require__(5622);
-var http = __nccwpck_require__(8605);
-var https = __nccwpck_require__(7211);
-var parseUrl = __nccwpck_require__(8835).parse;
-var fs = __nccwpck_require__(5747);
-var mime = __nccwpck_require__(3583);
-var asynckit = __nccwpck_require__(4812);
-var populate = __nccwpck_require__(4932);
+var CombinedStream = __nccwpck_require__(85443);
+var util = __nccwpck_require__(31669);
+var path = __nccwpck_require__(85622);
+var http = __nccwpck_require__(98605);
+var https = __nccwpck_require__(57211);
+var parseUrl = __nccwpck_require__(78835).parse;
+var fs = __nccwpck_require__(35747);
+var mime = __nccwpck_require__(43583);
+var asynckit = __nccwpck_require__(14812);
+var populate = __nccwpck_require__(94932);
 
 // Public API
 module.exports = FormData;
@@ -44535,7 +44623,7 @@ FormData.prototype.toString = function () {
 
 /***/ }),
 
-/***/ 4932:
+/***/ 94932:
 /***/ ((module) => {
 
 // populates missing values
@@ -44552,41 +44640,41 @@ module.exports = function(dst, src) {
 
 /***/ }),
 
-/***/ 304:
+/***/ 70304:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var http = __nccwpck_require__(8605)
-var https = __nccwpck_require__(7211)
-var url = __nccwpck_require__(8835)
-var util = __nccwpck_require__(1669)
-var stream = __nccwpck_require__(2413)
-var zlib = __nccwpck_require__(8761)
-var aws2 = __nccwpck_require__(6342)
-var aws4 = __nccwpck_require__(6071)
-var httpSignature = __nccwpck_require__(2479)
-var mime = __nccwpck_require__(3583)
-var caseless = __nccwpck_require__(5684)
-var ForeverAgent = __nccwpck_require__(7568)
-var FormData = __nccwpck_require__(1377)
-var extend = __nccwpck_require__(8171)
-var isstream = __nccwpck_require__(3362)
-var isTypedArray = __nccwpck_require__(657).strict
-var helpers = __nccwpck_require__(4845)
-var cookies = __nccwpck_require__(976)
-var getProxyFromURI = __nccwpck_require__(5654)
-var Querystring = __nccwpck_require__(6476)/* .Querystring */ .h
+var http = __nccwpck_require__(98605)
+var https = __nccwpck_require__(57211)
+var url = __nccwpck_require__(78835)
+var util = __nccwpck_require__(31669)
+var stream = __nccwpck_require__(92413)
+var zlib = __nccwpck_require__(78761)
+var aws2 = __nccwpck_require__(96342)
+var aws4 = __nccwpck_require__(16071)
+var httpSignature = __nccwpck_require__(42479)
+var mime = __nccwpck_require__(43583)
+var caseless = __nccwpck_require__(35684)
+var ForeverAgent = __nccwpck_require__(47568)
+var FormData = __nccwpck_require__(11377)
+var extend = __nccwpck_require__(38171)
+var isstream = __nccwpck_require__(83362)
+var isTypedArray = __nccwpck_require__(10657).strict
+var helpers = __nccwpck_require__(74845)
+var cookies = __nccwpck_require__(50976)
+var getProxyFromURI = __nccwpck_require__(75654)
+var Querystring = __nccwpck_require__(66476)/* .Querystring */ .h
 var Har = __nccwpck_require__(3248)/* .Har */ .t
-var Auth = __nccwpck_require__(6996)/* .Auth */ .g
-var OAuth = __nccwpck_require__(1174)/* .OAuth */ .f
-var hawk = __nccwpck_require__(4473)
-var Multipart = __nccwpck_require__(7810)/* .Multipart */ .$
+var Auth = __nccwpck_require__(76996)/* .Auth */ .g
+var OAuth = __nccwpck_require__(41174)/* .OAuth */ .f
+var hawk = __nccwpck_require__(34473)
+var Multipart = __nccwpck_require__(87810)/* .Multipart */ .$
 var Redirect = __nccwpck_require__(3048)/* .Redirect */ .l
-var Tunnel = __nccwpck_require__(7619)/* .Tunnel */ .n
-var now = __nccwpck_require__(5644)
-var Buffer = __nccwpck_require__(1867).Buffer
+var Tunnel = __nccwpck_require__(17619)/* .Tunnel */ .n
+var now = __nccwpck_require__(85644)
+var Buffer = __nccwpck_require__(21867).Buffer
 
 var safeStringify = helpers.safeStringify
 var isReadStream = helpers.isReadStream
@@ -46113,17 +46201,17 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 4347:
+/***/ 24347:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(6244);
+module.exports = __nccwpck_require__(56244);
 
 /***/ }),
 
-/***/ 6244:
+/***/ 56244:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
-var RetryOperation = __nccwpck_require__(5369);
+var RetryOperation = __nccwpck_require__(45369);
 
 exports.operation = function(options) {
   var timeouts = exports.timeouts(options);
@@ -46227,7 +46315,7 @@ exports.wrap = function(obj, options, methods) {
 
 /***/ }),
 
-/***/ 5369:
+/***/ 45369:
 /***/ ((module) => {
 
 function RetryOperation(timeouts, options) {
@@ -46392,12 +46480,12 @@ RetryOperation.prototype.mainError = function() {
 
 /***/ }),
 
-/***/ 1867:
+/***/ 21867:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
 /* eslint-disable node/no-deprecated-api */
-var buffer = __nccwpck_require__(4293)
+var buffer = __nccwpck_require__(64293)
 var Buffer = buffer.Buffer
 
 // alternative to using Object.keys for old browsers
@@ -46464,7 +46552,7 @@ SafeBuffer.allocUnsafeSlow = function (size) {
 
 /***/ }),
 
-/***/ 5118:
+/***/ 15118:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -46472,7 +46560,7 @@ SafeBuffer.allocUnsafeSlow = function (size) {
 
 
 
-var buffer = __nccwpck_require__(4293)
+var buffer = __nccwpck_require__(64293)
 var Buffer = buffer.Buffer
 
 var safer = {}
@@ -46549,12 +46637,12 @@ module.exports = safer
 
 /***/ }),
 
-/***/ 6126:
+/***/ 66126:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
 
-var Buffer = __nccwpck_require__(5118).Buffer;
+var Buffer = __nccwpck_require__(15118).Buffer;
 
 var algInfo = {
 	'dsa': {
@@ -46731,23 +46819,23 @@ module.exports = {
 
 module.exports = Certificate;
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var crypto = __nccwpck_require__(6417);
-var Fingerprint = __nccwpck_require__(3079);
-var Signature = __nccwpck_require__(1394);
-var errs = __nccwpck_require__(7979);
-var util = __nccwpck_require__(1669);
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var Identity = __nccwpck_require__(508);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var crypto = __nccwpck_require__(76417);
+var Fingerprint = __nccwpck_require__(13079);
+var Signature = __nccwpck_require__(91394);
+var errs = __nccwpck_require__(27979);
+var util = __nccwpck_require__(31669);
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var Identity = __nccwpck_require__(70508);
 
 var formats = {};
-formats['openssh'] = __nccwpck_require__(4033);
-formats['x509'] = __nccwpck_require__(267);
-formats['pem'] = __nccwpck_require__(217);
+formats['openssh'] = __nccwpck_require__(94033);
+formats['x509'] = __nccwpck_require__(10267);
+formats['pem'] = __nccwpck_require__(30217);
 
 var CertificateParseError = errs.CertificateParseError;
 var InvalidAlgorithmError = errs.InvalidAlgorithmError;
@@ -47141,7 +47229,7 @@ Certificate._oldVersionDetect = function (obj) {
 
 /***/ }),
 
-/***/ 7602:
+/***/ 57602:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2017 Joyent, Inc.
@@ -47152,21 +47240,21 @@ module.exports = {
 	generateED25519: generateED25519
 };
 
-var assert = __nccwpck_require__(6631);
-var crypto = __nccwpck_require__(6417);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
-var nacl = __nccwpck_require__(8729);
+var assert = __nccwpck_require__(66631);
+var crypto = __nccwpck_require__(76417);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
+var nacl = __nccwpck_require__(68729);
 
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
 
 var CRYPTO_HAVE_ECDH = (crypto.createECDH !== undefined);
 
-var ecdh = __nccwpck_require__(9865);
+var ecdh = __nccwpck_require__(49865);
 var ec = __nccwpck_require__(3943);
-var jsbn = __nccwpck_require__(5587).BigInteger;
+var jsbn = __nccwpck_require__(85587).BigInteger;
 
 function DiffieHellman(key) {
 	utils.assertCompatible(key, Key, [1, 4], 'key');
@@ -47545,7 +47633,7 @@ function generateECDSA(curve) {
 
 /***/ }),
 
-/***/ 4694:
+/***/ 14694:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
@@ -47555,12 +47643,12 @@ module.exports = {
 	Signer: Signer
 };
 
-var nacl = __nccwpck_require__(8729);
-var stream = __nccwpck_require__(2413);
-var util = __nccwpck_require__(1669);
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var Signature = __nccwpck_require__(1394);
+var nacl = __nccwpck_require__(68729);
+var stream = __nccwpck_require__(92413);
+var util = __nccwpck_require__(31669);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var Signature = __nccwpck_require__(91394);
 
 function Verifier(key, hashAlgo) {
 	if (hashAlgo.toLowerCase() !== 'sha512')
@@ -47644,13 +47732,13 @@ Signer.prototype.sign = function () {
 
 /***/ }),
 
-/***/ 7979:
+/***/ 27979:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
 
-var assert = __nccwpck_require__(6631);
-var util = __nccwpck_require__(1669);
+var assert = __nccwpck_require__(66631);
+var util = __nccwpck_require__(31669);
 
 function FingerprintFormatError(fp, format) {
 	if (Error.captureStackTrace)
@@ -47735,22 +47823,22 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3079:
+/***/ 13079:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2018 Joyent, Inc.
 
 module.exports = Fingerprint;
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var crypto = __nccwpck_require__(6417);
-var errs = __nccwpck_require__(7979);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var crypto = __nccwpck_require__(76417);
+var errs = __nccwpck_require__(27979);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
 var Certificate = __nccwpck_require__(7406);
-var utils = __nccwpck_require__(575);
+var utils = __nccwpck_require__(80575);
 
 var FingerprintFormatError = errs.FingerprintFormatError;
 var InvalidAlgorithmError = errs.InvalidAlgorithmError;
@@ -47972,17 +48060,17 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
 
-var pem = __nccwpck_require__(4324);
-var ssh = __nccwpck_require__(8927);
-var rfc4253 = __nccwpck_require__(8688);
-var dnssec = __nccwpck_require__(2296);
-var putty = __nccwpck_require__(974);
+var pem = __nccwpck_require__(14324);
+var ssh = __nccwpck_require__(68927);
+var rfc4253 = __nccwpck_require__(88688);
+var dnssec = __nccwpck_require__(63561);
+var putty = __nccwpck_require__(80974);
 
 var DNSSEC_PRIVKEY_HEADER_PREFIX = 'Private-key-format: v1';
 
@@ -48093,7 +48181,7 @@ function write(key, options) {
 
 /***/ }),
 
-/***/ 2296:
+/***/ 63561:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2017 Joyent, Inc.
@@ -48103,13 +48191,13 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var utils = __nccwpck_require__(575);
-var SSHBuffer = __nccwpck_require__(5621);
-var Dhe = __nccwpck_require__(7602);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var utils = __nccwpck_require__(80575);
+var SSHBuffer = __nccwpck_require__(25621);
+var Dhe = __nccwpck_require__(57602);
 
 var supportedAlgos = {
 	'rsa-sha1' : 5,
@@ -48387,7 +48475,7 @@ function write(key, options) {
 
 /***/ }),
 
-/***/ 4033:
+/***/ 94033:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2017 Joyent, Inc.
@@ -48404,17 +48492,17 @@ module.exports = {
 	toBuffer: toBuffer
 };
 
-var assert = __nccwpck_require__(6631);
-var SSHBuffer = __nccwpck_require__(5621);
-var crypto = __nccwpck_require__(6417);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var Identity = __nccwpck_require__(508);
-var rfc4253 = __nccwpck_require__(8688);
-var Signature = __nccwpck_require__(1394);
-var utils = __nccwpck_require__(575);
+var assert = __nccwpck_require__(66631);
+var SSHBuffer = __nccwpck_require__(25621);
+var crypto = __nccwpck_require__(76417);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var Identity = __nccwpck_require__(70508);
+var rfc4253 = __nccwpck_require__(88688);
+var Signature = __nccwpck_require__(91394);
+var utils = __nccwpck_require__(80575);
 var Certificate = __nccwpck_require__(7406);
 
 function verify(cert, key) {
@@ -48746,7 +48834,7 @@ function getCertType(key) {
 
 /***/ }),
 
-/***/ 4324:
+/***/ 14324:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2018 Joyent, Inc.
@@ -48756,21 +48844,21 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var asn1 = __nccwpck_require__(970);
-var crypto = __nccwpck_require__(6417);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
+var assert = __nccwpck_require__(66631);
+var asn1 = __nccwpck_require__(80970);
+var crypto = __nccwpck_require__(76417);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
 
-var pkcs1 = __nccwpck_require__(9367);
+var pkcs1 = __nccwpck_require__(69367);
 var pkcs8 = __nccwpck_require__(4173);
 var sshpriv = __nccwpck_require__(3923);
-var rfc4253 = __nccwpck_require__(8688);
+var rfc4253 = __nccwpck_require__(88688);
 
-var errors = __nccwpck_require__(7979);
+var errors = __nccwpck_require__(27979);
 
 var OID_PBES2 = '1.2.840.113549.1.5.13';
 var OID_PBKDF2 = '1.2.840.113549.1.5.12';
@@ -49043,7 +49131,7 @@ function write(key, options, type) {
 
 /***/ }),
 
-/***/ 9367:
+/***/ 69367:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
@@ -49055,15 +49143,15 @@ module.exports = {
 	writePkcs1: writePkcs1
 };
 
-var assert = __nccwpck_require__(6631);
-var asn1 = __nccwpck_require__(970);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
+var assert = __nccwpck_require__(66631);
+var asn1 = __nccwpck_require__(80970);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
 
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var pem = __nccwpck_require__(4324);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var pem = __nccwpck_require__(14324);
 
 var pkcs8 = __nccwpck_require__(4173);
 var readECDSACurve = pkcs8.readECDSACurve;
@@ -49439,14 +49527,14 @@ module.exports = {
 	writeECDSACurve: writeECDSACurve
 };
 
-var assert = __nccwpck_require__(6631);
-var asn1 = __nccwpck_require__(970);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var pem = __nccwpck_require__(4324);
+var assert = __nccwpck_require__(66631);
+var asn1 = __nccwpck_require__(80970);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var pem = __nccwpck_require__(14324);
 
 function read(buf, options) {
 	return (pem.read(buf, options, 'pkcs8'));
@@ -50061,7 +50149,7 @@ function writePkcs8EdDSAPrivate(key, der) {
 
 /***/ }),
 
-/***/ 974:
+/***/ 80974:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2018 Joyent, Inc.
@@ -50071,12 +50159,12 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var rfc4253 = __nccwpck_require__(8688);
-var Key = __nccwpck_require__(6814);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var rfc4253 = __nccwpck_require__(88688);
+var Key = __nccwpck_require__(36814);
 
-var errors = __nccwpck_require__(7979);
+var errors = __nccwpck_require__(27979);
 
 function read(buf, options) {
 	var lines = buf.toString('ascii').split(/[\r\n]+/);
@@ -50167,7 +50255,7 @@ function wrap(txt, len) {
 
 /***/ }),
 
-/***/ 8688:
+/***/ 88688:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
@@ -50185,13 +50273,13 @@ module.exports = {
 	algToKeyType: algToKeyType
 };
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var SSHBuffer = __nccwpck_require__(5621);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var SSHBuffer = __nccwpck_require__(25621);
 
 function algToKeyType(alg) {
 	assert.string(alg);
@@ -50351,19 +50439,19 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var asn1 = __nccwpck_require__(970);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
-var crypto = __nccwpck_require__(6417);
+var assert = __nccwpck_require__(66631);
+var asn1 = __nccwpck_require__(80970);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
+var crypto = __nccwpck_require__(76417);
 
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var pem = __nccwpck_require__(4324);
-var rfc4253 = __nccwpck_require__(8688);
-var SSHBuffer = __nccwpck_require__(5621);
-var errors = __nccwpck_require__(7979);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var pem = __nccwpck_require__(14324);
+var rfc4253 = __nccwpck_require__(88688);
+var SSHBuffer = __nccwpck_require__(25621);
+var errors = __nccwpck_require__(27979);
 
 var bcrypt;
 
@@ -50412,7 +50500,7 @@ function readSSHPrivate(type, buf, options) {
 		var rounds = kdfOptsBuf.readInt();
 		var cinf = utils.opensshCipherInfo(cipher);
 		if (bcrypt === undefined) {
-			bcrypt = __nccwpck_require__(958);
+			bcrypt = __nccwpck_require__(45447);
 		}
 
 		if (typeof (options.passphrase) === 'string') {
@@ -50533,7 +50621,7 @@ function write(key, options) {
 		kdfopts = kdfssh.toBuffer();
 
 		if (bcrypt === undefined) {
-			bcrypt = __nccwpck_require__(958);
+			bcrypt = __nccwpck_require__(45447);
 		}
 		var pass = new Uint8Array(passphrase);
 		var salti = new Uint8Array(salt);
@@ -50609,7 +50697,7 @@ function write(key, options) {
 
 /***/ }),
 
-/***/ 8927:
+/***/ 68927:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
@@ -50619,12 +50707,12 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var rfc4253 = __nccwpck_require__(8688);
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var rfc4253 = __nccwpck_require__(88688);
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
 
 var sshpriv = __nccwpck_require__(3923);
 
@@ -50731,12 +50819,12 @@ function write(key, options) {
 
 /***/ }),
 
-/***/ 217:
+/***/ 30217:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2016 Joyent, Inc.
 
-var x509 = __nccwpck_require__(267);
+var x509 = __nccwpck_require__(10267);
 
 module.exports = {
 	read: read,
@@ -50745,16 +50833,16 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var asn1 = __nccwpck_require__(970);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var pem = __nccwpck_require__(4324);
-var Identity = __nccwpck_require__(508);
-var Signature = __nccwpck_require__(1394);
+var assert = __nccwpck_require__(66631);
+var asn1 = __nccwpck_require__(80970);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var pem = __nccwpck_require__(14324);
+var Identity = __nccwpck_require__(70508);
+var Signature = __nccwpck_require__(91394);
 var Certificate = __nccwpck_require__(7406);
 
 function read(buf, options) {
@@ -50826,7 +50914,7 @@ function write(cert, options) {
 
 /***/ }),
 
-/***/ 267:
+/***/ 10267:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2017 Joyent, Inc.
@@ -50839,16 +50927,16 @@ module.exports = {
 	write: write
 };
 
-var assert = __nccwpck_require__(6631);
-var asn1 = __nccwpck_require__(970);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var utils = __nccwpck_require__(575);
-var Key = __nccwpck_require__(6814);
-var PrivateKey = __nccwpck_require__(9602);
-var pem = __nccwpck_require__(4324);
-var Identity = __nccwpck_require__(508);
-var Signature = __nccwpck_require__(1394);
+var assert = __nccwpck_require__(66631);
+var asn1 = __nccwpck_require__(80970);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var utils = __nccwpck_require__(80575);
+var Key = __nccwpck_require__(36814);
+var PrivateKey = __nccwpck_require__(29602);
+var pem = __nccwpck_require__(14324);
+var Identity = __nccwpck_require__(70508);
+var Signature = __nccwpck_require__(91394);
 var Certificate = __nccwpck_require__(7406);
 var pkcs8 = __nccwpck_require__(4173);
 
@@ -51585,23 +51673,23 @@ function writeBitField(setBits, bitIndex) {
 
 /***/ }),
 
-/***/ 508:
+/***/ 70508:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2017 Joyent, Inc.
 
 module.exports = Identity;
 
-var assert = __nccwpck_require__(6631);
-var algs = __nccwpck_require__(6126);
-var crypto = __nccwpck_require__(6417);
-var Fingerprint = __nccwpck_require__(3079);
-var Signature = __nccwpck_require__(1394);
-var errs = __nccwpck_require__(7979);
-var util = __nccwpck_require__(1669);
-var utils = __nccwpck_require__(575);
-var asn1 = __nccwpck_require__(970);
-var Buffer = __nccwpck_require__(5118).Buffer;
+var assert = __nccwpck_require__(66631);
+var algs = __nccwpck_require__(66126);
+var crypto = __nccwpck_require__(76417);
+var Fingerprint = __nccwpck_require__(13079);
+var Signature = __nccwpck_require__(91394);
+var errs = __nccwpck_require__(27979);
+var util = __nccwpck_require__(31669);
+var utils = __nccwpck_require__(80575);
+var asn1 = __nccwpck_require__(80970);
+var Buffer = __nccwpck_require__(15118).Buffer;
 
 /*JSSTYLED*/
 var DNS_NAME_RE = /^([*]|[a-z0-9][a-z0-9\-]{0,62})(?:\.([*]|[a-z0-9][a-z0-9\-]{0,62}))*$/i;
@@ -51965,18 +52053,18 @@ Identity._oldVersionDetect = function (obj) {
 
 /***/ }),
 
-/***/ 7022:
+/***/ 87022:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
 
-var Key = __nccwpck_require__(6814);
-var Fingerprint = __nccwpck_require__(3079);
-var Signature = __nccwpck_require__(1394);
-var PrivateKey = __nccwpck_require__(9602);
+var Key = __nccwpck_require__(36814);
+var Fingerprint = __nccwpck_require__(13079);
+var Signature = __nccwpck_require__(91394);
+var PrivateKey = __nccwpck_require__(29602);
 var Certificate = __nccwpck_require__(7406);
-var Identity = __nccwpck_require__(508);
-var errs = __nccwpck_require__(7979);
+var Identity = __nccwpck_require__(70508);
+var errs = __nccwpck_require__(27979);
 
 module.exports = {
 	/* top-level classes */
@@ -52012,26 +52100,26 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6814:
+/***/ 36814:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2018 Joyent, Inc.
 
 module.exports = Key;
 
-var assert = __nccwpck_require__(6631);
-var algs = __nccwpck_require__(6126);
-var crypto = __nccwpck_require__(6417);
-var Fingerprint = __nccwpck_require__(3079);
-var Signature = __nccwpck_require__(1394);
-var DiffieHellman = __nccwpck_require__(7602).DiffieHellman;
-var errs = __nccwpck_require__(7979);
-var utils = __nccwpck_require__(575);
-var PrivateKey = __nccwpck_require__(9602);
+var assert = __nccwpck_require__(66631);
+var algs = __nccwpck_require__(66126);
+var crypto = __nccwpck_require__(76417);
+var Fingerprint = __nccwpck_require__(13079);
+var Signature = __nccwpck_require__(91394);
+var DiffieHellman = __nccwpck_require__(57602).DiffieHellman;
+var errs = __nccwpck_require__(27979);
+var utils = __nccwpck_require__(80575);
+var PrivateKey = __nccwpck_require__(29602);
 var edCompat;
 
 try {
-	edCompat = __nccwpck_require__(4694);
+	edCompat = __nccwpck_require__(14694);
 } catch (e) {
 	/* Just continue through, and bail out if we try to use it. */
 }
@@ -52041,15 +52129,15 @@ var KeyParseError = errs.KeyParseError;
 
 var formats = {};
 formats['auto'] = __nccwpck_require__(8243);
-formats['pem'] = __nccwpck_require__(4324);
-formats['pkcs1'] = __nccwpck_require__(9367);
+formats['pem'] = __nccwpck_require__(14324);
+formats['pkcs1'] = __nccwpck_require__(69367);
 formats['pkcs8'] = __nccwpck_require__(4173);
-formats['rfc4253'] = __nccwpck_require__(8688);
-formats['ssh'] = __nccwpck_require__(8927);
+formats['rfc4253'] = __nccwpck_require__(88688);
+formats['ssh'] = __nccwpck_require__(68927);
 formats['ssh-private'] = __nccwpck_require__(3923);
 formats['openssh'] = formats['ssh-private'];
-formats['dnssec'] = __nccwpck_require__(2296);
-formats['putty'] = __nccwpck_require__(974);
+formats['dnssec'] = __nccwpck_require__(63561);
+formats['putty'] = __nccwpck_require__(80974);
 formats['ppk'] = formats['putty'];
 
 function Key(opts) {
@@ -52313,29 +52401,29 @@ Key._oldVersionDetect = function (obj) {
 
 /***/ }),
 
-/***/ 9602:
+/***/ 29602:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2017 Joyent, Inc.
 
 module.exports = PrivateKey;
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var crypto = __nccwpck_require__(6417);
-var Fingerprint = __nccwpck_require__(3079);
-var Signature = __nccwpck_require__(1394);
-var errs = __nccwpck_require__(7979);
-var util = __nccwpck_require__(1669);
-var utils = __nccwpck_require__(575);
-var dhe = __nccwpck_require__(7602);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var crypto = __nccwpck_require__(76417);
+var Fingerprint = __nccwpck_require__(13079);
+var Signature = __nccwpck_require__(91394);
+var errs = __nccwpck_require__(27979);
+var util = __nccwpck_require__(31669);
+var utils = __nccwpck_require__(80575);
+var dhe = __nccwpck_require__(57602);
 var generateECDSA = dhe.generateECDSA;
 var generateED25519 = dhe.generateED25519;
-var edCompat = __nccwpck_require__(4694);
-var nacl = __nccwpck_require__(8729);
+var edCompat = __nccwpck_require__(14694);
+var nacl = __nccwpck_require__(68729);
 
-var Key = __nccwpck_require__(6814);
+var Key = __nccwpck_require__(36814);
 
 var InvalidAlgorithmError = errs.InvalidAlgorithmError;
 var KeyParseError = errs.KeyParseError;
@@ -52343,14 +52431,14 @@ var KeyEncryptedError = errs.KeyEncryptedError;
 
 var formats = {};
 formats['auto'] = __nccwpck_require__(8243);
-formats['pem'] = __nccwpck_require__(4324);
-formats['pkcs1'] = __nccwpck_require__(9367);
+formats['pem'] = __nccwpck_require__(14324);
+formats['pkcs1'] = __nccwpck_require__(69367);
 formats['pkcs8'] = __nccwpck_require__(4173);
-formats['rfc4253'] = __nccwpck_require__(8688);
+formats['rfc4253'] = __nccwpck_require__(88688);
 formats['ssh-private'] = __nccwpck_require__(3923);
 formats['openssh'] = formats['ssh-private'];
 formats['ssh'] = formats['ssh-private'];
-formats['dnssec'] = __nccwpck_require__(2296);
+formats['dnssec'] = __nccwpck_require__(63561);
 
 function PrivateKey(opts) {
 	assert.object(opts, 'options');
@@ -52566,21 +52654,21 @@ PrivateKey._oldVersionDetect = function (obj) {
 
 /***/ }),
 
-/***/ 1394:
+/***/ 91394:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
 
 module.exports = Signature;
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var algs = __nccwpck_require__(6126);
-var crypto = __nccwpck_require__(6417);
-var errs = __nccwpck_require__(7979);
-var utils = __nccwpck_require__(575);
-var asn1 = __nccwpck_require__(970);
-var SSHBuffer = __nccwpck_require__(5621);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var algs = __nccwpck_require__(66126);
+var crypto = __nccwpck_require__(76417);
+var errs = __nccwpck_require__(27979);
+var utils = __nccwpck_require__(80575);
+var asn1 = __nccwpck_require__(80970);
+var SSHBuffer = __nccwpck_require__(25621);
 
 var InvalidAlgorithmError = errs.InvalidAlgorithmError;
 var SignatureParseError = errs.SignatureParseError;
@@ -52887,15 +52975,15 @@ Signature._oldVersionDetect = function (obj) {
 
 /***/ }),
 
-/***/ 5621:
+/***/ 25621:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
 
 module.exports = SSHBuffer;
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
 
 function SSHBuffer(opts) {
 	assert.object(opts, 'options');
@@ -53043,7 +53131,7 @@ SSHBuffer.prototype.write = function (buf) {
 
 /***/ }),
 
-/***/ 575:
+/***/ 80575:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Copyright 2015 Joyent, Inc.
@@ -53069,17 +53157,17 @@ module.exports = {
 	pbkdf2: pbkdf2
 };
 
-var assert = __nccwpck_require__(6631);
-var Buffer = __nccwpck_require__(5118).Buffer;
-var PrivateKey = __nccwpck_require__(9602);
-var Key = __nccwpck_require__(6814);
-var crypto = __nccwpck_require__(6417);
-var algs = __nccwpck_require__(6126);
-var asn1 = __nccwpck_require__(970);
+var assert = __nccwpck_require__(66631);
+var Buffer = __nccwpck_require__(15118).Buffer;
+var PrivateKey = __nccwpck_require__(29602);
+var Key = __nccwpck_require__(36814);
+var crypto = __nccwpck_require__(76417);
+var algs = __nccwpck_require__(66126);
+var asn1 = __nccwpck_require__(80970);
 
 var ec = __nccwpck_require__(3943);
-var jsbn = __nccwpck_require__(5587).BigInteger;
-var nacl = __nccwpck_require__(8729);
+var jsbn = __nccwpck_require__(85587).BigInteger;
+var nacl = __nccwpck_require__(68729);
 
 var MAX_CLASS_DEPTH = 3;
 
@@ -53454,7 +53542,7 @@ function opensshCipherInfo(cipher) {
 
 /***/ }),
 
-/***/ 42:
+/***/ 90042:
 /***/ ((module) => {
 
 "use strict";
@@ -53543,14 +53631,14 @@ module.exports = function (requireCache, callback, callbackForModulesToKeep, mod
 
 /***/ }),
 
-/***/ 9318:
+/***/ 59318:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const os = __nccwpck_require__(2087);
-const tty = __nccwpck_require__(3867);
-const hasFlag = __nccwpck_require__(1621);
+const os = __nccwpck_require__(12087);
+const tty = __nccwpck_require__(33867);
+const hasFlag = __nccwpck_require__(31621);
 
 const {env} = process;
 
@@ -53686,7 +53774,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7372:
+/***/ 47372:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -53721,18 +53809,18 @@ module.exports = {
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-var net = __nccwpck_require__(1631);
-var urlParse = __nccwpck_require__(8835).parse;
-var util = __nccwpck_require__(1669);
-var pubsuffix = __nccwpck_require__(4401);
+var net = __nccwpck_require__(11631);
+var urlParse = __nccwpck_require__(78835).parse;
+var util = __nccwpck_require__(31669);
+var pubsuffix = __nccwpck_require__(94401);
 var Store = __nccwpck_require__(460)/* .Store */ .y;
-var MemoryCookieStore = __nccwpck_require__(2640)/* .MemoryCookieStore */ .m;
-var pathMatch = __nccwpck_require__(4336)/* .pathMatch */ .U;
-var VERSION = __nccwpck_require__(3199);
+var MemoryCookieStore = __nccwpck_require__(52640)/* .MemoryCookieStore */ .m;
+var pathMatch = __nccwpck_require__(54336)/* .pathMatch */ .U;
+var VERSION = __nccwpck_require__(93199);
 
 var punycode;
 try {
-  punycode = __nccwpck_require__(4213);
+  punycode = __nccwpck_require__(94213);
 } catch(e) {
   console.warn("tough-cookie: can't load punycode; won't use punycode for domain normalization");
 }
@@ -55169,14 +55257,14 @@ exports.defaultPath = defaultPath;
 exports.pathMatch = pathMatch;
 exports.getPublicSuffix = pubsuffix.getPublicSuffix;
 exports.cookieCompare = cookieCompare;
-exports.permuteDomain = __nccwpck_require__(5986).permuteDomain;
+exports.permuteDomain = __nccwpck_require__(55986).permuteDomain;
 exports.permutePath = permutePath;
 exports.canonicalDomain = canonicalDomain;
 
 
 /***/ }),
 
-/***/ 2640:
+/***/ 52640:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55212,9 +55300,9 @@ exports.canonicalDomain = canonicalDomain;
  */
 
 var Store = __nccwpck_require__(460)/* .Store */ .y;
-var permuteDomain = __nccwpck_require__(5986).permuteDomain;
-var pathMatch = __nccwpck_require__(4336)/* .pathMatch */ .U;
-var util = __nccwpck_require__(1669);
+var permuteDomain = __nccwpck_require__(55986).permuteDomain;
+var pathMatch = __nccwpck_require__(54336)/* .pathMatch */ .U;
+var util = __nccwpck_require__(31669);
 
 function MemoryCookieStore() {
   Store.call(this);
@@ -55365,7 +55453,7 @@ MemoryCookieStore.prototype.getAllCookies = function(cb) {
 
 /***/ }),
 
-/***/ 4336:
+/***/ 54336:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -55434,7 +55522,7 @@ exports.U = pathMatch;
 
 /***/ }),
 
-/***/ 5986:
+/***/ 55986:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55469,7 +55557,7 @@ exports.U = pathMatch;
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-var pubsuffix = __nccwpck_require__(4401);
+var pubsuffix = __nccwpck_require__(94401);
 
 // Gives the permutation of all possible domainMatch()es of a given domain. The
 // array is in shortest-to-longest order.  Handy for indexing.
@@ -55498,7 +55586,7 @@ exports.permuteDomain = permuteDomain;
 
 /***/ }),
 
-/***/ 4401:
+/***/ 94401:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -55533,7 +55621,7 @@ exports.permuteDomain = permuteDomain;
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-var psl = __nccwpck_require__(9975);
+var psl = __nccwpck_require__(29975);
 
 function getPublicSuffix(domain) {
   return psl.get(domain);
@@ -55627,7 +55715,7 @@ Store.prototype.getAllCookies = function(cb) {
 
 /***/ }),
 
-/***/ 3199:
+/***/ 93199:
 /***/ ((module) => {
 
 // generated by genversion
@@ -55636,20 +55724,20 @@ module.exports = '2.5.0'
 
 /***/ }),
 
-/***/ 1137:
+/***/ 11137:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(1631)
+var net = __nccwpck_require__(11631)
   , tls = __nccwpck_require__(4016)
-  , http = __nccwpck_require__(8605)
-  , https = __nccwpck_require__(7211)
-  , events = __nccwpck_require__(8614)
-  , assert = __nccwpck_require__(2357)
-  , util = __nccwpck_require__(1669)
-  , Buffer = __nccwpck_require__(1867).Buffer
+  , http = __nccwpck_require__(98605)
+  , https = __nccwpck_require__(57211)
+  , events = __nccwpck_require__(28614)
+  , assert = __nccwpck_require__(42357)
+  , util = __nccwpck_require__(31669)
+  , Buffer = __nccwpck_require__(21867).Buffer
   ;
 
 exports.httpOverHttp = httpOverHttp
@@ -55888,27 +55976,27 @@ exports.debug = debug // for test
 
 /***/ }),
 
-/***/ 4294:
+/***/ 74294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(4219);
+module.exports = __nccwpck_require__(54219);
 
 
 /***/ }),
 
-/***/ 4219:
+/***/ 54219:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(1631);
+var net = __nccwpck_require__(11631);
 var tls = __nccwpck_require__(4016);
-var http = __nccwpck_require__(8605);
-var https = __nccwpck_require__(7211);
-var events = __nccwpck_require__(8614);
-var assert = __nccwpck_require__(2357);
-var util = __nccwpck_require__(1669);
+var http = __nccwpck_require__(98605);
+var https = __nccwpck_require__(57211);
+var events = __nccwpck_require__(28614);
+var assert = __nccwpck_require__(42357);
+var util = __nccwpck_require__(31669);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -56168,7 +56256,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 8729:
+/***/ 68729:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 (function(nacl) {
@@ -58547,7 +58635,7 @@ nacl.setPRNG = function(fn) {
     });
   } else if (true) {
     // Node.js.
-    crypto = __nccwpck_require__(6417);
+    crypto = __nccwpck_require__(76417);
     if (crypto && crypto.randomBytes) {
       nacl.setPRNG(function(x, n) {
         var i, v = crypto.randomBytes(n);
@@ -58563,7 +58651,7 @@ nacl.setPRNG = function(fn) {
 
 /***/ }),
 
-/***/ 4839:
+/***/ 64839:
 /***/ ((__unused_webpack_module, exports) => {
 
 var __webpack_unused_export__;
@@ -58573,7 +58661,7 @@ class e{constructor(e){const{length:a,separator:i,dictionaries:n,style:l,seed:r}
 
 /***/ }),
 
-/***/ 5030:
+/***/ 45030:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -58599,7 +58687,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 20:
+/***/ 70020:
 /***/ (function(__unused_webpack_module, exports) {
 
 /** @license URI.js v4.4.0 (c) 2011 Gary Court. License: http://github.com/garycourt/uri-js */
@@ -60048,7 +60136,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 /***/ }),
 
-/***/ 2707:
+/***/ 92707:
 /***/ ((module) => {
 
 /**
@@ -60081,13 +60169,13 @@ module.exports = bytesToUuid;
 
 /***/ }),
 
-/***/ 5859:
+/***/ 15859:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Unique ID creation requires a high quality random # generator.  In node.js
 // this is pretty straight-forward - we use the crypto API.
 
-var crypto = __nccwpck_require__(6417);
+var crypto = __nccwpck_require__(76417);
 
 module.exports = function nodeRNG() {
   return crypto.randomBytes(16);
@@ -60096,11 +60184,11 @@ module.exports = function nodeRNG() {
 
 /***/ }),
 
-/***/ 824:
+/***/ 80824:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var rng = __nccwpck_require__(5859);
-var bytesToUuid = __nccwpck_require__(2707);
+var rng = __nccwpck_require__(15859);
+var bytesToUuid = __nccwpck_require__(92707);
 
 function v4(options, buf, offset) {
   var i = buf && offset || 0;
@@ -60132,18 +60220,18 @@ module.exports = v4;
 
 /***/ }),
 
-/***/ 1692:
+/***/ 81692:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /*
  * verror.js: richer JavaScript errors
  */
 
-var mod_assertplus = __nccwpck_require__(6631);
-var mod_util = __nccwpck_require__(1669);
+var mod_assertplus = __nccwpck_require__(66631);
+var mod_util = __nccwpck_require__(31669);
 
-var mod_extsprintf = __nccwpck_require__(1508);
-var mod_isError = __nccwpck_require__(5898)/* .isError */ .VZ;
+var mod_extsprintf = __nccwpck_require__(41508);
+var mod_isError = __nccwpck_require__(95898)/* .isError */ .VZ;
 var sprintf = mod_extsprintf.sprintf;
 
 /*
@@ -60590,15 +60678,15 @@ WError.prototype.cause = function we_cause(c)
 
 /***/ }),
 
-/***/ 1508:
+/***/ 41508:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 /*
  * extsprintf.js: extended POSIX-style sprintf
  */
 
-var mod_assert = __nccwpck_require__(2357);
-var mod_util = __nccwpck_require__(1669);
+var mod_assert = __nccwpck_require__(42357);
+var mod_util = __nccwpck_require__(31669);
 
 /*
  * Public interface
@@ -60822,7 +60910,7 @@ function dumpException(ex)
 
 /***/ }),
 
-/***/ 2940:
+/***/ 62940:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -60862,7 +60950,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 2877:
+/***/ 22877:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -60870,7 +60958,7 @@ module.exports = eval("require")("encoding");
 
 /***/ }),
 
-/***/ 6835:
+/***/ 66835:
 /***/ ((module) => {
 
 "use strict";
@@ -60878,7 +60966,7 @@ module.exports = JSON.parse('{"$schema":"http://json-schema.org/draft-07/schema#
 
 /***/ }),
 
-/***/ 1030:
+/***/ 81030:
 /***/ ((module) => {
 
 "use strict";
@@ -60886,7 +60974,7 @@ module.exports = JSON.parse('{"$schema":"http://json-schema.org/draft-06/schema#
 
 /***/ }),
 
-/***/ 38:
+/***/ 40038:
 /***/ ((module) => {
 
 "use strict";
@@ -60894,7 +60982,7 @@ module.exports = JSON.parse('{"$schema":"http://json-schema.org/draft-07/schema#
 
 /***/ }),
 
-/***/ 696:
+/***/ 20696:
 /***/ ((module) => {
 
 "use strict";
@@ -60902,7 +60990,7 @@ module.exports = JSON.parse('{"name":"axios","version":"0.21.1","description":"P
 
 /***/ }),
 
-/***/ 4391:
+/***/ 24391:
 /***/ ((module) => {
 
 "use strict";
@@ -60910,7 +60998,7 @@ module.exports = JSON.parse('{"$id":"afterRequest.json#","$schema":"http://json-
 
 /***/ }),
 
-/***/ 4440:
+/***/ 94440:
 /***/ ((module) => {
 
 "use strict";
@@ -60918,7 +61006,7 @@ module.exports = JSON.parse('{"$id":"beforeRequest.json#","$schema":"http://json
 
 /***/ }),
 
-/***/ 9850:
+/***/ 99850:
 /***/ ((module) => {
 
 "use strict";
@@ -60926,7 +61014,7 @@ module.exports = JSON.parse('{"$id":"browser.json#","$schema":"http://json-schem
 
 /***/ }),
 
-/***/ 7654:
+/***/ 77654:
 /***/ ((module) => {
 
 "use strict";
@@ -60934,7 +61022,7 @@ module.exports = JSON.parse('{"$id":"cache.json#","$schema":"http://json-schema.
 
 /***/ }),
 
-/***/ 3656:
+/***/ 73656:
 /***/ ((module) => {
 
 "use strict";
@@ -60942,7 +61030,7 @@ module.exports = JSON.parse('{"$id":"content.json#","$schema":"http://json-schem
 
 /***/ }),
 
-/***/ 7948:
+/***/ 67948:
 /***/ ((module) => {
 
 "use strict";
@@ -60950,7 +61038,7 @@ module.exports = JSON.parse('{"$id":"cookie.json#","$schema":"http://json-schema
 
 /***/ }),
 
-/***/ 3412:
+/***/ 33412:
 /***/ ((module) => {
 
 "use strict";
@@ -60958,7 +61046,7 @@ module.exports = JSON.parse('{"$id":"creator.json#","$schema":"http://json-schem
 
 /***/ }),
 
-/***/ 2525:
+/***/ 32525:
 /***/ ((module) => {
 
 "use strict";
@@ -60966,7 +61054,7 @@ module.exports = JSON.parse('{"$id":"entry.json#","$schema":"http://json-schema.
 
 /***/ }),
 
-/***/ 4943:
+/***/ 84943:
 /***/ ((module) => {
 
 "use strict";
@@ -60974,7 +61062,7 @@ module.exports = JSON.parse('{"$id":"har.json#","$schema":"http://json-schema.or
 
 /***/ }),
 
-/***/ 8344:
+/***/ 68344:
 /***/ ((module) => {
 
 "use strict";
@@ -60982,7 +61070,7 @@ module.exports = JSON.parse('{"$id":"header.json#","$schema":"http://json-schema
 
 /***/ }),
 
-/***/ 9142:
+/***/ 69142:
 /***/ ((module) => {
 
 "use strict";
@@ -60990,7 +61078,7 @@ module.exports = JSON.parse('{"$id":"log.json#","$schema":"http://json-schema.or
 
 /***/ }),
 
-/***/ 9075:
+/***/ 29075:
 /***/ ((module) => {
 
 "use strict";
@@ -60998,7 +61086,7 @@ module.exports = JSON.parse('{"$id":"page.json#","$schema":"http://json-schema.o
 
 /***/ }),
 
-/***/ 5096:
+/***/ 15096:
 /***/ ((module) => {
 
 "use strict";
@@ -61006,7 +61094,7 @@ module.exports = JSON.parse('{"$id":"pageTimings.json#","$schema":"http://json-s
 
 /***/ }),
 
-/***/ 3697:
+/***/ 73697:
 /***/ ((module) => {
 
 "use strict";
@@ -61014,7 +61102,7 @@ module.exports = JSON.parse('{"$id":"postData.json#","$schema":"http://json-sche
 
 /***/ }),
 
-/***/ 877:
+/***/ 70877:
 /***/ ((module) => {
 
 "use strict";
@@ -61022,7 +61110,7 @@ module.exports = JSON.parse('{"$id":"query.json#","$schema":"http://json-schema.
 
 /***/ }),
 
-/***/ 2084:
+/***/ 92084:
 /***/ ((module) => {
 
 "use strict";
@@ -61030,7 +61118,7 @@ module.exports = JSON.parse('{"$id":"request.json#","$schema":"http://json-schem
 
 /***/ }),
 
-/***/ 702:
+/***/ 20702:
 /***/ ((module) => {
 
 "use strict";
@@ -61038,7 +61126,7 @@ module.exports = JSON.parse('{"$id":"response.json#","$schema":"http://json-sche
 
 /***/ }),
 
-/***/ 6941:
+/***/ 36941:
 /***/ ((module) => {
 
 "use strict";
@@ -61046,7 +61134,7 @@ module.exports = JSON.parse('{"$id":"timings.json#","$schema":"http://json-schem
 
 /***/ }),
 
-/***/ 3313:
+/***/ 73313:
 /***/ ((module) => {
 
 "use strict";
@@ -61054,7 +61142,7 @@ module.exports = JSON.parse('{"application/1d-interleaved-parityfec":{"source":"
 
 /***/ }),
 
-/***/ 7574:
+/***/ 2156:
 /***/ ((module) => {
 
 "use strict";
@@ -61062,7 +61150,7 @@ module.exports = JSON.parse('["ac","com.ac","edu.ac","gov.ac","net.ac","mil.ac",
 
 /***/ }),
 
-/***/ 2357:
+/***/ 42357:
 /***/ ((module) => {
 
 "use strict";
@@ -61070,7 +61158,7 @@ module.exports = require("assert");;
 
 /***/ }),
 
-/***/ 7303:
+/***/ 77303:
 /***/ ((module) => {
 
 "use strict";
@@ -61078,7 +61166,7 @@ module.exports = require("async_hooks");;
 
 /***/ }),
 
-/***/ 4293:
+/***/ 64293:
 /***/ ((module) => {
 
 "use strict";
@@ -61086,7 +61174,7 @@ module.exports = require("buffer");;
 
 /***/ }),
 
-/***/ 6417:
+/***/ 76417:
 /***/ ((module) => {
 
 "use strict";
@@ -61094,7 +61182,7 @@ module.exports = require("crypto");;
 
 /***/ }),
 
-/***/ 8614:
+/***/ 28614:
 /***/ ((module) => {
 
 "use strict";
@@ -61102,7 +61190,7 @@ module.exports = require("events");;
 
 /***/ }),
 
-/***/ 5747:
+/***/ 35747:
 /***/ ((module) => {
 
 "use strict";
@@ -61110,7 +61198,7 @@ module.exports = require("fs");;
 
 /***/ }),
 
-/***/ 8605:
+/***/ 98605:
 /***/ ((module) => {
 
 "use strict";
@@ -61118,7 +61206,7 @@ module.exports = require("http");;
 
 /***/ }),
 
-/***/ 7211:
+/***/ 57211:
 /***/ ((module) => {
 
 "use strict";
@@ -61126,7 +61214,7 @@ module.exports = require("https");;
 
 /***/ }),
 
-/***/ 1631:
+/***/ 11631:
 /***/ ((module) => {
 
 "use strict";
@@ -61134,7 +61222,7 @@ module.exports = require("net");;
 
 /***/ }),
 
-/***/ 2087:
+/***/ 12087:
 /***/ ((module) => {
 
 "use strict";
@@ -61142,7 +61230,7 @@ module.exports = require("os");;
 
 /***/ }),
 
-/***/ 5622:
+/***/ 85622:
 /***/ ((module) => {
 
 "use strict";
@@ -61150,7 +61238,7 @@ module.exports = require("path");;
 
 /***/ }),
 
-/***/ 4213:
+/***/ 94213:
 /***/ ((module) => {
 
 "use strict";
@@ -61158,7 +61246,7 @@ module.exports = require("punycode");;
 
 /***/ }),
 
-/***/ 1191:
+/***/ 71191:
 /***/ ((module) => {
 
 "use strict";
@@ -61166,7 +61254,7 @@ module.exports = require("querystring");;
 
 /***/ }),
 
-/***/ 2413:
+/***/ 92413:
 /***/ ((module) => {
 
 "use strict";
@@ -61182,7 +61270,7 @@ module.exports = require("tls");;
 
 /***/ }),
 
-/***/ 3867:
+/***/ 33867:
 /***/ ((module) => {
 
 "use strict";
@@ -61190,7 +61278,7 @@ module.exports = require("tty");;
 
 /***/ }),
 
-/***/ 8835:
+/***/ 78835:
 /***/ ((module) => {
 
 "use strict";
@@ -61198,7 +61286,7 @@ module.exports = require("url");;
 
 /***/ }),
 
-/***/ 1669:
+/***/ 31669:
 /***/ ((module) => {
 
 "use strict";
@@ -61206,7 +61294,7 @@ module.exports = require("util");;
 
 /***/ }),
 
-/***/ 8761:
+/***/ 78761:
 /***/ ((module) => {
 
 "use strict";
@@ -61331,17 +61419,17 @@ __nccwpck_require__.d(Inputs_namespaceObject, {
 });
 
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
-var core = __nccwpck_require__(2186);
+var core = __nccwpck_require__(42186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
-var github = __nccwpck_require__(5438);
+var github = __nccwpck_require__(95438);
 // EXTERNAL MODULE: ./node_modules/lodash/escapeRegExp.js
-var escapeRegExp = __nccwpck_require__(8415);
+var escapeRegExp = __nccwpck_require__(98415);
 var escapeRegExp_default = /*#__PURE__*/__nccwpck_require__.n(escapeRegExp);
 // EXTERNAL MODULE: ./node_modules/lodash/isFunction.js
-var isFunction = __nccwpck_require__(7799);
+var isFunction = __nccwpck_require__(17799);
 var isFunction_default = /*#__PURE__*/__nccwpck_require__.n(isFunction);
 // EXTERNAL MODULE: ./node_modules/lodash/isNil.js
-var lodash_isNil = __nccwpck_require__(4977);
+var lodash_isNil = __nccwpck_require__(84977);
 var isNil_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isNil);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
@@ -61367,7 +61455,7 @@ const slackErrorChannelId = () => (0,core.getInput)('slack-error-channel-id', { 
 const slackToken = () => (0,core.getInput)('slack-token', { required: true });
 
 // EXTERNAL MODULE: ./node_modules/@slack/web-api/dist/index.js
-var dist = __nccwpck_require__(431);
+var dist = __nccwpck_require__(60431);
 ;// CONCATENATED MODULE: ./src/services/Slack/Client.ts
 
 
@@ -61501,9 +61589,9 @@ const sendUserMessage = (userId, message) => __awaiter(void 0, void 0, void 0, f
 
 
 // EXTERNAL MODULE: external "crypto"
-var external_crypto_ = __nccwpck_require__(6417);
+var external_crypto_ = __nccwpck_require__(76417);
 // EXTERNAL MODULE: ./node_modules/node-fetch/lib/index.js
-var lib = __nccwpck_require__(467);
+var lib = __nccwpck_require__(80467);
 var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 ;// CONCATENATED MODULE: ./src/services/Credentials.ts
 var Credentials_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -61569,7 +61657,7 @@ const Credentials_fetchRepository = (name) => Credentials_awaiter(void 0, void 0
 var isUndefined = __nccwpck_require__(2825);
 var isUndefined_default = /*#__PURE__*/__nccwpck_require__.n(isUndefined);
 // EXTERNAL MODULE: ./node_modules/@octokit/rest/dist-node/index.js
-var dist_node = __nccwpck_require__(5375);
+var dist_node = __nccwpck_require__(55375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
@@ -61874,7 +61962,7 @@ const Constants_MasterBranchName = 'master';
 const ReleaseBranchName = `${GithubWriteUser}/release-candidate`;
 
 // EXTERNAL MODULE: ./node_modules/lodash/isEqual.js
-var isEqual = __nccwpck_require__(52);
+var isEqual = __nccwpck_require__(20052);
 var isEqual_default = /*#__PURE__*/__nccwpck_require__.n(isEqual);
 ;// CONCATENATED MODULE: ./src/services/Github/PullRequest.ts
 var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -62147,7 +62235,7 @@ const addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0,
 });
 
 // EXTERNAL MODULE: ./node_modules/jira-client/lib/jira.js
-var jira = __nccwpck_require__(6411);
+var jira = __nccwpck_require__(26411);
 var jira_default = /*#__PURE__*/__nccwpck_require__.n(jira);
 ;// CONCATENATED MODULE: ./src/services/Jira/Client.ts
 
@@ -62538,10 +62626,10 @@ const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 
 });
 
 // EXTERNAL MODULE: ./node_modules/lodash/isEmpty.js
-var lodash_isEmpty = __nccwpck_require__(2384);
+var lodash_isEmpty = __nccwpck_require__(53912);
 var isEmpty_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isEmpty);
 // EXTERNAL MODULE: external "querystring"
-var external_querystring_ = __nccwpck_require__(1191);
+var external_querystring_ = __nccwpck_require__(71191);
 ;// CONCATENATED MODULE: ./src/services/Jira/Release.ts
 var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -62692,13 +62780,13 @@ const createRelease = (repoName, prNumber, releaseVersion, releaseName) => Relea
 
 
 // EXTERNAL MODULE: ./node_modules/lodash/snakeCase.js
-var snakeCase = __nccwpck_require__(1419);
+var snakeCase = __nccwpck_require__(31419);
 var snakeCase_default = /*#__PURE__*/__nccwpck_require__.n(snakeCase);
 // EXTERNAL MODULE: ./node_modules/lodash/startCase.js
-var startCase = __nccwpck_require__(9274);
+var startCase = __nccwpck_require__(69274);
 var startCase_default = /*#__PURE__*/__nccwpck_require__.n(startCase);
 // EXTERNAL MODULE: ./node_modules/unique-names-generator/dist/index.js
-var unique_names_generator_dist = __nccwpck_require__(4839);
+var unique_names_generator_dist = __nccwpck_require__(64839);
 ;// CONCATENATED MODULE: ./src/services/String.ts
 
 
@@ -63648,7 +63736,7 @@ const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, voi
 });
 
 // EXTERNAL MODULE: ./node_modules/dateformat/lib/dateformat.js
-var dateformat = __nccwpck_require__(1512);
+var dateformat = __nccwpck_require__(51512);
 var dateformat_default = /*#__PURE__*/__nccwpck_require__.n(dateformat);
 ;// CONCATENATED MODULE: ./src/services/Github/Release.ts
 var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -63967,7 +64055,7 @@ const approvePullRequest = (email, repoAndPr) => approvePullRequest_awaiter(void
 });
 
 // EXTERNAL MODULE: ./node_modules/lodash/truncate.js
-var truncate = __nccwpck_require__(5010);
+var truncate = __nccwpck_require__(35010);
 var truncate_default = /*#__PURE__*/__nccwpck_require__.n(truncate);
 ;// CONCATENATED MODULE: ./src/triggers/createPullRequestForJiraIssue.ts
 var createPullRequestForJiraIssue_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61439,7 +61439,6 @@ const positiveEmoji = () => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 const scrubMessage = (message) => {
@@ -61457,7 +61456,6 @@ const scrubMessage = (message) => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendErrorMessage = (message) => __awaiter(void 0, void 0, void 0, function* () {
@@ -61476,7 +61474,6 @@ const sendErrorMessage = (message) => __awaiter(void 0, void 0, void 0, function
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const sendUserMessage = (userId, message) => __awaiter(void 0, void 0, void 0, function* () {
@@ -61526,7 +61523,6 @@ var Credentials_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 const fetchCredentials = (identifier) => Credentials_awaiter(void 0, void 0, void 0, function* () {
@@ -61551,7 +61547,6 @@ const fetchCredentials = (identifier) => Credentials_awaiter(void 0, void 0, voi
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 const Credentials_fetchRepository = (name) => Credentials_awaiter(void 0, void 0, void 0, function* () {
@@ -61611,7 +61606,6 @@ const TreeTypes = {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -61629,7 +61623,6 @@ const createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, fun
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -61648,7 +61641,6 @@ const createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, voi
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -61666,7 +61658,6 @@ const createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -61683,7 +61674,6 @@ const createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
@@ -61713,7 +61703,6 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -61729,7 +61718,6 @@ const compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, 
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 const getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -61751,7 +61739,6 @@ const getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, vo
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 const getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
@@ -61765,7 +61752,6 @@ const getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, funct
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 const repositoryUrl = (repo) => `https://github.com/${Inputs_organizationName()}/${repo}`;
@@ -61790,7 +61776,6 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 const deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -61815,7 +61800,6 @@ const deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, fu
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -61844,7 +61828,6 @@ const getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, funct
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 const createBranch = (repo, baseBranchName, newBranchName, filePath, fileContent, commitMessage) => Branch_awaiter(void 0, void 0, void 0, function* () {
@@ -61912,7 +61895,6 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -61933,7 +61915,6 @@ const assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, vo
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 const createPullRequest = (repo, base, head, title, body, token) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -61952,7 +61933,6 @@ const createPullRequest = (repo, base, head, title, body, token) => PullRequest_
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 const getIssueKey = (pr) => {
@@ -61976,7 +61956,6 @@ const getIssueKey = (pr) => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -62002,7 +61981,6 @@ const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0,
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -62024,7 +62002,6 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 const extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\d+)\].*$/, '$1'), 10) ||
@@ -62035,7 +62012,6 @@ const extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -62051,7 +62027,6 @@ const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Inputs_organizationName()}/${repo}/pull/${number}`;
@@ -62062,7 +62037,6 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Input
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -62081,7 +62055,6 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
@@ -62120,7 +62093,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -62138,7 +62110,6 @@ const setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 const addLabels = (repo, number, added) => Label_awaiter(void 0, void 0, void 0, function* () {
@@ -62228,7 +62199,6 @@ const JiraFieldStoryPointEstimate = 'Story point estimate';
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (issue, fieldName) => {
@@ -62240,7 +62210,6 @@ const idForFieldName = (issue, fieldName) => {
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue) => {
@@ -62268,7 +62237,6 @@ const populateExplicitFields = (issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -62292,7 +62260,6 @@ const getChildIssues = (key) => Issue_awaiter(void 0, void 0, void 0, function* 
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -62311,7 +62278,6 @@ const getIssue = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 const getEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -62339,7 +62305,6 @@ const recursiveGetEpic = (key) => Issue_awaiter(void 0, void 0, void 0, function
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 const getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -62359,7 +62324,6 @@ const getIssuePullRequestNumbers = (issueId, repo) => Issue_awaiter(void 0, void
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -62373,7 +62337,6 @@ const isIssueOnBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 const issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
@@ -62381,10 +62344,8 @@ const issueUrl = (key) => `https://${jiraHost()}/browse/${key}`;
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 const moveIssueToBoard = (boardId, issueId) => Issue_awaiter(void 0, void 0, void 0, function* () {
@@ -62467,7 +62428,6 @@ var Project_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -62483,7 +62443,6 @@ const getBoard = (projectId) => Project_awaiter(void 0, void 0, void 0, function
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -62503,7 +62462,6 @@ const getColumns = (projectId) => Project_awaiter(void 0, void 0, void 0, functi
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -62527,7 +62485,6 @@ const getInProgressColumn = (projectId) => Project_awaiter(void 0, void 0, void 
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -62551,7 +62508,6 @@ const getReviewColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, f
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -62574,7 +62530,6 @@ const getValidatedColumn = (projectId) => Project_awaiter(void 0, void 0, void 0
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 0, function* () {
@@ -62613,7 +62568,6 @@ var Release_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 const createJiraRelease = (projectKey, name, description) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62643,7 +62597,6 @@ const createJiraRelease = (projectKey, name, description) => Release_awaiter(voi
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 const findJiraRelease = (projectKey, name) => Release_awaiter(void 0, void 0, void 0, function* () {
@@ -62754,7 +62707,6 @@ var unique_names_generator_dist = __nccwpck_require__(4839);
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 const parameterize = (str) => snakeCase_default()(str.trim().toLowerCase())
@@ -63562,7 +63514,6 @@ mustache.Writer = Writer;
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 const render = (template, vars) => mustache_mustache.render(template, vars);
@@ -63647,7 +63598,6 @@ var Epic_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 const createEpicPullRequest = (epic, repositoryName) => Epic_awaiter(void 0, void 0, void 0, function* () {
@@ -63733,7 +63683,6 @@ var Github_Release_awaiter = (undefined && undefined.__awaiter) || function (thi
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -63794,7 +63743,6 @@ const getReleaseNotes = (repoName, releaseDate, releaseName, commits) => Github_
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -63821,7 +63769,6 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -63851,7 +63798,6 @@ const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Gith
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -63864,7 +63810,6 @@ const reportError = (slackId, message) => Github_Release_awaiter(void 0, void 0,
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -63877,7 +63822,6 @@ const reportInfo = (slackId, message) => Github_Release_awaiter(void 0, void 0, 
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
@@ -63940,7 +63884,6 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "js-yaml": "^4.1.0",
-    "lint-staged": "^10.5.4",
+    "lint-staged": "^11.0.0",
     "prettier": "2.2.1",
     "ts-jest": "^26.5.6",
     "tscpaths": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.169",
     "@types/mustache": "^4.1.1",
-    "@types/node": "^15.0.2",
+    "@types/node": "^15.3.0",
     "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/parser": "^4.24.0",
     "@vercel/ncc": "0.28.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/mustache": "^4.1.1",
     "@types/node": "^15.0.2",
     "@types/node-fetch": "^2.5.10",
-    "@typescript-eslint/parser": "^4.22.1",
+    "@typescript-eslint/parser": "^4.24.0",
     "@vercel/ncc": "0.28.5",
     "eslint": "^7.26.0",
     "eslint-config-airbnb-typescript": "^12.3.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@actions/exec": "^1.0.4",
     "@actions/github": "^4.0.0",
     "@octokit/rest": "^18.0.9",
-    "@slack/web-api": "^6.1.0",
+    "@slack/web-api": "^6.2.3",
     "dateformat": "^4.5.1",
     "jira-client": "^6.21.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-github": "^4.1.3",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.6",
-    "eslint-plugin-jsdoc": "^33.1.0",
+    "eslint-plugin-jsdoc": "^34.8.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-unused-imports": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "jest-circus": "^26.6.3",
     "js-yaml": "^4.1.0",
     "lint-staged": "^11.0.0",
-    "prettier": "2.2.1",
+    "prettier": "2.3.0",
     "ts-jest": "^26.5.6",
     "tscpaths": "^0.0.9",
     "typescript": "^4.2.4"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/parser": "^4.22.1",
     "@vercel/ncc": "0.28.5",
-    "eslint": "^7.25.0",
+    "eslint": "^7.26.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "unique-names-generator": "^4.4.0"
   },
   "devDependencies": {
-    "@octokit/webhooks": "^9.4.0",
+    "@octokit/webhooks": "^9.6.1",
     "@octokit/webhooks-definitions": "^3.67.2",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.23",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.23",
     "@types/jira-client": "^6.13.1",
-    "@types/lodash": "^4.14.168",
+    "@types/lodash": "^4.14.169",
     "@types/mustache": "^4.1.1",
     "@types/node": "^15.0.2",
     "@types/node-fetch": "^2.5.10",

--- a/src/actions/check-run-completed-action/index.ts
+++ b/src/actions/check-run-completed-action/index.ts
@@ -16,7 +16,7 @@ export const run = async (): Promise<void> => {
     payload: {
       check_run: { check_suite: checkSuite },
     },
-  } = ((await context) as unknown) as {
+  } = (await context) as unknown as {
     payload: Schema.CheckRunEvent
   }
   await checkSuiteCompleted({

--- a/src/actions/check-suite-completed-action/__tests__/checkSuiteCompleted.test.ts
+++ b/src/actions/check-suite-completed-action/__tests__/checkSuiteCompleted.test.ts
@@ -46,7 +46,7 @@ describe('check-suite-completed-action', () => {
     let infoSpy: jest.SpyInstance
 
     // Cast this via 'unknown' to avoid having to fill in a bunch of unused payload fields.
-    const checkSuitePayload = (rawPayload as unknown) as Schema.CheckSuiteEvent
+    const checkSuitePayload = rawPayload as unknown as Schema.CheckSuiteEvent
 
     beforeEach(() => {
       addLabelsSpy = jest

--- a/src/actions/check-suite-completed-action/checkSuiteCompleted.ts
+++ b/src/actions/check-suite-completed-action/checkSuiteCompleted.ts
@@ -24,7 +24,6 @@ import { positiveEmoji, sendUserMessage } from '@sr-services/Slack'
  * @param {Issue}                issue       The Jira issue that the PR is linked to.
  * @param {Repository}           repoName    The name of the Github repository.
  * @param {PullsGetResponseData} pullRequest The pull request being checked.
- *
  * @returns {string | undefined} A message to be sent to the user in Slack.
  */
 const handleFailure = async (
@@ -45,7 +44,6 @@ const handleFailure = async (
  *
  * @param {string}               checkName   The name of the Github app running the check.
  * @param {PullsGetResponseData} pullRequest The pull request being checked.
- *
  * @returns {string | undefined} A message to be sent to the user in Slack.
  */
 const handleSuccess = (

--- a/src/actions/check-suite-completed-action/index.ts
+++ b/src/actions/check-suite-completed-action/index.ts
@@ -12,7 +12,7 @@ import { checkSuiteCompleted } from '@sr-actions/check-suite-completed-action/ch
  * $ act --job check_suite_completed_action --eventpath src/actions/check-suite-completed-action/__tests__/fixtures/check-suite-success-payload.json
  */
 export const run = async (): Promise<void> => {
-  const { payload } = ((await context) as unknown) as {
+  const { payload } = (await context) as unknown as {
     payload: Schema.CheckSuiteEvent
   }
   await checkSuiteCompleted(payload)

--- a/src/actions/pull-request-closed-action/index.ts
+++ b/src/actions/pull-request-closed-action/index.ts
@@ -12,7 +12,7 @@ import { pullRequestClosed } from '@sr-actions/pull-request-closed-action/pullRe
  * $ act --job pull_request_closed_action --eventpath src/actions/pull-request-closed-action/__tests__/fixtures/pull-request-closed.json
  */
 export const run = async (): Promise<void> => {
-  const { payload } = ((await context) as unknown) as {
+  const { payload } = (await context) as unknown as {
     payload: Schema.PullRequestEvent
   }
   await pullRequestClosed(payload)

--- a/src/actions/pull-request-closed-action/pullRequestClosed.ts
+++ b/src/actions/pull-request-closed-action/pullRequestClosed.ts
@@ -3,6 +3,7 @@ import Schema from '@octokit/webhooks-definitions/schema'
 import isNil from 'lodash/isNil'
 
 import { ReleaseBranchName } from '@sr-services/Constants'
+import { fetchRepository } from '@sr-services/Credentials'
 import { createReleaseTag, getIssueKey } from '@sr-services/Github'
 import {
   createRelease as createJiraRelease,
@@ -42,14 +43,17 @@ export const pullRequestClosed = async (
     } else {
       const releaseVersion = `v${matches[1]}` // v2021-01-12-0426
       const releaseName = matches[2] // Energetic Eagle
+      const repo = await fetchRepository(repository.name)
 
-      info(`Creating Jira release ${releaseVersion} (${releaseName})...`)
-      await createJiraRelease(
-        repository.name,
-        pullRequest.number,
-        releaseVersion,
-        releaseName
-      )
+      if (repo?.allow_jira_release) {
+        info(`Creating Jira release ${releaseVersion} (${releaseName})...`)
+        await createJiraRelease(
+          repository.name,
+          pullRequest.number,
+          releaseVersion,
+          releaseName
+        )
+      }
 
       // Discard the first line (the PR heading), because it is basically a duplicate of the release name.
       info(`Creating Github release ${releaseVersion} (${releaseName})...`)

--- a/src/actions/pull-request-converted-to-draft-action/__tests__/pullRequestConvertedToDraft.test.ts
+++ b/src/actions/pull-request-converted-to-draft-action/__tests__/pullRequestConvertedToDraft.test.ts
@@ -24,10 +24,10 @@ jest.mock('@sr-services/Github', () => ({
 
 describe('pull-request-converted-to-draft-action', () => {
   describe('pullRequestConvertedToDraft', () => {
-    const payload = ({
+    const payload = {
       ...mockGithubPullRequestPayload,
       action: 'converted_to_draft',
-    } as unknown) as Schema.PullRequestConvertedToDraftEvent
+    } as unknown as Schema.PullRequestConvertedToDraftEvent
     const prName = `${payload.repository.name}#${payload.pull_request.number}`
     let addLabelsSpy: jest.SpyInstance
     let getInProgressColumnSpy: jest.SpyInstance

--- a/src/actions/pull-request-converted-to-draft-action/index.ts
+++ b/src/actions/pull-request-converted-to-draft-action/index.ts
@@ -12,7 +12,7 @@ import { pullRequestConvertedToDraft } from '@sr-actions/pull-request-converted-
  * $ act --job pull_request_converted_to_draft_action --eventpath src/actions/pull-request-converted-to-draft-action/__tests__/fixtures/pull-request-converted-to-draft.json
  */
 export const run = async (): Promise<void> => {
-  const { payload } = ((await context) as unknown) as {
+  const { payload } = (await context) as unknown as {
     payload: Schema.PullRequestEvent
   }
   await pullRequestConvertedToDraft(payload)

--- a/src/actions/pull-request-labeled-action/__tests__/pullRequestLabeled.test.ts
+++ b/src/actions/pull-request-labeled-action/__tests__/pullRequestLabeled.test.ts
@@ -36,7 +36,7 @@ describe('pull-request-labeled-action', () => {
     let sendUserMessageSpy: jest.SpyInstance
 
     // Cast this via 'unknown' to avoid having to fill in a bunch of unused payload fields.
-    const payload = (rawPayload as unknown) as Schema.PullRequestLabeledEvent
+    const payload = rawPayload as unknown as Schema.PullRequestLabeledEvent
 
     beforeEach(() => {
       addLabelsSpy = jest
@@ -64,24 +64,24 @@ describe('pull-request-labeled-action', () => {
     })
 
     it('does nothing if the event was triggered by another Github action', async () => {
-      const automatedPayload = ({
+      const automatedPayload = {
         ...payload,
         sender: {
           login: GithubWriteUser,
         },
-      } as unknown) as Schema.PullRequestLabeledEvent
+      } as unknown as Schema.PullRequestLabeledEvent
       await pullRequestLabeled(automatedPayload)
       expect(addLabelsSpy).toHaveBeenCalledTimes(0)
     })
 
     it('assigns owners', async () => {
       const assignReviewersSpy = jest.spyOn(Github, 'assignReviewers')
-      const dependabotPayload = ({
+      const dependabotPayload = {
         ...payload,
         label: {
           name: DependenciesLabel,
         },
-      } as unknown) as Schema.PullRequestLabeledEvent
+      } as unknown as Schema.PullRequestLabeledEvent
       await pullRequestLabeled(dependabotPayload)
       expect(assignReviewersSpy).toHaveBeenCalledWith(
         payload.repository.name,
@@ -97,12 +97,12 @@ describe('pull-request-labeled-action', () => {
 
     it('assigns reviewers to dependabot PRs', async () => {
       const assignOwnersSpy = jest.spyOn(Github, 'assignOwners')
-      const dependabotPayload = ({
+      const dependabotPayload = {
         ...payload,
         label: {
           name: SecurityLabel,
         },
-      } as unknown) as Schema.PullRequestLabeledEvent
+      } as unknown as Schema.PullRequestLabeledEvent
       await pullRequestLabeled(dependabotPayload)
       expect(assignOwnersSpy).toHaveBeenCalledWith(
         payload.repository.name,
@@ -113,12 +113,12 @@ describe('pull-request-labeled-action', () => {
     })
 
     describe('security label', () => {
-      const securityPayload = ({
+      const securityPayload = {
         ...payload,
         label: {
           name: SecurityLabel,
         },
-      } as unknown) as Schema.PullRequestLabeledEvent
+      } as unknown as Schema.PullRequestLabeledEvent
 
       it('assigns a priority', async () => {
         await pullRequestLabeled(securityPayload)
@@ -141,7 +141,7 @@ describe('pull-request-labeled-action', () => {
       })
 
       it('does nothing if the PR has already been prioritized', async () => {
-        const prioritizedPayload = ({
+        const prioritizedPayload = {
           ...securityPayload,
           pull_request: {
             ...securityPayload.pull_request,
@@ -151,7 +151,7 @@ describe('pull-request-labeled-action', () => {
               },
             ],
           },
-        } as unknown) as Schema.PullRequestLabeledEvent
+        } as unknown as Schema.PullRequestLabeledEvent
         await pullRequestLabeled(prioritizedPayload)
         expect(addLabelsSpy).toHaveBeenCalledWith('actions', 493, [
           SecurityLabel,

--- a/src/actions/pull-request-labeled-action/index.ts
+++ b/src/actions/pull-request-labeled-action/index.ts
@@ -12,7 +12,7 @@ import { pullRequestLabeled } from '@sr-actions/pull-request-labeled-action/pull
  * $ act --job pull_request_labeled_action --eventpath src/actions/pull-request-labeled-action/__tests__/fixtures/pull-request-labeled.json
  */
 export const run = async (): Promise<void> => {
-  const { payload } = ((await context) as unknown) as {
+  const { payload } = (await context) as unknown as {
     payload: Schema.PullRequestLabeledEvent
   }
   await pullRequestLabeled(payload)

--- a/src/actions/pull-request-ready-for-review-action/index.ts
+++ b/src/actions/pull-request-ready-for-review-action/index.ts
@@ -12,7 +12,7 @@ import { pullRequestReadyForReview } from '@sr-actions/pull-request-ready-for-re
  * $ act --job pull_request_ready_for_review_action --eventpath src/actions/pull-request-ready-for-review-action/__tests__/fixtures/pull-request-ready-for-review.json
  */
 export const run = async (): Promise<void> => {
-  const { payload } = ((await context) as unknown) as {
+  const { payload } = (await context) as unknown as {
     payload: Schema.PullRequestEvent
   }
   await pullRequestReadyForReview(payload)

--- a/src/actions/rebase-epic-action/index.ts
+++ b/src/actions/rebase-epic-action/index.ts
@@ -12,7 +12,7 @@ import { rebase } from '@sr-services/Github/Rebase'
 export const run = async (): Promise<void> => {
   const {
     payload: { pull_request, repository },
-  } = ((await context) as unknown) as {
+  } = (await context) as unknown as {
     payload: Schema.PullRequestEvent
   }
 

--- a/src/actions/trigger-action/index.ts
+++ b/src/actions/trigger-action/index.ts
@@ -28,7 +28,7 @@ export const run = async (): Promise<void> => {
     payload: {
       inputs: { email, event, param },
     },
-  } = ((await context) as unknown) as Context
+  } = (await context) as unknown as Context
 
   switch (event) {
     case 'approvePullRequest':

--- a/src/services/Credentials.ts
+++ b/src/services/Credentials.ts
@@ -20,6 +20,7 @@ export interface Credentials extends User {
 
 export interface Repository {
   allow_auto_review: boolean
+  allow_jira_release: boolean
   jira_project_id?: number
   leads: User[]
   reviewers: User[]

--- a/src/services/Credentials.ts
+++ b/src/services/Credentials.ts
@@ -31,7 +31,6 @@ export interface Repository {
  * Fetches the user credentials from the remote credential service for the given email or name.
  *
  * @param {string} identifier The email address or Jira display name of the user to look up.
- *
  * @returns {Credentials} The credentials object.
  */
 export const fetchCredentials = async (
@@ -66,7 +65,6 @@ export const fetchCredentials = async (
  * Fetches the repository with the given name from the remote credential service.
  *
  * @param {string} name The name of the repository to look up.
- *
  * @returns {Repository} The repository object.
  */
 export const fetchRepository = async (name: string): Promise<Repository> => {

--- a/src/services/Github/Branch.ts
+++ b/src/services/Github/Branch.ts
@@ -23,7 +23,6 @@ import { organizationName } from '@sr-services/Inputs'
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {void}
  */
 export const deleteBranch = async (
@@ -54,7 +53,6 @@ export const deleteBranch = async (
  *
  * @param {Repository} repo   The name of the repository that the branch belongs to.
  * @param {Branch}     branch The name of the branch to fetch.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 export const getBranch = async (
@@ -88,7 +86,6 @@ export const getBranch = async (
  * @param {string}     filePath       A path at which we will create a new file, to make sure the new branch differes from the base.
  * @param {string}     fileContent    The text that the file will contain.
  * @param {string}     commitMessage  The text to use as the commit message.
- *
  * @returns {GitCreateRefResponseData} The new branch data.
  */
 export const createBranch = async (

--- a/src/services/Github/Epic.ts
+++ b/src/services/Github/Epic.ts
@@ -26,7 +26,6 @@ import { PullRequestForEpicTemplate, render } from '@sr-services/Template'
  * @param {Issue} epic            The Jira epic we will create the pull request for.
  * @param {string} repositoryName Jira Epics don't have a repository - if we encounter an issue
  *                                belonging to an epic, we will use the child issue's repository.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 export const createEpicPullRequest = async (

--- a/src/services/Github/Git.ts
+++ b/src/services/Github/Git.ts
@@ -61,7 +61,6 @@ export interface Tree {
  *
  * @param {Repository} repo    The name of the repository that the blob will belong to.
  * @param {string}     content The content to put in the blob.
- *
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 export const createGitBlob = async (
@@ -84,7 +83,6 @@ export const createGitBlob = async (
  * @param {string}     message The commit message.
  * @param {Sha}        tree    The tree to attach the commit to.
  * @param {Sha}        parent  The parent to attach the commit to.
- *
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 export const createGitCommit = async (
@@ -110,7 +108,6 @@ export const createGitCommit = async (
  * @param {Repository} repo   The name of the repository that the branch will belong to.
  * @param {Branch}     branch The name of the branch to create.
  * @param {Sha}        sha    The commit sha to base the branch on.
- *
  * @returns {GitCreateRefResponseData} The branch data.
  */
 export const createGitBranch = async (
@@ -134,7 +131,6 @@ export const createGitBranch = async (
  * @param {Repository} repo     The name of the repository that the branch will belong to.
  * @param {Tree[]}     tree     The data to use when creating the tree.
  * @param {Sha}        baseTree The tree to base the new tree on.
- *
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 export const createGitTree = async (
@@ -157,7 +153,6 @@ export const createGitTree = async (
  *
  * @param {Repository} repo The name of the repository whose commit we want to fetch.
  * @param {Sha}        sha  The sha hash of the commit.
- *
  * @returns {GitGetCommitResponseData} The commit data.
  */
 export const getCommit = async (

--- a/src/services/Github/Label.ts
+++ b/src/services/Github/Label.ts
@@ -35,7 +35,6 @@ const mutuallyExclusiveLabels = [
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   labels The list of labels to set.
- *
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 export const setLabels = async (
@@ -59,7 +58,6 @@ export const setLabels = async (
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The PR number.
  * @param {string[]}   added  The labels to add.
- *
  * @returns {IssuesAddLabelsResponseData} The PR data.
  */
 export const addLabels = async (

--- a/src/services/Github/PullRequest.ts
+++ b/src/services/Github/PullRequest.ts
@@ -22,7 +22,6 @@ export interface PullRequestContent {
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 export const assignOwners = async (
@@ -49,7 +48,6 @@ export const assignOwners = async (
  * @param {string}     title The title of the PR.
  * @param {string}     body  The body of the PR.
  * @param {string}     token The Github API token to use when creating the PR.
- *
  * @returns {PullsGetResponseData} The PR data.
  */
 export const createPullRequest = async (
@@ -77,7 +75,6 @@ export const createPullRequest = async (
  * Returns the Jira issue key for the pull request with the given number.
  *
  * @param {PullRequestContent} pr The body of the pull request which we will parse.
- *
  * @returns {string | undefined} The Jira issue key.
  */
 export const getIssueKey = (pr: PullRequestContent): string | undefined => {
@@ -106,7 +103,6 @@ export const getIssueKey = (pr: PullRequestContent): string | undefined => {
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {PullsGetResponseData} The pull request data.
  */
 export const getPullRequest = async (
@@ -138,7 +134,6 @@ export const getPullRequest = async (
  * @param {Repository} repo      The name of the repository that the PR belongs to.
  * @param {number}     number    The PR number.
  * @param {string[]}   usernames The usernames of the users to assign as owners.
- *
  * @returns {PullsRequestReviewersResponseData} The PR data.
  */
 export const assignReviewers = async (
@@ -172,7 +167,6 @@ export const assignReviewers = async (
  * Extracts a pull request from a commit message, in the format "[#123] Do something".
  *
  * @param {string} message The commit message to extract the pull request number from.
- *
  * @returns {number | undefined} The number of the pull request, if one can be found.
  */
 export const extractPullRequestNumber = (message: string): number | undefined =>
@@ -185,7 +179,6 @@ export const extractPullRequestNumber = (message: string): number | undefined =>
  *
  * @param {Repository} repo   The name of the repository that the PR belongs to.
  * @param {number}     number The pull request number whose commits we want to fetch.
- *
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 export const listPullRequestCommits = async (
@@ -206,7 +199,6 @@ export const listPullRequestCommits = async (
  *
  * @param {Repository} repo   The name of the repository that the PR will belong to.
  * @param {number}     number The pull request number to fetch.
- *
  * @returns {string} The URL of the pull request.
  */
 export const pullRequestUrl = (repo: Repository, number: number): string =>
@@ -219,7 +211,6 @@ export const pullRequestUrl = (repo: Repository, number: number): string =>
  * @param {number}     number    The PR number.
  * @param {string}     event     The type of review ('APPROVE', 'COMMENT' or 'REQUEST_CHANGES').
  * @param {string}     body      The review body.
- *
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 export const reviewPullRequest = async (
@@ -245,7 +236,6 @@ export const reviewPullRequest = async (
  * @param {Repository} repo       The name of the repository that the PR belongs to.
  * @param {number}     number     The pull request number to update.
  * @param {object}     attributes The data to update.
- *
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 export const updatePullRequest = async (

--- a/src/services/Github/Release.ts
+++ b/src/services/Github/Release.ts
@@ -48,7 +48,6 @@ import { generateReleaseName } from '@sr-services/String'
  * @param {string}     releaseDate The formatted date and time of the release.
  * @param {string}     releaseName The name of the release.
  * @param {Commit[]}   commits     The list of commits that make up the release.
- *
  * @returns {string} The pull request description.
  */
 const getReleaseNotes = async (
@@ -139,7 +138,6 @@ const getReleaseNotes = async (
  *
  * @param {Repository} repoName The name of the repository that the branch will belong to.
  * @param {string}     sha      The commit sha to branch from.
- *
  * @returns {ReposGetBranchResponseData} The branch data.
  */
 const ensureReleasebranch = async (
@@ -174,7 +172,6 @@ const ensureReleasebranch = async (
  * @param {string}     releaseDate The name of the release (basically a formatted datetime).
  * @param {string}     releaseName The name of the release.
  * @param {string}     body        The pull request release notes.
- *
  * @returns {PullsGetResponseData | void} The pull request, if it exists.
  */
 const getReleasePullRequest = async (
@@ -222,7 +219,6 @@ const getReleasePullRequest = async (
  *
  * @param {string} slackId The Slack user ID of the person to send the error message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportError = async (slackId: string, message: string) => {
@@ -236,7 +232,6 @@ const reportError = async (slackId: string, message: string) => {
  *
  * @param {string} slackId The Slack user ID of the person to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 const reportInfo = async (slackId: string, message: string) => {
@@ -250,7 +245,6 @@ const reportInfo = async (slackId: string, message: string) => {
  *
  * @param {string} email         The email address of the user who requested the release be created.
  * @param {ReposGetResponseData} repo The Github repository that we will create the release / pull request for.
- *
  * @returns {void}
  */
 export const createReleasePullRequest = async (
@@ -353,7 +347,6 @@ export const createReleasePullRequest = async (
  * @param {string}     tagName      The string to tag the release with (eg. v2021-01-12-0426).
  * @param {string}     releaseName  The name of the release (eg. Energetic Eagle).
  * @param {string}     releaseNotes The notes to include as the body of the release.
- *
  * @returns {ReposCreateReleaseResponseData} The resulting release.
  */
 export const createReleaseTag = async (

--- a/src/services/Github/Repository.ts
+++ b/src/services/Github/Repository.ts
@@ -13,7 +13,6 @@ import { organizationName } from '@sr-services/Inputs'
  * @param {Repository} repo The name of the repository to fetch.
  * @param {Sha}        base The base commit to merge INTO (eg. master, when making a release).
  * @param {Sha}        head The head commit to merge FROM (eg. develop, when making a release).
- *
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 export const compareCommits = async (
@@ -35,7 +34,6 @@ export const compareCommits = async (
  * Decides what number the next pull request will be.
  *
  * @param {Repository} repo The name of the repository that the PR will belong to.
- *
  * @returns {number}   The number of the next PR.
  */
 export const getNextPullRequestNumber = async (
@@ -62,7 +60,6 @@ export const getNextPullRequestNumber = async (
  * Returns the repository with the given name.
  *
  * @param {Repository} repo The name of the repository to fetch.
- *
  * @returns {ReposGetResponseData} The repository data.
  */
 export const getRepository = async (
@@ -79,7 +76,6 @@ export const getRepository = async (
  * Returns the URL of the repository with the given name.
  *
  * @param {Repository} repo The name of the repository.
- *
  * @returns {string} The URL of the repository.
  */
 export const repositoryUrl = (repo: Repository): string =>

--- a/src/services/Github/__tests__/Branch.test.ts
+++ b/src/services/Github/__tests__/Branch.test.ts
@@ -169,7 +169,7 @@ describe('Branch', () => {
       const spy = jest
         .spyOn(client.git, 'deleteRef')
         .mockImplementation((_args?: DeleteBranchParams) =>
-          Promise.resolve(({ status: 204 } as unknown) as OctokitResponse<void>)
+          Promise.resolve({ status: 204 } as unknown as OctokitResponse<void>)
         )
       const result = await Branch.deleteBranch(repo, branch)
       expect(spy).toHaveBeenCalledWith(deleteBranchParams)

--- a/src/services/Github/__tests__/Git.test.ts
+++ b/src/services/Github/__tests__/Git.test.ts
@@ -149,9 +149,9 @@ describe('Git', () => {
         .spyOn(readClient.git, 'getCommit')
         .mockImplementation(
           (_args?: { owner: string; repo: Repository; commit_sha: string }) =>
-            Promise.resolve(({
+            Promise.resolve({
               data: { message: 'Fix the widget' },
-            } as unknown) as OctokitResponse<GitGetCommitResponseData>)
+            } as unknown as OctokitResponse<GitGetCommitResponseData>)
         )
       const result = await getCommit(repo, 'my-sha')
       expect(spy).toHaveBeenCalledWith({

--- a/src/services/Github/__tests__/PullRequest.test.ts
+++ b/src/services/Github/__tests__/PullRequest.test.ts
@@ -181,28 +181,26 @@ describe('PullRequest', () => {
 
   describe('getIssueKey', () => {
     it('gets the key from the title if possible', () => {
-      const pullRequest = ({
-        body:
-          '[Jira Tech task](https://example.atlassian.net/browse/ISSUE-789)',
+      const pullRequest = {
+        body: '[Jira Tech task](https://example.atlassian.net/browse/ISSUE-789)',
         title: '[ISSUE-456] My Issue',
-      } as unknown) as Schema.PullRequest
+      } as unknown as Schema.PullRequest
       expect(getIssueKey(pullRequest)).toEqual('ISSUE-456')
     })
 
     it('gets the key from the body if possible', () => {
-      const pullRequest = ({
-        body:
-          '[Jira Tech task](https://example.atlassian.net/browse/ISSUE-789)',
+      const pullRequest = {
+        body: '[Jira Tech task](https://example.atlassian.net/browse/ISSUE-789)',
         title: 'My Issue',
-      } as unknown) as Schema.PullRequest
+      } as unknown as Schema.PullRequest
       expect(getIssueKey(pullRequest)).toEqual('ISSUE-789')
     })
 
     it("returns undefined if the key can't be found", () => {
-      const pullRequest = ({
+      const pullRequest = {
         body: 'My body',
         title: 'My Issue',
-      } as unknown) as Schema.PullRequest
+      } as unknown as Schema.PullRequest
       expect(getIssueKey(pullRequest)).toBeUndefined()
     })
   })
@@ -240,9 +238,9 @@ describe('PullRequest', () => {
       const spy = jest
         .spyOn(Client.readClient.pulls, 'listCommits')
         .mockReturnValue(
-          Promise.resolve(({
+          Promise.resolve({
             data: [mockGitCommit],
-          } as unknown) as OctokitResponse<PullsListCommitsResponseData>)
+          } as unknown as OctokitResponse<PullsListCommitsResponseData>)
         )
       const result = await listPullRequestCommits(repo, 123)
       expect(spy).toHaveBeenCalledWith({

--- a/src/services/Github/__tests__/Release.test.ts
+++ b/src/services/Github/__tests__/Release.test.ts
@@ -93,10 +93,10 @@ describe('Release', () => {
       compareCommitsSpy = jest
         .spyOn(Repository, 'compareCommits')
         .mockReturnValue(
-          Promise.resolve(({
+          Promise.resolve({
             commits: [mockGitCommit],
             total_commits: 1,
-          } as unknown) as ReposCompareCommitsResponseData)
+          } as unknown as ReposCompareCommitsResponseData)
         )
       createGitBranchSpy = jest.spyOn(Git, 'createGitBranch')
       createPullRequestSpy = jest.spyOn(PullRequest, 'createPullRequest')
@@ -115,9 +115,9 @@ describe('Release', () => {
         .spyOn(core, 'info')
         .mockImplementation((_message: string | Error) => undefined)
       listPullsSpy = jest.spyOn(readClient.pulls, 'list').mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           data: [mockGithubPullRequest],
-        } as unknown) as OctokitResponse<PullsListResponseData>)
+        } as unknown as OctokitResponse<PullsListResponseData>)
       )
       pullRequestUrlSpy = jest.spyOn(PullRequest, 'pullRequestUrl')
       repositoryUrlSpy = jest.spyOn(Repository, 'repositoryUrl')
@@ -162,10 +162,10 @@ describe('Release', () => {
     })
 
     it(`does nothing if the ${MasterBranchName} branch already has the latest release`, async () => {
-      const response = Promise.resolve(({
+      const response = Promise.resolve({
         commits: [],
         total_commits: 0,
-      } as unknown) as ReposCompareCommitsResponseData)
+      } as unknown as ReposCompareCommitsResponseData)
       compareCommitsSpy.mockReturnValue(response)
       await createReleasePullRequest(email, mockGithubRepository)
       const message = `Branch '${MasterBranchName}' already contains the latest release - nothing to do`
@@ -175,9 +175,9 @@ describe('Release', () => {
     it('returns an existing pull request if one exists', async () => {
       updatePullRequestSpy.mockReturnValue(Promise.resolve(undefined))
       listPullsSpy.mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           data: [mockGithubPullRequest],
-        } as unknown) as OctokitResponse<PullsListResponseData>)
+        } as unknown as OctokitResponse<PullsListResponseData>)
       )
       await createReleasePullRequest(email, mockGithubRepository)
       const message = `An existing release pull request was found (${mockGithubRepository.name}#${mockGithubPullRequest.number}) - updating the release notes...`
@@ -194,9 +194,9 @@ describe('Release', () => {
 
     it('creates a release pull request', async () => {
       listPullsSpy.mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           data: [],
-        } as unknown) as OctokitResponse<PullsListResponseData>)
+        } as unknown as OctokitResponse<PullsListResponseData>)
       )
       await createReleasePullRequest(email, mockGithubRepository)
       const message =
@@ -236,15 +236,15 @@ describe('Release', () => {
 
     it('handles commit authors with no Github login', async () => {
       listPullsSpy.mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           data: [],
-        } as unknown) as OctokitResponse<PullsListResponseData>)
+        } as unknown as OctokitResponse<PullsListResponseData>)
       )
       compareCommitsSpy.mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           commits: [{ ...mockGitCommit, author: { login: null } }],
           total_commits: 1,
-        } as unknown) as ReposCompareCommitsResponseData)
+        } as unknown as ReposCompareCommitsResponseData)
       )
       await createReleasePullRequest(email, mockGithubRepository)
       expect(createPullRequestSpy).toHaveBeenCalled()
@@ -252,15 +252,15 @@ describe('Release', () => {
 
     it('handles commits with no author', async () => {
       listPullsSpy.mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           data: [],
-        } as unknown) as OctokitResponse<PullsListResponseData>)
+        } as unknown as OctokitResponse<PullsListResponseData>)
       )
       compareCommitsSpy.mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           commits: [{ ...mockGitCommit, author: null }],
           total_commits: 1,
-        } as unknown) as ReposCompareCommitsResponseData)
+        } as unknown as ReposCompareCommitsResponseData)
       )
       await createReleasePullRequest(email, mockGithubRepository)
       expect(createPullRequestSpy).toHaveBeenCalled()
@@ -271,9 +271,9 @@ describe('Release', () => {
     it('calls the Github API', async () => {
       const repo = 'my-repo'
       const spy = jest.spyOn(client.repos, 'createRelease').mockReturnValue(
-        Promise.resolve(({
+        Promise.resolve({
           data: mockGithubRelease,
-        } as unknown) as OctokitResponse<ReposCreateReleaseResponseData>)
+        } as unknown as OctokitResponse<ReposCreateReleaseResponseData>)
       )
       const result = await createReleaseTag(
         repo,

--- a/src/services/Jira/Issue.ts
+++ b/src/services/Jira/Issue.ts
@@ -91,7 +91,6 @@ export const JiraFieldStoryPointEstimate = 'Story point estimate'
  *
  * @param {Issue}  issue     The issue whose fields we want to search.
  * @param {string} fieldName The human-readable field name to search for.
- *
  * @returns {string} The field ID.
  */
 const idForFieldName = (
@@ -107,7 +106,6 @@ const idForFieldName = (
  * identifiers mapped to the 'names' list.
  *
  * @param {Issue} issue The issue whose data we want to populate.
- *
  * @returns {Issue} The issues, with fields populated.
  */
 const populateExplicitFields = (issue: Issue) => {
@@ -118,9 +116,11 @@ const populateExplicitFields = (issue: Issue) => {
   fieldId = idForFieldName(issue, JiraFieldRepository)
   if (fieldId) {
     Object.assign(issue.fields, {
-      repository: ((issue.fields as unknown) as {
-        [customField: string]: { value: string }
-      })[fieldId]?.value,
+      repository: (
+        issue.fields as unknown as {
+          [customField: string]: { value: string }
+        }
+      )[fieldId]?.value,
     })
   }
 
@@ -129,9 +129,11 @@ const populateExplicitFields = (issue: Issue) => {
   fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate)
   if (fieldId) {
     Object.assign(issue.fields, {
-      storyPointEstimate: ((issue.fields as unknown) as {
-        [customField: string]: number
-      })[fieldId],
+      storyPointEstimate: (
+        issue.fields as unknown as {
+          [customField: string]: number
+        }
+      )[fieldId],
     })
   }
 
@@ -142,7 +144,6 @@ const populateExplicitFields = (issue: Issue) => {
  * Fetches all direct children of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue[]} The direct child issues.
  */
 export const getChildIssues = async (key: string): Promise<Issue[]> => {
@@ -172,7 +173,6 @@ export const getChildIssues = async (key: string): Promise<Issue[]> => {
  * Fetches the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The issue data.
  */
 export const getIssue = async (key: string): Promise<Issue | undefined> => {
@@ -193,7 +193,6 @@ export const getIssue = async (key: string): Promise<Issue | undefined> => {
  * Fetches the parent epic (if one exists) of the issue with the given key from Jira.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {Issue} The epic issue data.
  */
 export const getEpic = async (key: string): Promise<Issue | undefined> => {
@@ -225,7 +224,6 @@ export const recursiveGetEpic = async (
  *
  * @param {string}     issueId The ID of the Jira issue (eg. '10910').
  * @param {Repository} repo    The name of the repository we're dealing with.
- *
  * @returns {number[]} The PR numbers.
  */
 export const getIssuePullRequestNumbers = async (
@@ -257,7 +255,6 @@ export const getIssuePullRequestNumbers = async (
  *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {boolean} True if the issue is on the board.
  */
 export const isIssueOnBoard = async (
@@ -276,7 +273,6 @@ export const isIssueOnBoard = async (
  * Returns the URL of the issue with the given key.
  *
  * @param {string} key The key of the Jira issue (eg. 'ISSUE-236').
- *
  * @returns {string} The URL of the issue.
  */
 export const issueUrl = (key: string): string =>
@@ -286,10 +282,8 @@ export const issueUrl = (key: string): string =>
  * Moves the issue to the board with the given ID.
  *
  * @see https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-issue-post
- *
  * @param {string} boardId The ID of the Jira board (eg. '4').
  * @param {string} issueId The ID of the Jira issue (eg. '10910').
- *
  * @returns {number} The status code of the response.
  */
 export const moveIssueToBoard = async (

--- a/src/services/Jira/Project.ts
+++ b/src/services/Jira/Project.ts
@@ -46,7 +46,6 @@ interface JiraProject {
  * Fetches the board definition for the given project ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoard | undefined} The board belonging to te project.
  */
 export const getBoard = async (
@@ -68,7 +67,6 @@ export const getBoard = async (
  * Fetches the list of columns for the project with the given ID.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {JiraBoardColumn[] | undefined} The board belonging to te project.
  */
 export const getColumns = async (
@@ -93,7 +91,6 @@ export const getColumns = async (
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as in-progress.
  */
 export const getInProgressColumn = async (
@@ -126,7 +123,6 @@ export const getInProgressColumn = async (
  * This fetches the column names for the project and decides which one is appropriate.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as ready-for-review.
  */
 export const getReviewColumn = async (projectId: string): Promise<string> => {
@@ -157,7 +153,6 @@ export const getReviewColumn = async (projectId: string): Promise<string> => {
  * 'Review', if it exists.
  *
  * @param {string} projectId The *numeric* ID of the Jira project (eg. 10003).
- *
  * @returns {string} The name of the column used to mark issues as validated.
  */
 export const getValidatedColumn = async (
@@ -189,7 +184,6 @@ export const getValidatedColumn = async (
  * Fetches the project with the given ID.
  *
  * @param {string} projectKey The key of the Jira project (eg. 'STUDIO').
- *
  * @returns {JiraProject} The project.
  */
 export const getProject = async (projectKey: string): Promise<JiraProject> => {

--- a/src/services/Jira/Release.ts
+++ b/src/services/Jira/Release.ts
@@ -37,7 +37,6 @@ interface FindJiraReleaseResponse {
  * @param {string} projectKey  The key of the project which we will create a release for.
  * @param {string} name        The name of the release.
  * @param {string} description The release description.
- *
  * @returns {JiraRelease} The newly created release.
  */
 export const createJiraRelease = async (
@@ -64,7 +63,7 @@ export const createJiraRelease = async (
   }
   // The types for createVersion() are messed up, and expect a string.
   const data = (await client.createVersion(
-    (args as unknown) as string
+    args as unknown as string
   )) as JiraRelease
   return data
 }
@@ -74,7 +73,6 @@ export const createJiraRelease = async (
  *
  * @param {string} projectKey The key of the project whose release we are looking for.
  * @param {string} name       The name of the release.
- *
  * @returns {JiraRelease | undefined} The release if it exists, or undefined if it doesn't.
  */
 export const findJiraRelease = async (

--- a/src/services/Slack/Message.ts
+++ b/src/services/Slack/Message.ts
@@ -56,7 +56,6 @@ export const positiveEmoji = (): string => {
  * Makes sure that secrets in the message are scrubbed out.
  *
  * @param {string} message The message to send.
- *
  * @returns {string} The scrubbed message
  */
 export const scrubMessage = (message: string): string => {
@@ -75,7 +74,6 @@ export const scrubMessage = (message: string): string => {
  * Sends an error message to the default slack group.
  *
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 export const sendErrorMessage = async (message: string): Promise<void> => {
@@ -96,7 +94,6 @@ export const sendErrorMessage = async (message: string): Promise<void> => {
  *
  * @param {string} userId  The Slack user ID to send the message to.
  * @param {string} message The message to send.
- *
  * @returns {void}
  */
 export const sendUserMessage = async (

--- a/src/services/String.ts
+++ b/src/services/String.ts
@@ -10,7 +10,6 @@ import {
  * Converts strings to a format safe for use in URLs, branch names etc.
  *
  * @param {string} str The string to parameterize.
- *
  * @returns {string} The parameterized string.
  */
 export const parameterize = (str: string): string =>

--- a/src/services/Template.ts
+++ b/src/services/Template.ts
@@ -9,7 +9,6 @@ interface TemplateVars {
  *
  * @param {string} template The mustache.js template string.
  * @param {object} vars     The vars to replace in the template.
- *
  * @returns {string} The rendered template.
  */
 export const render = (template: string, vars: TemplateVars): string =>

--- a/src/tests/Mocks.ts
+++ b/src/tests/Mocks.ts
@@ -57,43 +57,46 @@ export const mockGitCommit = {
   },
 }
 
-export const mockGithubBranch = ({
+export const mockGithubBranch = {
   commit: {
     sha: 'branch-sha',
   },
   name: 'my-branch',
   sha: 'branch-sha',
-} as unknown) as ReposGetBranchResponseData
+} as unknown as ReposGetBranchResponseData
 
-export const mockGithubPullRequestCreateResponse = ({
+export const mockGithubPullRequestCreateResponse = {
   id: 1234,
   number: 123,
   title: 'Add a Widget',
-} as unknown) as PullsCreateResponseData
+} as unknown as PullsCreateResponseData
 
-export const mockGithubPullRequestReviewResponse = ({
+export const mockGithubPullRequestReviewResponse = {
   id: 1234,
   body: ':thumbsup:',
-} as unknown) as PullsCreateReviewResponseData
+} as unknown as PullsCreateReviewResponseData
 
-export const mockGithubPullRequestUpdateResponse = ({
+export const mockGithubPullRequestUpdateResponse = {
   id: 1234,
   number: 123,
   title: 'Add a Widget',
-} as unknown) as PullsUpdateResponseData
+} as unknown as PullsUpdateResponseData
 
-export const mockGithubPullRequestPayload = (pullRequestPayload as unknown) as Schema.PullRequestEvent
+export const mockGithubPullRequestPayload =
+  pullRequestPayload as unknown as Schema.PullRequestEvent
 
-export const mockGithubPullRequest = (mockGithubPullRequestPayload.pull_request as unknown) as PullsGetResponseData
+export const mockGithubPullRequest =
+  mockGithubPullRequestPayload.pull_request as unknown as PullsGetResponseData
 
 export const mockGithubReleaseName = 'Energetic Eagle'
 
-export const mockGithubRelease = ({
+export const mockGithubRelease = {
   name: `v2021-01-12-0426 (${mockGithubReleaseName})`,
   tag_name: 'v2021-01-12-0426',
-} as unknown) as ReposCreateReleaseResponseData
+} as unknown as ReposCreateReleaseResponseData
 
-export const mockGithubRepository = (repository as unknown) as ReposGetResponseData
+export const mockGithubRepository =
+  repository as unknown as ReposGetResponseData
 
 export const mockIssuesAddAssigneesResponseData = {
   id: 1234,

--- a/src/tests/Mocks.ts
+++ b/src/tests/Mocks.ts
@@ -149,6 +149,7 @@ export const mockJiraRelease = {
 
 export const mockRepository = {
   allow_auto_review: true,
+  allow_jira_release: true,
   leads: [{ github_username: 'dhh', slack_id: 'slack-dhh' }],
   reviewers: [{ github_username: 'wycats', slack_id: 'slack-wycats' }],
   status: 'ok',

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -153,7 +153,7 @@ export const createPullRequestForJiraIssue = async (
         newBranchName,
         `.meta/${issue.key}.md`,
         `${jiraUrl}\n\nCreated at ${new Date().toISOString()}`,
-        `[${issue.key}] [skip ci] Create pull request.`
+        `[${issue.key}] [skip ci] [skip netlify] Create pull request.`
       )
     }
 

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -197,7 +197,8 @@ export const createPullRequestForJiraIssue = async (
   info(`Notifying Slack user ${credentials.slack_id}...`)
   const url = pullRequestUrl(repo.name, pullRequestNumber)
 
-  const message = `Here's your pull request: *<${url}|${repo.name}#${pullRequestNumber}>*
+  const message =
+    `Here's your pull request: *<${url}|${repo.name}#${pullRequestNumber}>*
     Please prefix your commits with \`[#${pullRequestNumber}] [${issue.key}]\`\n
     Checkout the new branch with:
     \`git checkout --track origin/${newBranchName}\`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,9 +2749,9 @@ has@^1.0.3:
     function-bind "^1.1.1"
 
 hosted-git-info@^2.1.4:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,19 +679,19 @@
   resolved "https://registry.yarnpkg.com/@octokit/webhooks-methods/-/webhooks-methods-1.0.0.tgz#274799138725c89a3466e3af2026afe755f28c4b"
   integrity sha512-pVceMQcj9SZ5p2RkemL0TuuPdGULNQj9F3Pq1cNM1xH+Kst1VNt0dj3PEGZRZV473njrDnYdi/OG4wWY9TLbbA==
 
-"@octokit/webhooks-types@3.72.0":
-  version "3.72.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-3.72.0.tgz#43dc2125cfb6217c3bd69479c79dc76da2551550"
-  integrity sha512-G+XcAeGU+IImH/4L0LTKAUj2GbyuHBkQVkFHuga/zgsCXdm3iSwoPjkW462Cq1U3U8QzuH4kJp17M5W/omKE8Q==
+"@octokit/webhooks-types@3.75.0":
+  version "3.75.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-3.75.0.tgz#6301226143c9d0a96972b6c27b17d929a98ca5d3"
+  integrity sha512-vQkYwpCNX816UJiMssnEr4jWlVXmmd6kOpcmNdEQ6646Lh6kYeNBP6C2tVOAoCcs7/xK2sGf8qOJ5rT3QGL62w==
 
-"@octokit/webhooks@^9.4.0":
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-9.4.0.tgz#d346006c23ea0d533fd1817023029772bdd656e5"
-  integrity sha512-bEJZVsIpe2mhlyPgldw9PF/MFPAg7aRqbbGJkras2n9iJTHhHSDSfgLRzgvCWXe9zaSvX59B+NU25c8+v52YBg==
+"@octokit/webhooks@^9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-9.6.1.tgz#a7686edcf0c0a08257dd4590344e8c7a73fb6866"
+  integrity sha512-RIVpKDmNaCMgiSnCzDmw/GTOyLvpDHfNVxJvQWRG8EsPhTF1fXsaxHkyR1unX8v5xPr/cRjoIstEPSiXyd31Aw==
   dependencies:
     "@octokit/request-error" "^2.0.2"
     "@octokit/webhooks-methods" "^1.0.0"
-    "@octokit/webhooks-types" "3.72.0"
+    "@octokit/webhooks-types" "3.75.0"
     aggregate-error "^3.1.0"
 
 "@sinonjs/commons@^1.7.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -336,10 +336,10 @@
     esquery "^1.4.0"
     jsdoctypeparser "^9.0.0"
 
-"@eslint/eslintrc@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
-  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
+"@eslint/eslintrc@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.1.tgz#442763b88cecbe3ee0ec7ca6d6dd6168550cbf14"
+  integrity sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -2151,13 +2151,13 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.25.0:
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.25.0.tgz#1309e4404d94e676e3e831b3a3ad2b050031eb67"
-  integrity sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==
+eslint@^7.26.0:
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.26.0.tgz#d416fdcdcb3236cd8f282065312813f8c13982f6"
+  integrity sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==
   dependencies:
     "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.4.0"
+    "@eslint/eslintrc" "^0.4.1"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,10 +874,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^15.0.2":
-  version "15.0.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
-  integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^15.3.0":
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
+  integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4451,10 +4451,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.2.1, prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@2.3.0, prettier@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
+  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,10 +1487,10 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -1603,10 +1603,10 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
-  integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 comment-parser@1.1.5, comment-parser@^1.1.5:
   version "1.1.5"
@@ -1677,7 +1677,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1736,7 +1736,7 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -2265,7 +2265,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^4.0.0, execa@^4.1.0:
+execa@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -2278,6 +2278,21 @@ execa@^4.0.0, execa@^4.1.0:
     npm-run-path "^4.0.0"
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
+execa@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
 exit@^0.1.2:
@@ -2583,6 +2598,11 @@ get-stream@^5.0.0:
   dependencies:
     pump "^3.0.0"
 
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -2778,6 +2798,11 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 husky@^6.0.0:
   version "6.0.0"
@@ -3053,6 +3078,11 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -3734,40 +3764,41 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.5.4:
-  version "10.5.4"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.4.tgz#cd153b5f0987d2371fc1d2847a409a2fe705b665"
-  integrity sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==
+lint-staged@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.0.0.tgz#24d0a95aa316ba28e257f5c4613369a75a10c712"
+  integrity sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==
   dependencies:
-    chalk "^4.1.0"
+    chalk "^4.1.1"
     cli-truncate "^2.1.0"
-    commander "^6.2.0"
+    commander "^7.2.0"
     cosmiconfig "^7.0.0"
-    debug "^4.2.0"
+    debug "^4.3.1"
     dedent "^0.7.0"
     enquirer "^2.3.6"
-    execa "^4.1.0"
-    listr2 "^3.2.2"
-    log-symbols "^4.0.0"
-    micromatch "^4.0.2"
+    execa "^5.0.0"
+    listr2 "^3.8.2"
+    log-symbols "^4.1.0"
+    micromatch "^4.0.4"
     normalize-path "^3.0.0"
     please-upgrade-node "^3.2.0"
     string-argv "0.3.1"
     stringify-object "^3.3.0"
 
-listr2@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.2.2.tgz#d20feb75015e506992b55af40722ba1af168b8f1"
-  integrity sha512-AajqcZEUikF2ioph6PfH3dIuxJclhr3i3kHgTOP0xeXdWQohrvJAAmqVcV43/GI987HFY/vzT73jYXoa4esDHg==
+listr2@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.8.2.tgz#99b138ad1cfb08f1b0aacd422972e49b2d814b99"
+  integrity sha512-E28Fw7Zd3HQlCJKzb9a8C8M0HtFWQeucE+S8YrSrqZObuCLPRHMRrR8gNmYt65cU9orXYHwvN5agXC36lYt7VQ==
   dependencies:
-    chalk "^4.1.0"
+    chalk "^4.1.1"
     cli-truncate "^2.1.0"
     figures "^3.2.0"
     indent-string "^4.0.0"
     log-update "^4.0.0"
     p-map "^4.0.0"
-    rxjs "^6.6.3"
+    rxjs "^6.6.7"
     through "^2.3.8"
+    wrap-ansi "^7.0.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -3804,12 +3835,13 @@ lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
-  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
   dependencies:
-    chalk "^4.0.0"
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 log-update@^4.0.0:
   version "4.0.0"
@@ -3888,13 +3920,13 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+micromatch@^4.0.2, micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
   dependencies:
     braces "^3.0.1"
-    picomatch "^2.0.5"
+    picomatch "^2.2.3"
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -4036,7 +4068,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run-path@^4.0.0:
+npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
@@ -4142,7 +4174,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -4344,10 +4376,15 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -4683,10 +4720,10 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
-rxjs@^6.6.3:
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
-  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+rxjs@^6.6.7:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -4800,7 +4837,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
@@ -5479,6 +5516,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,10 +327,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@es-joy/jsdoccomment@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.4.3.tgz#c66b42aa66d2e0718f77fccc8d9061cf0b1092ac"
-  integrity sha512-t0JWZfQiG+Qkr6+tl05dlGcgE/MMPqs7QfNlFkTsbpcCu2Zfukcan/fIiHKTc0iOs4Yh3cnfklMayJnlmKaOwQ==
+"@es-joy/jsdoccomment@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.6.0.tgz#8926a8184df0968860f8c69b3bfc52efa6aeaa30"
+  integrity sha512-zT1EtysKMITJ7vE4RvOJqitxk/Str6It8hq+fykxkwLuTyzgak+TnVuVSIyovT/qrEz3i46ypCSXgNtIDYwNOg==
   dependencies:
     comment-parser "^1.1.5"
     esquery "^1.4.0"
@@ -2070,12 +2070,12 @@ eslint-plugin-jest@^24.3.6:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-jsdoc@^33.1.0:
-  version "33.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-33.1.0.tgz#9aa52d0eb0126ea42528aa352265007dce320565"
-  integrity sha512-nyH1qAj5f4uDnDpg4aiAS65wJSfxfBDf0lIgNfxtew31z3VRaM8WsVmpe4UhI2u27oOD/ChRuye6KAzzuHn6Jw==
+eslint-plugin-jsdoc@^34.8.1:
+  version "34.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.1.tgz#d617663136d65cccbbd398be4bb87dc22f584d25"
+  integrity sha512-OLLq1UfzHr4Z+Y07R/t8x4eF5FS5yxWeUwaLaRv6DgX7pJEEl/3PzwDZfnYWFy2HQSanGmZnBhUQoHe6kPxN4g==
   dependencies:
-    "@es-joy/jsdoccomment" "^0.4.3"
+    "@es-joy/jsdoccomment" "^0.6.0"
     comment-parser "1.1.5"
     debug "^4.3.1"
     esquery "^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -708,30 +708,31 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@slack/logger@>=1.0.0 <3.0.0":
+"@slack/logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
+  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
+  dependencies:
+    "@types/node" ">=12.0.0"
+
+"@slack/types@^2.0.0":
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-2.0.0.tgz#6a4e1c755849bc0f66dac08a8be54ce790ec0e6b"
-  integrity sha512-OkIJpiU2fz6HOJujhlhfIGrc8hB4ibqtf7nnbJQDerG0BqwZCfmgtK5sWzZ0TkXVRBKD5MpLrTmCYyMxoMCgPw==
-  dependencies:
-    "@types/node" ">=8.9.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.0.0.tgz#7b938ab576cd1d6c9ff9ad67a96f8058d101af10"
+  integrity sha512-Nu4jWC39mDY5egAX4oElwOypdu8Cx9tmR7bo3ghaHYaC7mkKM1+b+soanW5s2ssu4yOLxMdFExMh6wlR34B6CA==
 
-"@slack/types@^1.7.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.9.0.tgz#aa8f90b2f66ac54a77e42606644366f93cff4871"
-  integrity sha512-RmwgMWqOtzd2JPXdiaD/tyrDD0vtjjRDFdxN1I3tAxwBbg4aryzDUVqFc8na16A+3Xik/UN8X1hvVTw8J4EB9w==
-
-"@slack/web-api@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.1.0.tgz#27a17f61eb72100d6722ff17f581349c41d19b5f"
-  integrity sha512-9MVHw+rDBaFvkvzm8lDNH/nlkvJCDKRIjFGMdpbyZlVLsm4rcht4qyiL71bqdyLATHXJnWknb/sl0FQGLLobIA==
+"@slack/web-api@^6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.2.3.tgz#063ca32987587d1879520badab485796be621e77"
+  integrity sha512-Qt0JUSuT1RKFYRpMfbP0xKkqWoXGzmEa4N+7H5oB9eH228ABn1sM3LDNW7ZQiLs5jpDuzHAp7dSxAZpb+ZfO/w==
   dependencies:
-    "@slack/logger" ">=1.0.0 <3.0.0"
-    "@slack/types" "^1.7.0"
+    "@slack/logger" "^3.0.0"
+    "@slack/types" "^2.0.0"
     "@types/is-stream" "^1.1.0"
     "@types/node" ">=12.0.0"
     axios "^0.21.1"
     eventemitter3 "^3.1.0"
     form-data "^2.5.0"
+    is-electron "^2.2.0"
     is-stream "^1.1.0"
     p-queue "^6.6.1"
     p-retry "^4.0.0"
@@ -874,7 +875,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@>=8.9.0", "@types/node@^15.3.0":
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@^15.3.0":
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
   integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
@@ -2959,6 +2960,11 @@ is-docker@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
+is-electron@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
+  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -851,10 +851,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.168":
-  version "4.14.168"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
-  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+"@types/lodash@^4.14.169":
+  version "4.14.169"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.169.tgz#83c217688f07a4d9ef8f28a3ebd1d318f6ff4cbb"
+  integrity sha512-DvmZHoHTFJ8zhVYwCLWbQ7uAbYQEk52Ev2/ZiQ7Y7gQGeV9pjBqjnQpECMHfKS1rCYAhMI7LHVxwyZLZinJgdw==
 
 "@types/minimatch@*":
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,14 +957,14 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^4.20.0", "@typescript-eslint/parser@^4.22.1", "@typescript-eslint/parser@^4.4.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.1.tgz#a95bda0fd01d994a15fc3e99dc984294f25c19cc"
-  integrity sha512-l+sUJFInWhuMxA6rtirzjooh8cM/AATAe3amvIkqKFeMzkn85V+eLzb1RyuXkHak4dLfYzOmF6DXPyflJvjQnw==
+"@typescript-eslint/parser@^4.20.0", "@typescript-eslint/parser@^4.24.0", "@typescript-eslint/parser@^4.4.1":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.24.0.tgz#2e5f1cc78ffefe43bfac7e5659309a92b09a51bd"
+  integrity sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.22.1"
-    "@typescript-eslint/types" "4.22.1"
-    "@typescript-eslint/typescript-estree" "4.22.1"
+    "@typescript-eslint/scope-manager" "4.24.0"
+    "@typescript-eslint/types" "4.24.0"
+    "@typescript-eslint/typescript-estree" "4.24.0"
     debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.21.0":
@@ -975,23 +975,23 @@
     "@typescript-eslint/types" "4.21.0"
     "@typescript-eslint/visitor-keys" "4.21.0"
 
-"@typescript-eslint/scope-manager@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz#5bb357f94f9cd8b94e6be43dd637eb73b8f355b4"
-  integrity sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==
+"@typescript-eslint/scope-manager@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz#38088216f0eaf235fa30ed8cabf6948ec734f359"
+  integrity sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==
   dependencies:
-    "@typescript-eslint/types" "4.22.1"
-    "@typescript-eslint/visitor-keys" "4.22.1"
+    "@typescript-eslint/types" "4.24.0"
+    "@typescript-eslint/visitor-keys" "4.24.0"
 
 "@typescript-eslint/types@4.21.0":
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.21.0.tgz#abdc3463bda5d31156984fa5bc316789c960edef"
   integrity sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==
 
-"@typescript-eslint/types@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.1.tgz#bf99c6cec0b4a23d53a61894816927f2adad856a"
-  integrity sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==
+"@typescript-eslint/types@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.24.0.tgz#6d0cca2048cbda4e265e0c4db9c2a62aaad8228c"
+  integrity sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==
 
 "@typescript-eslint/typescript-estree@4.21.0":
   version "4.21.0"
@@ -1006,13 +1006,13 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.1.tgz#dca379eead8cdfd4edc04805e83af6d148c164f9"
-  integrity sha512-p3We0pAPacT+onSGM+sPR+M9CblVqdA9F1JEdIqRVlxK5Qth4ochXQgIyb9daBomyQKAXbygxp1aXQRV0GC79A==
+"@typescript-eslint/typescript-estree@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz#b49249679a98014d8b03e8d4b70864b950e3c90f"
+  integrity sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==
   dependencies:
-    "@typescript-eslint/types" "4.22.1"
-    "@typescript-eslint/visitor-keys" "4.22.1"
+    "@typescript-eslint/types" "4.24.0"
+    "@typescript-eslint/visitor-keys" "4.24.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -1027,12 +1027,12 @@
     "@typescript-eslint/types" "4.21.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz#6045ae25a11662c671f90b3a403d682dfca0b7a6"
-  integrity sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==
+"@typescript-eslint/visitor-keys@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz#a8fafdc76cad4e04a681a945fbbac4e35e98e297"
+  integrity sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==
   dependencies:
-    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/types" "4.24.0"
     eslint-visitor-keys "^2.0.0"
 
 "@vercel/ncc@0.28.5":


### PR DESCRIPTION
## Release Candidate 2021-05-20-0715 (Quickest Quail)

### Pull Requests

- #522 Remove Jira Release Publish Automation from (Slackbot | Git Actions) ([STUDIO-2037](https://shuttlerock.atlassian.net/browse/STUDIO-2037))

### Dependency updates

- Bump hosted-git-info from 2.8.8 to [2.8.9](https://github.com/Shuttlerock/actions/commit/f1c14cef65a5458ca5dba5dec4636c30e415276f)
- Bump lint-staged from 10.5.4 to [11.0.0](https://github.com/Shuttlerock/actions/commit/6cae93b7e6a3d6d49cf59a3b7722188bcc8638a4)
- Bump eslint from 7.25.0 to [7.26.0](https://github.com/Shuttlerock/actions/commit/e9e0a561b34d3878659957c71d7e58dc985ba60c)
- Bump @octokit/webhooks from 9.4.0 to [9.6.1](https://github.com/Shuttlerock/actions/commit/459a1692f259235d6c0f7e327c0d395d4ccb7e79)
- Bump @typescript-eslint/parser from 4.22.1 to [4.24.0](https://github.com/Shuttlerock/actions/commit/5bd190fff76884c10411c18718729f36e2ca85ef)
- Bump @types/lodash from 4.14.168 to [4.14.169](https://github.com/Shuttlerock/actions/commit/6d78ba2b5507e343f4c6c1d8cb3e011f75266858)
- Bump eslint-plugin-jsdoc from 33.1.0 to [34.8.1](https://github.com/Shuttlerock/actions/commit/b950432afa3c77faba0d917824b03ef832fbc9d7)
- Bump @types/node from 15.0.2 to [15.3.0](https://github.com/Shuttlerock/actions/commit/ca37683f5203f1d8da505c0fc052f122670bd40b)
- Bump prettier from 2.2.1 to [2.3.0](https://github.com/Shuttlerock/actions/commit/a2190a1b740a9b1791defbf7552c54d7db69764c)
- Bump @slack/web-api from 6.1.0 to [6.2.3](https://github.com/Shuttlerock/actions/commit/254b4bab161fa53fe4f1e9cee0d42934949b5f64)
