### PR TITLE
Fix for Jira release boolean logic

### DIFF
--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -62630,7 +62630,7 @@ const pullRequestClosed = (payload) => pullRequestClosed_awaiter(void 0, void 0,
             const releaseVersion = `v${matches[1]}`; // v2021-01-12-0426
             const releaseName = matches[2]; // Energetic Eagle
             const repo = yield fetchRepository(repository.name);
-            if (repo === null || repo === void 0 ? void 0 : repo.allow_jira_release) {
+            if (!(repo === null || repo === void 0 ? void 0 : repo.skip_jira_release)) {
                 (0,core.info)(`Creating Jira release ${releaseVersion} (${releaseName})...`);
                 yield createRelease(repository.name, pullRequest.number, releaseVersion, releaseName);
             }

--- a/src/actions/pull-request-closed-action/__tests__/pullRequestClosed.test.ts
+++ b/src/actions/pull-request-closed-action/__tests__/pullRequestClosed.test.ts
@@ -108,7 +108,7 @@ describe('pull-request-closed-action', () => {
 
       it('does not create a Jira release', async () => {
         fetchRepositorySpy.mockImplementation((_name?: string) =>
-          Promise.resolve({ ...mockRepository, allow_jira_release: false })
+          Promise.resolve({ ...mockRepository, skip_jira_release: true })
         )
         await pullRequestClosed(releasePayload)
         expect(createJiraReleaseSpy).toHaveBeenCalledTimes(0)

--- a/src/actions/pull-request-closed-action/pullRequestClosed.ts
+++ b/src/actions/pull-request-closed-action/pullRequestClosed.ts
@@ -45,7 +45,7 @@ export const pullRequestClosed = async (
       const releaseName = matches[2] // Energetic Eagle
       const repo = await fetchRepository(repository.name)
 
-      if (repo?.allow_jira_release) {
+      if (!repo?.skip_jira_release) {
         info(`Creating Jira release ${releaseVersion} (${releaseName})...`)
         await createJiraRelease(
           repository.name,

--- a/src/services/Credentials.ts
+++ b/src/services/Credentials.ts
@@ -20,7 +20,7 @@ export interface Credentials extends User {
 
 export interface Repository {
   allow_auto_review: boolean
-  allow_jira_release: boolean
+  skip_jira_release: boolean
   jira_project_id?: number
   leads: User[]
   reviewers: User[]

--- a/src/tests/Mocks.ts
+++ b/src/tests/Mocks.ts
@@ -152,7 +152,7 @@ export const mockJiraRelease = {
 
 export const mockRepository = {
   allow_auto_review: true,
-  allow_jira_release: true,
+  skip_jira_release: false,
   leads: [{ github_username: 'dhh', slack_id: 'slack-dhh' }],
   reviewers: [{ github_username: 'wycats', slack_id: 'slack-wycats' }],
   status: 'ok',


### PR DESCRIPTION
## Fix for Jira release boolean logic
### Description
The recent boolean to make adding Jira releases option has flawed logic. This is to update the `action` repo to use the updated logic.

### How to test the PR
Tests should be green
Deployment Notes
None