### PR TITLE
Release Candidate 2021-06-02-1138 (Quiet Quelea)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Story Name Here
+
+[Story Link](https://shuttlerock.atlassian.net/browse/STUDIO-0000)
+
+Description from the story here
+
+## Type of change
+
+Select all that apply:
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Security issue
+- [ ] Infrastructure / network
+
+## How to test the PR
+
+- Step 1
+- Step 2
+- Step 3
+
+## Deployment Notes
+
+It requires new Environmental variables:
+
+- `EXAMPLE_ENV_VARIABLE=content`
+- `EXAMPLE_ENV_VARIABLE2=content`

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.169",
     "@types/mustache": "^4.1.1",
-    "@types/node": "^15.3.1",
+    "@types/node": "^15.6.1",
     "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/parser": "^4.24.0",
     "@vercel/ncc": "0.28.5",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-github": "^4.1.3",
     "eslint-plugin-import": "^2.23.2",
     "eslint-plugin-jest": "^24.3.6",
-    "eslint-plugin-jsdoc": "^34.8.1",
+    "eslint-plugin-jsdoc": "^34.8.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-unused-imports": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@actions/core": "^1.2.7",
+    "@actions/core": "^1.3.0",
     "@actions/exec": "^1.0.4",
     "@actions/github": "^4.0.0",
     "@octokit/rest": "^18.0.9",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/jira-client": "^6.13.1",
     "@types/lodash": "^4.14.169",
     "@types/mustache": "^4.1.1",
-    "@types/node": "^15.3.0",
+    "@types/node": "^15.3.1",
     "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/parser": "^4.24.0",
     "@vercel/ncc": "0.28.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.7.tgz#594f8c45b213f0146e4be7eda8ae5cf4e198e5ab"
-  integrity sha512-kzLFD5BgEvq6ubcxdgPbRKGD2Qrgya/5j+wh4LZzqT915I0V3rED+MvjH6NXghbvk1MXknpNNQ3uKjXSEN00Ig==
+"@actions/core@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.3.0.tgz#f5e4b24c889e7f2e58b466cc8c7481292284eba0"
+  integrity sha512-xxtX0Cwdhb8LcgatfJkokqT8KzPvcIbwL9xpLU09nOwBzaStbfm0dNncsP0M4us+EpoPdWy7vbzU5vSOH7K6pg==
 
 "@actions/exec@^1.0.4":
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,10 +875,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@^15.3.0":
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
-  integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@^15.3.1":
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.1.tgz#23a06b87eedb524016616e886b116b8fdcb180af"
+  integrity sha512-weaeiP4UF4XgF++3rpQhpIJWsCTS4QJw5gvBhQu6cFIxTwyxWIe3xbnrY/o2lTCQ0lsdb8YIUDUvLR4Vuz5rbw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,10 +875,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@^15.3.1":
-  version "15.3.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.1.tgz#23a06b87eedb524016616e886b116b8fdcb180af"
-  integrity sha512-weaeiP4UF4XgF++3rpQhpIJWsCTS4QJw5gvBhQu6cFIxTwyxWIe3xbnrY/o2lTCQ0lsdb8YIUDUvLR4Vuz5rbw==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.0.0", "@types/node@^15.6.1":
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
+  integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5689,9 +5689,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^7.2.3:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
-  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,10 +2108,10 @@ eslint-plugin-jest@^24.3.6:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-jsdoc@^34.8.1:
-  version "34.8.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.1.tgz#d617663136d65cccbbd398be4bb87dc22f584d25"
-  integrity sha512-OLLq1UfzHr4Z+Y07R/t8x4eF5FS5yxWeUwaLaRv6DgX7pJEEl/3PzwDZfnYWFy2HQSanGmZnBhUQoHe6kPxN4g==
+eslint-plugin-jsdoc@^34.8.2:
+  version "34.8.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.2.tgz#94708429667e165f722aa50b98e863920f9ba14e"
+  integrity sha512-UOU9A40Cl806JMtla2vF+RM6sNqfLPbhLv9FZqhcC7+LmChD3DVaWqM7ADxpF0kMyZNWe1QKUnqGnXaA3NTn+w==
   dependencies:
     "@es-joy/jsdoccomment" "^0.6.0"
     comment-parser "1.1.5"


### PR DESCRIPTION
## Release Candidate 2021-06-02-1138 (Quiet Quelea)

### Pull Requests

- #542 Update repository configuration

### Dependency updates

- Bump eslint-plugin-jsdoc from 34.8.1 to [34.8.2](https://github.com/Shuttlerock/actions/commit/9d44d99efb6c48c19a36a0cfe896a23045d99d59)
- Bump @types/node from 15.3.0 to [15.3.1](https://github.com/Shuttlerock/actions/commit/233231a5b70c9b753b11507c2507447c8a6b342f)
- Bump ws from 7.3.1 to [7.4.6](https://github.com/Shuttlerock/actions/commit/1b1611273aba256eefe8aeaa3a7065c5bac5c1c3)
- Bump @types/node from 15.3.1 to [15.6.1](https://github.com/Shuttlerock/actions/commit/47e3963d08ab6cab3ad052d867dc4361720d3eec)
- Bump @actions/core from 1.2.7 to [1.3.0](https://github.com/Shuttlerock/actions/commit/99501205717ad45e92ce2491700a29452068b6bb)
