### PR TITLE
[SECURITY-436] Fail gracefully when required Github secrets are missing

### DIFF
--- a/.meta/SECURITY-436.md
+++ b/.meta/SECURITY-436.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-436
+
+Created at 2021-06-17T03:56:30.699Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -60216,8 +60216,8 @@ var dist_node = __nccwpck_require__(5375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
-const Client_client = new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
-const Client_readClient = new dist_node/* Octokit */.v({ auth: githubReadToken() });
+const Client_client = () => new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
+const Client_readClient = () => new dist_node/* Octokit */.v({ auth: githubReadToken() });
 const Client_clientForToken = (token) => {
     return new Octokit({ auth: token });
 };
@@ -60252,7 +60252,7 @@ const Git_TreeTypes = {
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createBlob({
+    const response = yield client().git.createBlob({
         owner: organizationName(),
         repo,
         content,
@@ -60269,7 +60269,7 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createCommit({
+    const response = yield client().git.createCommit({
         owner: organizationName(),
         repo,
         message,
@@ -60287,7 +60287,7 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createRef({
+    const response = yield client().git.createRef({
         owner: organizationName(),
         repo,
         ref: `refs/heads/${branch}`,
@@ -60304,7 +60304,7 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createTree({
+    const response = yield client().git.createTree({
         owner: organizationName(),
         repo,
         tree,
@@ -60320,7 +60320,7 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_readClient.git.getCommit({
+    const response = yield Client_readClient().git.getCommit({
         owner: Inputs_organizationName(),
         repo,
         commit_sha: sha,
@@ -60349,7 +60349,7 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.compareCommits({
+    const response = yield readClient().repos.compareCommits({
         owner: organizationName(),
         repo,
         base,
@@ -60364,7 +60364,7 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         direction: 'desc',
         owner: organizationName(),
         page: 1,
@@ -60385,7 +60385,7 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.get({
+    const response = yield readClient().repos.get({
         owner: organizationName(),
         repo,
     });
@@ -60423,7 +60423,7 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield client.git.deleteRef({
+        const response = yield client().git.deleteRef({
             owner: organizationName(),
             repo,
             ref: `heads/${branch}`,
@@ -60447,7 +60447,7 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield readClient.repos.getBranch({
+        const response = yield readClient().repos.getBranch({
             owner: organizationName(),
             repo,
             branch,
@@ -60517,7 +60517,7 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.issues.addAssignees({
+    const response = yield client().issues.addAssignees({
         assignees: usernames,
         issue_number: number,
         owner: organizationName(),
@@ -60581,7 +60581,7 @@ const PullRequest_getIssueKey = (pr) => {
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.pulls.get({
+        const response = yield Client_readClient().pulls.get({
             owner: Inputs_organizationName(),
             pull_number: number,
             repo,
@@ -60611,7 +60611,7 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
     }
     // We can't assign the PR owner as a reviewer.
     const reviewers = usernames.filter((username) => username !== pullRequest.user.login);
-    const response = yield client.pulls.requestReviewers({
+    const response = yield client().pulls.requestReviewers({
         reviewers,
         pull_number: number,
         owner: organizationName(),
@@ -60636,7 +60636,7 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.listCommits({
+    const response = yield readClient().pulls.listCommits({
         owner: organizationName(),
         pull_number: number,
         repo,
@@ -60661,7 +60661,7 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.createReview({
+    const response = yield client().pulls.createReview({
         body,
         event,
         owner: organizationName(),
@@ -60679,7 +60679,7 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
+    const response = yield client().pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
     return response.data;
 });
 
@@ -60717,7 +60717,7 @@ const mutuallyExclusiveLabels = [
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_client.issues.setLabels({
+    const response = yield Client_client().issues.setLabels({
         issue_number: number,
         labels,
         owner: Inputs_organizationName(),
@@ -62551,7 +62551,7 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     info('Searching for an existing release pull request...');
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         base: MasterBranchName,
         direction: 'desc',
         head: `${organizationName()}:${ReleaseBranchName}`,
@@ -62642,7 +62642,7 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     const name = `${tagName} (${releaseName})`;
-    const response = yield client.repos.createRelease({
+    const response = yield client().repos.createRelease({
         body: releaseNotes,
         draft: false,
         name,

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -60144,13 +60144,13 @@ var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
-const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: true });
+const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: false });
 // The secret to use when connecting to the internal credentials API.
-const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: true });
+const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: false });
 // Token with read access to Github - provided by Github.
-const githubReadToken = () => (0,core.getInput)('repo-token', { required: true });
+const githubReadToken = () => (0,core.getInput)('repo-token', { required: false });
 // Token with write access to Github - set in organization secrets.
-const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: true });
+const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: false });
 // The email address to use when connecting to the Jira API.
 const Inputs_jiraEmail = () => (0,core.getInput)('jira-email', { required: false });
 // The host to use when connecting to the Jira API.
@@ -60158,11 +60158,11 @@ const Inputs_jiraHost = () => (0,core.getInput)('jira-host', { required: false }
 // The API token to use when connecting to the Jira API.
 const Inputs_jiraToken = () => (0,core.getInput)('jira-token', { required: false });
 // The Github organization name.
-const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: true });
+const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: false });
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
-const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: true });
+const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: false });
 // Token with write access to Slack.
-const slackToken = () => (0,core.getInput)('slack-token', { required: true });
+const slackToken = () => (0,core.getInput)('slack-token', { required: false });
 
 ;// CONCATENATED MODULE: ./src/services/Credentials.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -142,7 +142,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
@@ -228,6 +228,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -60216,8 +60216,8 @@ var dist_node = __nccwpck_require__(5375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
-const Client_client = new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
-const Client_readClient = new dist_node/* Octokit */.v({ auth: githubReadToken() });
+const Client_client = () => new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
+const Client_readClient = () => new dist_node/* Octokit */.v({ auth: githubReadToken() });
 const Client_clientForToken = (token) => {
     return new Octokit({ auth: token });
 };
@@ -60252,7 +60252,7 @@ const Git_TreeTypes = {
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createBlob({
+    const response = yield client().git.createBlob({
         owner: organizationName(),
         repo,
         content,
@@ -60269,7 +60269,7 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createCommit({
+    const response = yield client().git.createCommit({
         owner: organizationName(),
         repo,
         message,
@@ -60287,7 +60287,7 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createRef({
+    const response = yield client().git.createRef({
         owner: organizationName(),
         repo,
         ref: `refs/heads/${branch}`,
@@ -60304,7 +60304,7 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createTree({
+    const response = yield client().git.createTree({
         owner: organizationName(),
         repo,
         tree,
@@ -60320,7 +60320,7 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_readClient.git.getCommit({
+    const response = yield Client_readClient().git.getCommit({
         owner: Inputs_organizationName(),
         repo,
         commit_sha: sha,
@@ -60349,7 +60349,7 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.compareCommits({
+    const response = yield readClient().repos.compareCommits({
         owner: organizationName(),
         repo,
         base,
@@ -60364,7 +60364,7 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         direction: 'desc',
         owner: organizationName(),
         page: 1,
@@ -60385,7 +60385,7 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.get({
+    const response = yield readClient().repos.get({
         owner: organizationName(),
         repo,
     });
@@ -60423,7 +60423,7 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield client.git.deleteRef({
+        const response = yield client().git.deleteRef({
             owner: organizationName(),
             repo,
             ref: `heads/${branch}`,
@@ -60447,7 +60447,7 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield readClient.repos.getBranch({
+        const response = yield readClient().repos.getBranch({
             owner: organizationName(),
             repo,
             branch,
@@ -60517,7 +60517,7 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.issues.addAssignees({
+    const response = yield client().issues.addAssignees({
         assignees: usernames,
         issue_number: number,
         owner: organizationName(),
@@ -60581,7 +60581,7 @@ const PullRequest_getIssueKey = (pr) => {
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.pulls.get({
+        const response = yield Client_readClient().pulls.get({
             owner: Inputs_organizationName(),
             pull_number: number,
             repo,
@@ -60611,7 +60611,7 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
     }
     // We can't assign the PR owner as a reviewer.
     const reviewers = usernames.filter((username) => username !== pullRequest.user.login);
-    const response = yield client.pulls.requestReviewers({
+    const response = yield client().pulls.requestReviewers({
         reviewers,
         pull_number: number,
         owner: organizationName(),
@@ -60636,7 +60636,7 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.listCommits({
+    const response = yield readClient().pulls.listCommits({
         owner: organizationName(),
         pull_number: number,
         repo,
@@ -60661,7 +60661,7 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.createReview({
+    const response = yield client().pulls.createReview({
         body,
         event,
         owner: organizationName(),
@@ -60679,7 +60679,7 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
+    const response = yield client().pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
     return response.data;
 });
 
@@ -60717,7 +60717,7 @@ const mutuallyExclusiveLabels = [
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_client.issues.setLabels({
+    const response = yield Client_client().issues.setLabels({
         issue_number: number,
         labels,
         owner: Inputs_organizationName(),
@@ -62551,7 +62551,7 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     info('Searching for an existing release pull request...');
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         base: MasterBranchName,
         direction: 'desc',
         head: `${organizationName()}:${ReleaseBranchName}`,
@@ -62642,7 +62642,7 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     const name = `${tagName} (${releaseName})`;
-    const response = yield client.repos.createRelease({
+    const response = yield client().repos.createRelease({
         body: releaseNotes,
         draft: false,
         name,

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -60144,13 +60144,13 @@ var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
-const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: true });
+const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: false });
 // The secret to use when connecting to the internal credentials API.
-const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: true });
+const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: false });
 // Token with read access to Github - provided by Github.
-const githubReadToken = () => (0,core.getInput)('repo-token', { required: true });
+const githubReadToken = () => (0,core.getInput)('repo-token', { required: false });
 // Token with write access to Github - set in organization secrets.
-const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: true });
+const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: false });
 // The email address to use when connecting to the Jira API.
 const Inputs_jiraEmail = () => (0,core.getInput)('jira-email', { required: false });
 // The host to use when connecting to the Jira API.
@@ -60158,11 +60158,11 @@ const Inputs_jiraHost = () => (0,core.getInput)('jira-host', { required: false }
 // The API token to use when connecting to the Jira API.
 const Inputs_jiraToken = () => (0,core.getInput)('jira-token', { required: false });
 // The Github organization name.
-const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: true });
+const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: false });
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
-const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: true });
+const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: false });
 // Token with write access to Slack.
-const slackToken = () => (0,core.getInput)('slack-token', { required: true });
+const slackToken = () => (0,core.getInput)('slack-token', { required: false });
 
 ;// CONCATENATED MODULE: ./src/services/Credentials.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -142,7 +142,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
@@ -228,6 +228,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -60141,13 +60141,13 @@ var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
-const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: true });
+const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: false });
 // The secret to use when connecting to the internal credentials API.
-const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: true });
+const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: false });
 // Token with read access to Github - provided by Github.
-const githubReadToken = () => (0,core.getInput)('repo-token', { required: true });
+const githubReadToken = () => (0,core.getInput)('repo-token', { required: false });
 // Token with write access to Github - set in organization secrets.
-const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: true });
+const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: false });
 // The email address to use when connecting to the Jira API.
 const jiraEmail = () => (0,core.getInput)('jira-email', { required: false });
 // The host to use when connecting to the Jira API.
@@ -60155,11 +60155,11 @@ const Inputs_jiraHost = () => (0,core.getInput)('jira-host', { required: false }
 // The API token to use when connecting to the Jira API.
 const jiraToken = () => (0,core.getInput)('jira-token', { required: false });
 // The Github organization name.
-const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: true });
+const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: false });
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
-const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: true });
+const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: false });
 // Token with write access to Slack.
-const slackToken = () => (0,core.getInput)('slack-token', { required: true });
+const slackToken = () => (0,core.getInput)('slack-token', { required: false });
 
 ;// CONCATENATED MODULE: ./src/services/Credentials.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -60213,8 +60213,8 @@ var dist_node = __nccwpck_require__(5375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
-const Client_client = new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
-const Client_readClient = new dist_node/* Octokit */.v({ auth: githubReadToken() });
+const Client_client = () => new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
+const Client_readClient = () => new dist_node/* Octokit */.v({ auth: githubReadToken() });
 const Client_clientForToken = (token) => {
     return new Octokit({ auth: token });
 };
@@ -60249,7 +60249,7 @@ const Git_TreeTypes = {
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createBlob({
+    const response = yield client().git.createBlob({
         owner: organizationName(),
         repo,
         content,
@@ -60266,7 +60266,7 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createCommit({
+    const response = yield client().git.createCommit({
         owner: organizationName(),
         repo,
         message,
@@ -60284,7 +60284,7 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createRef({
+    const response = yield client().git.createRef({
         owner: organizationName(),
         repo,
         ref: `refs/heads/${branch}`,
@@ -60301,7 +60301,7 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createTree({
+    const response = yield client().git.createTree({
         owner: organizationName(),
         repo,
         tree,
@@ -60317,7 +60317,7 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.git.getCommit({
+    const response = yield readClient().git.getCommit({
         owner: organizationName(),
         repo,
         commit_sha: sha,
@@ -60346,7 +60346,7 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.compareCommits({
+    const response = yield readClient().repos.compareCommits({
         owner: organizationName(),
         repo,
         base,
@@ -60361,7 +60361,7 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         direction: 'desc',
         owner: organizationName(),
         page: 1,
@@ -60382,7 +60382,7 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.get({
+    const response = yield readClient().repos.get({
         owner: organizationName(),
         repo,
     });
@@ -60420,7 +60420,7 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield client.git.deleteRef({
+        const response = yield client().git.deleteRef({
             owner: organizationName(),
             repo,
             ref: `heads/${branch}`,
@@ -60444,7 +60444,7 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield readClient.repos.getBranch({
+        const response = yield readClient().repos.getBranch({
             owner: organizationName(),
             repo,
             branch,
@@ -60513,7 +60513,7 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.issues.addAssignees({
+    const response = yield client().issues.addAssignees({
         assignees: usernames,
         issue_number: number,
         owner: organizationName(),
@@ -60577,7 +60577,7 @@ const PullRequest_getIssueKey = (pr) => {
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.pulls.get({
+        const response = yield Client_readClient().pulls.get({
             owner: Inputs_organizationName(),
             pull_number: number,
             repo,
@@ -60607,7 +60607,7 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
     }
     // We can't assign the PR owner as a reviewer.
     const reviewers = usernames.filter((username) => username !== pullRequest.user.login);
-    const response = yield client.pulls.requestReviewers({
+    const response = yield client().pulls.requestReviewers({
         reviewers,
         pull_number: number,
         owner: organizationName(),
@@ -60632,7 +60632,7 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_readClient.pulls.listCommits({
+    const response = yield Client_readClient().pulls.listCommits({
         owner: Inputs_organizationName(),
         pull_number: number,
         repo,
@@ -60657,7 +60657,7 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Input
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.createReview({
+    const response = yield client().pulls.createReview({
         body,
         event,
         owner: organizationName(),
@@ -60675,7 +60675,7 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
+    const response = yield client().pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
     return response.data;
 });
 
@@ -60713,7 +60713,7 @@ const mutuallyExclusiveLabels = [
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.issues.setLabels({
+    const response = yield client().issues.setLabels({
         issue_number: number,
         labels,
         owner: organizationName(),
@@ -62550,7 +62550,7 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     info('Searching for an existing release pull request...');
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         base: MasterBranchName,
         direction: 'desc',
         head: `${organizationName()}:${ReleaseBranchName}`,
@@ -62641,7 +62641,7 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     const name = `${tagName} (${releaseName})`;
-    const response = yield Client_client.repos.createRelease({
+    const response = yield Client_client().repos.createRelease({
         body: releaseNotes,
         draft: false,
         name,

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -142,7 +142,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
@@ -228,6 +228,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -60148,8 +60148,8 @@ const slackToken = () => (0,core.getInput)('slack-token', { required: true });
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
-const Client_client = new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
-const Client_readClient = new dist_node/* Octokit */.v({ auth: githubReadToken() });
+const Client_client = () => new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
+const Client_readClient = () => new dist_node/* Octokit */.v({ auth: githubReadToken() });
 const Client_clientForToken = (token) => {
     return new Octokit({ auth: token });
 };
@@ -60184,7 +60184,7 @@ const Git_TreeTypes = {
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => __awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createBlob({
+    const response = yield client().git.createBlob({
         owner: organizationName(),
         repo,
         content,
@@ -60201,7 +60201,7 @@ const Git_createGitBlob = (repo, content) => __awaiter(void 0, void 0, void 0, f
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => __awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createCommit({
+    const response = yield client().git.createCommit({
         owner: organizationName(),
         repo,
         message,
@@ -60219,7 +60219,7 @@ const Git_createGitCommit = (repo, message, tree, parent) => __awaiter(void 0, v
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => __awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createRef({
+    const response = yield client().git.createRef({
         owner: organizationName(),
         repo,
         ref: `refs/heads/${branch}`,
@@ -60236,7 +60236,7 @@ const Git_createGitBranch = (repo, branch, sha) => __awaiter(void 0, void 0, voi
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => __awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createTree({
+    const response = yield client().git.createTree({
         owner: organizationName(),
         repo,
         tree,
@@ -60252,7 +60252,7 @@ const Git_createGitTree = (repo, tree, baseTree) => __awaiter(void 0, void 0, vo
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => __awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.git.getCommit({
+    const response = yield readClient().git.getCommit({
         owner: organizationName(),
         repo,
         commit_sha: sha,
@@ -60281,7 +60281,7 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.compareCommits({
+    const response = yield readClient().repos.compareCommits({
         owner: organizationName(),
         repo,
         base,
@@ -60296,7 +60296,7 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         direction: 'desc',
         owner: organizationName(),
         page: 1,
@@ -60317,7 +60317,7 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.get({
+    const response = yield readClient().repos.get({
         owner: organizationName(),
         repo,
     });
@@ -60355,7 +60355,7 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield client.git.deleteRef({
+        const response = yield client().git.deleteRef({
             owner: organizationName(),
             repo,
             ref: `heads/${branch}`,
@@ -60379,7 +60379,7 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield readClient.repos.getBranch({
+        const response = yield readClient().repos.getBranch({
             owner: organizationName(),
             repo,
             branch,
@@ -60449,7 +60449,7 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.issues.addAssignees({
+    const response = yield client().issues.addAssignees({
         assignees: usernames,
         issue_number: number,
         owner: organizationName(),
@@ -60513,7 +60513,7 @@ const PullRequest_getIssueKey = (pr) => {
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.pulls.get({
+        const response = yield Client_readClient().pulls.get({
             owner: Inputs_organizationName(),
             pull_number: number,
             repo,
@@ -60543,7 +60543,7 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
     }
     // We can't assign the PR owner as a reviewer.
     const reviewers = usernames.filter((username) => username !== pullRequest.user.login);
-    const response = yield client.pulls.requestReviewers({
+    const response = yield client().pulls.requestReviewers({
         reviewers,
         pull_number: number,
         owner: organizationName(),
@@ -60568,7 +60568,7 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.listCommits({
+    const response = yield readClient().pulls.listCommits({
         owner: organizationName(),
         pull_number: number,
         repo,
@@ -60593,7 +60593,7 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.createReview({
+    const response = yield client().pulls.createReview({
         body,
         event,
         owner: organizationName(),
@@ -60611,7 +60611,7 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
+    const response = yield client().pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
     return response.data;
 });
 
@@ -60649,7 +60649,7 @@ const mutuallyExclusiveLabels = [
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_client.issues.setLabels({
+    const response = yield Client_client().issues.setLabels({
         issue_number: number,
         labels,
         owner: Inputs_organizationName(),
@@ -62550,7 +62550,7 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     info('Searching for an existing release pull request...');
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         base: MasterBranchName,
         direction: 'desc',
         head: `${organizationName()}:${ReleaseBranchName}`,
@@ -62641,7 +62641,7 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     const name = `${tagName} (${releaseName})`;
-    const response = yield client.repos.createRelease({
+    const response = yield client().repos.createRelease({
         body: releaseNotes,
         draft: false,
         name,

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -60140,13 +60140,13 @@ var dist_node = __nccwpck_require__(5375);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
-const Inputs_credentialsApiPrefix = () => getInput('credentials-api-prefix', { required: true });
+const Inputs_credentialsApiPrefix = () => getInput('credentials-api-prefix', { required: false });
 // The secret to use when connecting to the internal credentials API.
-const Inputs_credentialsApiSecret = () => getInput('credentials-api-secret', { required: true });
+const Inputs_credentialsApiSecret = () => getInput('credentials-api-secret', { required: false });
 // Token with read access to Github - provided by Github.
-const githubReadToken = () => (0,core.getInput)('repo-token', { required: true });
+const githubReadToken = () => (0,core.getInput)('repo-token', { required: false });
 // Token with write access to Github - set in organization secrets.
-const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: true });
+const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: false });
 // The email address to use when connecting to the Jira API.
 const jiraEmail = () => (0,core.getInput)('jira-email', { required: false });
 // The host to use when connecting to the Jira API.
@@ -60154,11 +60154,11 @@ const Inputs_jiraHost = () => (0,core.getInput)('jira-host', { required: false }
 // The API token to use when connecting to the Jira API.
 const jiraToken = () => (0,core.getInput)('jira-token', { required: false });
 // The Github organization name.
-const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: true });
+const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: false });
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
-const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: true });
+const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: false });
 // Token with write access to Slack.
-const slackToken = () => (0,core.getInput)('slack-token', { required: true });
+const slackToken = () => (0,core.getInput)('slack-token', { required: false });
 
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -142,7 +142,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
@@ -228,6 +228,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -60157,13 +60157,13 @@ var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
-const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: true });
+const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: false });
 // The secret to use when connecting to the internal credentials API.
-const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: true });
+const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: false });
 // Token with read access to Github - provided by Github.
-const githubReadToken = () => (0,core.getInput)('repo-token', { required: true });
+const githubReadToken = () => (0,core.getInput)('repo-token', { required: false });
 // Token with write access to Github - set in organization secrets.
-const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: true });
+const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: false });
 // The email address to use when connecting to the Jira API.
 const Inputs_jiraEmail = () => (0,core.getInput)('jira-email', { required: false });
 // The host to use when connecting to the Jira API.
@@ -60171,11 +60171,11 @@ const Inputs_jiraHost = () => (0,core.getInput)('jira-host', { required: false }
 // The API token to use when connecting to the Jira API.
 const Inputs_jiraToken = () => (0,core.getInput)('jira-token', { required: false });
 // The Github organization name.
-const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: true });
+const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: false });
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
-const slackErrorChannelId = () => (0,core.getInput)('slack-error-channel-id', { required: true });
+const slackErrorChannelId = () => (0,core.getInput)('slack-error-channel-id', { required: false });
 // Token with write access to Slack.
-const slackToken = () => (0,core.getInput)('slack-token', { required: true });
+const slackToken = () => (0,core.getInput)('slack-token', { required: false });
 
 ;// CONCATENATED MODULE: ./src/services/Credentials.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -35363,7 +35363,7 @@ module.exports = isBuffer;
 
 /***/ }),
 
-/***/ 2384:
+/***/ 3912:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var baseKeys = __nccwpck_require__(7164),
@@ -39559,7 +39559,7 @@ module.exports = {
 
 
 var stringify = __nccwpck_require__(9954);
-var parse = __nccwpck_require__(3912);
+var parse = __nccwpck_require__(316);
 var formats = __nccwpck_require__(4907);
 
 module.exports = {
@@ -39571,7 +39571,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3912:
+/***/ 316:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60122,6 +60122,9 @@ __nccwpck_require__.d(Inputs_namespaceObject, {
 var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
 var github = __nccwpck_require__(5438);
+// EXTERNAL MODULE: ./node_modules/lodash/isEmpty.js
+var lodash_isEmpty = __nccwpck_require__(3912);
+var isEmpty_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isEmpty);
 // EXTERNAL MODULE: ./node_modules/lodash/isNil.js
 var lodash_isNil = __nccwpck_require__(4977);
 var isNil_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isNil);
@@ -61186,8 +61189,6 @@ const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 
     return data;
 });
 
-// EXTERNAL MODULE: ./node_modules/lodash/isEmpty.js
-var lodash_isEmpty = __nccwpck_require__(2384);
 // EXTERNAL MODULE: external "querystring"
 var external_querystring_ = __nccwpck_require__(1191);
 ;// CONCATENATED MODULE: ./src/services/Jira/Release.ts
@@ -62711,12 +62712,20 @@ var pullRequestLabeled_awaiter = (undefined && undefined.__awaiter) || function 
 
 
 
+
+
 /**
  * Runs whenever a pull request is labeled.
  *
  * @param {WebhookPayloadPullRequest} payload The JSON payload from Github sent when a pull request is labeled.
  */
 const perform = (payload) => pullRequestLabeled_awaiter(void 0, void 0, void 0, function* () {
+    // Dependabot no longer gives us any inputs to work with. In this case we should just fail gracefully.
+    // @see https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+    if (isEmpty_default()(Inputs_githubWriteToken())) {
+        (0,core.info)('Organization name was not provided. Perhaps this is a dependabot PR? Giving up...');
+        return;
+    }
     const { label, pull_request: pullRequest, repository, sender } = payload;
     if (sender.login === Constants_GithubWriteUser) {
         (0,core.info)(`This label was added by @${Constants_GithubWriteUser} - nothing to do`);

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -60229,8 +60229,8 @@ var dist_node = __nccwpck_require__(5375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
-const Client_client = new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
-const Client_readClient = new dist_node/* Octokit */.v({ auth: githubReadToken() });
+const Client_client = () => new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
+const Client_readClient = () => new dist_node/* Octokit */.v({ auth: githubReadToken() });
 const Client_clientForToken = (token) => {
     return new Octokit({ auth: token });
 };
@@ -60265,7 +60265,7 @@ const Git_TreeTypes = {
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createBlob({
+    const response = yield client().git.createBlob({
         owner: organizationName(),
         repo,
         content,
@@ -60282,7 +60282,7 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createCommit({
+    const response = yield client().git.createCommit({
         owner: organizationName(),
         repo,
         message,
@@ -60300,7 +60300,7 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createRef({
+    const response = yield client().git.createRef({
         owner: organizationName(),
         repo,
         ref: `refs/heads/${branch}`,
@@ -60317,7 +60317,7 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createTree({
+    const response = yield client().git.createTree({
         owner: organizationName(),
         repo,
         tree,
@@ -60333,7 +60333,7 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.git.getCommit({
+    const response = yield readClient().git.getCommit({
         owner: organizationName(),
         repo,
         commit_sha: sha,
@@ -60362,7 +60362,7 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.compareCommits({
+    const response = yield readClient().repos.compareCommits({
         owner: organizationName(),
         repo,
         base,
@@ -60377,7 +60377,7 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         direction: 'desc',
         owner: organizationName(),
         page: 1,
@@ -60398,7 +60398,7 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.get({
+    const response = yield readClient().repos.get({
         owner: organizationName(),
         repo,
     });
@@ -60436,7 +60436,7 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield client.git.deleteRef({
+        const response = yield client().git.deleteRef({
             owner: organizationName(),
             repo,
             ref: `heads/${branch}`,
@@ -60460,7 +60460,7 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield readClient.repos.getBranch({
+        const response = yield readClient().repos.getBranch({
             owner: organizationName(),
             repo,
             branch,
@@ -60530,7 +60530,7 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_client.issues.addAssignees({
+    const response = yield Client_client().issues.addAssignees({
         assignees: usernames,
         issue_number: number,
         owner: Inputs_organizationName(),
@@ -60594,7 +60594,7 @@ const PullRequest_getIssueKey = (pr) => {
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.pulls.get({
+        const response = yield Client_readClient().pulls.get({
             owner: Inputs_organizationName(),
             pull_number: number,
             repo,
@@ -60624,7 +60624,7 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
     }
     // We can't assign the PR owner as a reviewer.
     const reviewers = usernames.filter((username) => username !== pullRequest.user.login);
-    const response = yield Client_client.pulls.requestReviewers({
+    const response = yield Client_client().pulls.requestReviewers({
         reviewers,
         pull_number: number,
         owner: Inputs_organizationName(),
@@ -60649,7 +60649,7 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.listCommits({
+    const response = yield readClient().pulls.listCommits({
         owner: organizationName(),
         pull_number: number,
         repo,
@@ -60674,7 +60674,7 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Input
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.createReview({
+    const response = yield client().pulls.createReview({
         body,
         event,
         owner: organizationName(),
@@ -60692,7 +60692,7 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
+    const response = yield client().pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
     return response.data;
 });
 
@@ -60730,7 +60730,7 @@ const mutuallyExclusiveLabels = [
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_client.issues.setLabels({
+    const response = yield Client_client().issues.setLabels({
         issue_number: number,
         labels,
         owner: Inputs_organizationName(),
@@ -62568,7 +62568,7 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     info('Searching for an existing release pull request...');
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         base: MasterBranchName,
         direction: 'desc',
         head: `${organizationName()}:${ReleaseBranchName}`,
@@ -62659,7 +62659,7 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     const name = `${tagName} (${releaseName})`;
-    const response = yield client.repos.createRelease({
+    const response = yield client().repos.createRelease({
         body: releaseNotes,
         draft: false,
         name,

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -35363,7 +35363,7 @@ module.exports = isBuffer;
 
 /***/ }),
 
-/***/ 2384:
+/***/ 3912:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var baseKeys = __nccwpck_require__(7164),
@@ -39559,7 +39559,7 @@ module.exports = {
 
 
 var stringify = __nccwpck_require__(9954);
-var parse = __nccwpck_require__(3912);
+var parse = __nccwpck_require__(316);
 var formats = __nccwpck_require__(4907);
 
 module.exports = {
@@ -39571,7 +39571,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3912:
+/***/ 316:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -60106,6 +60106,9 @@ __nccwpck_require__.d(__webpack_exports__, {
 var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
 var github = __nccwpck_require__(5438);
+// EXTERNAL MODULE: ./node_modules/lodash/isEmpty.js
+var lodash_isEmpty = __nccwpck_require__(3912);
+var isEmpty_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isEmpty);
 // EXTERNAL MODULE: ./node_modules/lodash/isNil.js
 var lodash_isNil = __nccwpck_require__(4977);
 var isNil_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isNil);
@@ -61170,8 +61173,6 @@ const Project_getProject = (projectKey) => Project_awaiter(void 0, void 0, void 
     return data;
 });
 
-// EXTERNAL MODULE: ./node_modules/lodash/isEmpty.js
-var lodash_isEmpty = __nccwpck_require__(2384);
 // EXTERNAL MODULE: external "querystring"
 var external_querystring_ = __nccwpck_require__(1191);
 ;// CONCATENATED MODULE: ./src/services/Jira/Release.ts
@@ -62693,6 +62694,8 @@ var pullRequestReadyForReview_awaiter = (undefined && undefined.__awaiter) || fu
 
 
 
+
+
 /**
  * Runs whenever a pull request is marked as 'ready for review'.
  *
@@ -62700,6 +62703,12 @@ var pullRequestReadyForReview_awaiter = (undefined && undefined.__awaiter) || fu
  */
 const pullRequestReadyForReview = (payload) => pullRequestReadyForReview_awaiter(void 0, void 0, void 0, function* () {
     const { pull_request: pullRequest, repository } = payload;
+    // Dependabot no longer gives us any inputs to work with. In this case we should just fail gracefully.
+    // @see https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+    if (isEmpty_default()(Inputs_githubWriteToken())) {
+        (0,core.info)('Organization name was not provided. Perhaps this is a dependabot PR? Giving up...');
+        return;
+    }
     (0,core.info)('Fetching repository details...');
     const repo = yield Credentials_fetchRepository(repository.name);
     const reviewers = repo.reviewers.map((user) => user.github_username);

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60141,13 +60141,13 @@ var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
-const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: true });
+const Inputs_credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: false });
 // The secret to use when connecting to the internal credentials API.
-const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: true });
+const Inputs_credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: false });
 // Token with read access to Github - provided by Github.
-const githubReadToken = () => (0,core.getInput)('repo-token', { required: true });
+const githubReadToken = () => (0,core.getInput)('repo-token', { required: false });
 // Token with write access to Github - set in organization secrets.
-const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: true });
+const Inputs_githubWriteToken = () => (0,core.getInput)('write-token', { required: false });
 // The email address to use when connecting to the Jira API.
 const jiraEmail = () => (0,core.getInput)('jira-email', { required: false });
 // The host to use when connecting to the Jira API.
@@ -60155,11 +60155,11 @@ const Inputs_jiraHost = () => (0,core.getInput)('jira-host', { required: false }
 // The API token to use when connecting to the Jira API.
 const jiraToken = () => (0,core.getInput)('jira-token', { required: false });
 // The Github organization name.
-const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: true });
+const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: false });
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
-const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: true });
+const Inputs_slackErrorChannelId = () => getInput('slack-error-channel-id', { required: false });
 // Token with write access to Slack.
-const slackToken = () => (0,core.getInput)('slack-token', { required: true });
+const slackToken = () => (0,core.getInput)('slack-token', { required: false });
 
 ;// CONCATENATED MODULE: ./src/services/Credentials.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -142,7 +142,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
@@ -228,6 +228,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60213,8 +60213,8 @@ var dist_node = __nccwpck_require__(5375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
-const Client_client = new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
-const Client_readClient = new dist_node/* Octokit */.v({ auth: githubReadToken() });
+const Client_client = () => new dist_node/* Octokit */.v({ auth: Inputs_githubWriteToken() });
+const Client_readClient = () => new dist_node/* Octokit */.v({ auth: githubReadToken() });
 const Client_clientForToken = (token) => {
     return new Octokit({ auth: token });
 };
@@ -60249,7 +60249,7 @@ const Git_TreeTypes = {
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createBlob({
+    const response = yield client().git.createBlob({
         owner: organizationName(),
         repo,
         content,
@@ -60266,7 +60266,7 @@ const Git_createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0,
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createCommit({
+    const response = yield client().git.createCommit({
         owner: organizationName(),
         repo,
         message,
@@ -60284,7 +60284,7 @@ const Git_createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0,
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createRef({
+    const response = yield client().git.createRef({
         owner: organizationName(),
         repo,
         ref: `refs/heads/${branch}`,
@@ -60301,7 +60301,7 @@ const Git_createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, v
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.git.createTree({
+    const response = yield client().git.createTree({
         owner: organizationName(),
         repo,
         tree,
@@ -60317,7 +60317,7 @@ const Git_createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, 
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.git.getCommit({
+    const response = yield readClient().git.getCommit({
         owner: organizationName(),
         repo,
         commit_sha: sha,
@@ -60346,7 +60346,7 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.compareCommits({
+    const response = yield readClient().repos.compareCommits({
         owner: organizationName(),
         repo,
         base,
@@ -60361,7 +60361,7 @@ const Repository_compareCommits = (repo, base, head) => Repository_awaiter(void 
  * @returns {number}   The number of the next PR.
  */
 const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         direction: 'desc',
         owner: organizationName(),
         page: 1,
@@ -60382,7 +60382,7 @@ const Repository_getNextPullRequestNumber = (repo) => Repository_awaiter(void 0,
  * @returns {ReposGetResponseData} The repository data.
  */
 const Repository_getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.repos.get({
+    const response = yield readClient().repos.get({
         owner: organizationName(),
         repo,
     });
@@ -60420,7 +60420,7 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  */
 const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield client.git.deleteRef({
+        const response = yield client().git.deleteRef({
             owner: organizationName(),
             repo,
             ref: `heads/${branch}`,
@@ -60444,7 +60444,7 @@ const Branch_deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, voi
  */
 const Branch_getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield readClient.repos.getBranch({
+        const response = yield readClient().repos.getBranch({
             owner: organizationName(),
             repo,
             branch,
@@ -60514,7 +60514,7 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const PullRequest_assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_client.issues.addAssignees({
+    const response = yield Client_client().issues.addAssignees({
         assignees: usernames,
         issue_number: number,
         owner: Inputs_organizationName(),
@@ -60578,7 +60578,7 @@ const PullRequest_getIssueKey = (pr) => {
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.pulls.get({
+        const response = yield Client_readClient().pulls.get({
             owner: Inputs_organizationName(),
             pull_number: number,
             repo,
@@ -60608,7 +60608,7 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
     }
     // We can't assign the PR owner as a reviewer.
     const reviewers = usernames.filter((username) => username !== pullRequest.user.login);
-    const response = yield Client_client.pulls.requestReviewers({
+    const response = yield Client_client().pulls.requestReviewers({
         reviewers,
         pull_number: number,
         owner: Inputs_organizationName(),
@@ -60633,7 +60633,7 @@ const PullRequest_extractPullRequestNumber = (message) => parseInt(message.repla
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.listCommits({
+    const response = yield readClient().pulls.listCommits({
         owner: organizationName(),
         pull_number: number,
         repo,
@@ -60658,7 +60658,7 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${organ
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.createReview({
+    const response = yield client().pulls.createReview({
         body,
         event,
         owner: organizationName(),
@@ -60676,7 +60676,7 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const PullRequest_updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield client.pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
+    const response = yield client().pulls.update(Object.assign(Object.assign({}, attributes), { owner: organizationName(), pull_number: number, repo }));
     return response.data;
 });
 
@@ -60714,7 +60714,7 @@ const mutuallyExclusiveLabels = [
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const Label_setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_client.issues.setLabels({
+    const response = yield Client_client().issues.setLabels({
         issue_number: number,
         labels,
         owner: Inputs_organizationName(),
@@ -62550,7 +62550,7 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     info('Searching for an existing release pull request...');
-    const response = yield readClient.pulls.list({
+    const response = yield readClient().pulls.list({
         base: MasterBranchName,
         direction: 'desc',
         head: `${organizationName()}:${ReleaseBranchName}`,
@@ -62641,7 +62641,7 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     const name = `${tagName} (${releaseName})`;
-    const response = yield client.repos.createRelease({
+    const response = yield client().repos.createRelease({
         body: releaseNotes,
         draft: false,
         name,

--- a/actions/rebase-epic-action/index.js
+++ b/actions/rebase-epic-action/index.js
@@ -134,7 +134,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
@@ -220,6 +220,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -142,7 +142,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(87351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
@@ -228,6 +228,21 @@ function getInput(name, options) {
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
 /**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61753,8 +61753,8 @@ var dist_node = __nccwpck_require__(55375);
 ;// CONCATENATED MODULE: ./src/services/Github/Client.ts
 
 
-const Github_Client_client = new dist_node/* Octokit */.v({ auth: githubWriteToken() });
-const Client_readClient = new dist_node/* Octokit */.v({ auth: githubReadToken() });
+const Github_Client_client = () => new dist_node/* Octokit */.v({ auth: githubWriteToken() });
+const Client_readClient = () => new dist_node/* Octokit */.v({ auth: githubReadToken() });
 const clientForToken = (token) => {
     return new dist_node/* Octokit */.v({ auth: token });
 };
@@ -61789,7 +61789,7 @@ const TreeTypes = {
  * @returns {GitCreateBlobResponseData} The blob data.
  */
 const createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.git.createBlob({
+    const response = yield Github_Client_client().git.createBlob({
         owner: Inputs_organizationName(),
         repo,
         content,
@@ -61806,7 +61806,7 @@ const createGitBlob = (repo, content) => Git_awaiter(void 0, void 0, void 0, fun
  * @returns {GitCreateCommitResponseData} The commit data.
  */
 const createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.git.createCommit({
+    const response = yield Github_Client_client().git.createCommit({
         owner: Inputs_organizationName(),
         repo,
         message,
@@ -61824,7 +61824,7 @@ const createGitCommit = (repo, message, tree, parent) => Git_awaiter(void 0, voi
  * @returns {GitCreateRefResponseData} The branch data.
  */
 const createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.git.createRef({
+    const response = yield Github_Client_client().git.createRef({
         owner: Inputs_organizationName(),
         repo,
         ref: `refs/heads/${branch}`,
@@ -61841,7 +61841,7 @@ const createGitBranch = (repo, branch, sha) => Git_awaiter(void 0, void 0, void 
  * @returns {GitCreateTreeResponseData} The branch data.
  */
 const createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.git.createTree({
+    const response = yield Github_Client_client().git.createTree({
         owner: Inputs_organizationName(),
         repo,
         tree,
@@ -61857,7 +61857,7 @@ const createGitTree = (repo, tree, baseTree) => Git_awaiter(void 0, void 0, void
  * @returns {GitGetCommitResponseData} The commit data.
  */
 const getCommit = (repo, sha) => Git_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.git.getCommit({
+    const response = yield readClient().git.getCommit({
         owner: organizationName(),
         repo,
         commit_sha: sha,
@@ -61886,7 +61886,7 @@ var Repository_awaiter = (undefined && undefined.__awaiter) || function (thisArg
  * @returns {ReposCompareCommitsResponseData} The diff data.
  */
 const compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_readClient.repos.compareCommits({
+    const response = yield Client_readClient().repos.compareCommits({
         owner: Inputs_organizationName(),
         repo,
         base,
@@ -61901,7 +61901,7 @@ const compareCommits = (repo, base, head) => Repository_awaiter(void 0, void 0, 
  * @returns {number}   The number of the next PR.
  */
 const getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_readClient.pulls.list({
+    const response = yield Client_readClient().pulls.list({
         direction: 'desc',
         owner: Inputs_organizationName(),
         page: 1,
@@ -61922,7 +61922,7 @@ const getNextPullRequestNumber = (repo) => Repository_awaiter(void 0, void 0, vo
  * @returns {ReposGetResponseData} The repository data.
  */
 const getRepository = (repo) => Repository_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Client_readClient.repos.get({
+    const response = yield Client_readClient().repos.get({
         owner: Inputs_organizationName(),
         repo,
     });
@@ -61960,7 +61960,7 @@ var Branch_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
  */
 const deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Github_Client_client.git.deleteRef({
+        const response = yield Github_Client_client().git.deleteRef({
             owner: Inputs_organizationName(),
             repo,
             ref: `heads/${branch}`,
@@ -61984,7 +61984,7 @@ const deleteBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, fu
  */
 const getBranch = (repo, branch) => Branch_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.repos.getBranch({
+        const response = yield Client_readClient().repos.getBranch({
             owner: Inputs_organizationName(),
             repo,
             branch,
@@ -62078,7 +62078,7 @@ var PullRequest_awaiter = (undefined && undefined.__awaiter) || function (thisAr
  * @returns {IssuesAddAssigneesResponseData} The PR data.
  */
 const assignOwners = (repo, number, usernames) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.issues.addAssignees({
+    const response = yield Github_Client_client().issues.addAssignees({
         assignees: usernames,
         issue_number: number,
         owner: Inputs_organizationName(),
@@ -62142,7 +62142,7 @@ const getIssueKey = (pr) => {
  */
 const PullRequest_getPullRequest = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
     try {
-        const response = yield Client_readClient.pulls.get({
+        const response = yield Client_readClient().pulls.get({
             owner: Inputs_organizationName(),
             pull_number: number,
             repo,
@@ -62172,7 +62172,7 @@ const assignReviewers = (repo, number, usernames) => PullRequest_awaiter(void 0,
     }
     // We can't assign the PR owner as a reviewer.
     const reviewers = usernames.filter((username) => username !== pullRequest.user.login);
-    const response = yield Github_Client_client.pulls.requestReviewers({
+    const response = yield Github_Client_client().pulls.requestReviewers({
         reviewers,
         pull_number: number,
         owner: Inputs_organizationName(),
@@ -62197,7 +62197,7 @@ const extractPullRequestNumber = (message) => parseInt(message.replace(/^.*\[#(\
  * @returns {PullsListCommitsResponseData} The pull request data.
  */
 const PullRequest_listPullRequestCommits = (repo, number) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield readClient.pulls.listCommits({
+    const response = yield readClient().pulls.listCommits({
         owner: organizationName(),
         pull_number: number,
         repo,
@@ -62222,7 +62222,7 @@ const PullRequest_pullRequestUrl = (repo, number) => `https://github.com/${Input
  * @returns {PullsCreateReviewResponseData} The review data.
  */
 const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.pulls.createReview({
+    const response = yield Github_Client_client().pulls.createReview({
         body,
         event,
         owner: Inputs_organizationName(),
@@ -62240,7 +62240,7 @@ const reviewPullRequest = (repo, number, event, body) => PullRequest_awaiter(voi
  * @returns {PullsGetResponseData} The updated pull request data.
  */
 const updatePullRequest = (repo, number, attributes) => PullRequest_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.pulls.update(Object.assign(Object.assign({}, attributes), { owner: Inputs_organizationName(), pull_number: number, repo }));
+    const response = yield Github_Client_client().pulls.update(Object.assign(Object.assign({}, attributes), { owner: Inputs_organizationName(), pull_number: number, repo }));
     return response.data;
 });
 
@@ -62278,7 +62278,7 @@ const mutuallyExclusiveLabels = [
  * @returns {IssuesSetLabelsResponseData} The PR data.
  */
 const setLabels = (repo, number, labels) => Label_awaiter(void 0, void 0, void 0, function* () {
-    const response = yield Github_Client_client.issues.setLabels({
+    const response = yield Github_Client_client().issues.setLabels({
         issue_number: number,
         labels,
         owner: Inputs_organizationName(),
@@ -63957,7 +63957,7 @@ const ensureReleasebranch = (repoName, sha) => Github_Release_awaiter(void 0, vo
  */
 const getReleasePullRequest = (repoName, releaseDate, releaseName, body) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     (0,core.info)('Searching for an existing release pull request...');
-    const response = yield Client_readClient.pulls.list({
+    const response = yield Client_readClient().pulls.list({
         base: Constants_MasterBranchName,
         direction: 'desc',
         head: `${Inputs_organizationName()}:${ReleaseBranchName}`,
@@ -64048,7 +64048,7 @@ const createReleasePullRequest = (email, repo) => Github_Release_awaiter(void 0,
  */
 const createReleaseTag = (repo, tagName, releaseName, releaseNotes) => Github_Release_awaiter(void 0, void 0, void 0, function* () {
     const name = `${tagName} (${releaseName})`;
-    const response = yield client.repos.createRelease({
+    const response = yield client().repos.createRelease({
         body: releaseNotes,
         draft: false,
         name,

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -61516,13 +61516,13 @@ var isNil_default = /*#__PURE__*/__nccwpck_require__.n(lodash_isNil);
 ;// CONCATENATED MODULE: ./src/services/Inputs.ts
 
 // The base URL to use when connecting to the internal credentials API.
-const credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: true });
+const credentialsApiPrefix = () => (0,core.getInput)('credentials-api-prefix', { required: false });
 // The secret to use when connecting to the internal credentials API.
-const credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: true });
+const credentialsApiSecret = () => (0,core.getInput)('credentials-api-secret', { required: false });
 // Token with read access to Github - provided by Github.
-const githubReadToken = () => (0,core.getInput)('repo-token', { required: true });
+const githubReadToken = () => (0,core.getInput)('repo-token', { required: false });
 // Token with write access to Github - set in organization secrets.
-const githubWriteToken = () => (0,core.getInput)('write-token', { required: true });
+const githubWriteToken = () => (0,core.getInput)('write-token', { required: false });
 // The email address to use when connecting to the Jira API.
 const jiraEmail = () => (0,core.getInput)('jira-email', { required: false });
 // The host to use when connecting to the Jira API.
@@ -61530,11 +61530,11 @@ const jiraHost = () => (0,core.getInput)('jira-host', { required: false });
 // The API token to use when connecting to the Jira API.
 const jiraToken = () => (0,core.getInput)('jira-token', { required: false });
 // The Github organization name.
-const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: true });
+const Inputs_organizationName = () => (0,core.getInput)('organization-name', { required: false });
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
-const slackErrorChannelId = () => (0,core.getInput)('slack-error-channel-id', { required: true });
+const slackErrorChannelId = () => (0,core.getInput)('slack-error-channel-id', { required: false });
 // Token with write access to Slack.
-const slackToken = () => (0,core.getInput)('slack-token', { required: true });
+const slackToken = () => (0,core.getInput)('slack-token', { required: false });
 
 // EXTERNAL MODULE: ./node_modules/@slack/web-api/dist/index.js
 var dist = __nccwpck_require__(60431);

--- a/src/services/Github/Branch.ts
+++ b/src/services/Github/Branch.ts
@@ -30,7 +30,7 @@ export const deleteBranch = async (
   branch: Branch
 ): Promise<void> => {
   try {
-    const response = await client.git.deleteRef({
+    const response = await client().git.deleteRef({
       owner: organizationName(),
       repo,
       ref: `heads/${branch}`,
@@ -60,7 +60,7 @@ export const getBranch = async (
   branch: Branch
 ): Promise<ReposGetBranchResponseData | undefined> => {
   try {
-    const response = await readClient.repos.getBranch({
+    const response = await readClient().repos.getBranch({
       owner: organizationName(),
       repo,
       branch,

--- a/src/services/Github/Client.ts
+++ b/src/services/Github/Client.ts
@@ -2,9 +2,10 @@ import { Octokit } from '@octokit/rest'
 
 import { githubReadToken, githubWriteToken } from '@sr-services/Inputs'
 
-export const client = new Octokit({ auth: githubWriteToken() })
+export const client = (): Octokit => new Octokit({ auth: githubWriteToken() })
 
-export const readClient = new Octokit({ auth: githubReadToken() })
+export const readClient = (): Octokit =>
+  new Octokit({ auth: githubReadToken() })
 
 export const clientForToken = (token: string): Octokit => {
   return new Octokit({ auth: token })

--- a/src/services/Github/Git.ts
+++ b/src/services/Github/Git.ts
@@ -67,7 +67,7 @@ export const createGitBlob = async (
   repo: Repository,
   content: string
 ): Promise<GitCreateBlobResponseData> => {
-  const response = await client.git.createBlob({
+  const response = await client().git.createBlob({
     owner: organizationName(),
     repo,
     content,
@@ -91,7 +91,7 @@ export const createGitCommit = async (
   tree: Sha,
   parent: Sha
 ): Promise<GitCreateCommitResponseData> => {
-  const response = await client.git.createCommit({
+  const response = await client().git.createCommit({
     owner: organizationName(),
     repo,
     message,
@@ -115,7 +115,7 @@ export const createGitBranch = async (
   branch: Branch,
   sha: Sha
 ): Promise<GitCreateRefResponseData> => {
-  const response = await client.git.createRef({
+  const response = await client().git.createRef({
     owner: organizationName(),
     repo,
     ref: `refs/heads/${branch}`,
@@ -138,7 +138,7 @@ export const createGitTree = async (
   tree: Tree[],
   baseTree: Sha
 ): Promise<GitCreateTreeResponseData> => {
-  const response = await client.git.createTree({
+  const response = await client().git.createTree({
     owner: organizationName(),
     repo,
     tree,
@@ -159,7 +159,7 @@ export const getCommit = async (
   repo: Repository,
   sha: Sha
 ): Promise<GitGetCommitResponseData> => {
-  const response = await readClient.git.getCommit({
+  const response = await readClient().git.getCommit({
     owner: organizationName(),
     repo,
     commit_sha: sha,

--- a/src/services/Github/Label.ts
+++ b/src/services/Github/Label.ts
@@ -42,7 +42,7 @@ export const setLabels = async (
   number: number,
   labels?: string[]
 ): Promise<IssuesSetLabelsResponseData> => {
-  const response = await client.issues.setLabels({
+  const response = await client().issues.setLabels({
     issue_number: number,
     labels,
     owner: organizationName(),

--- a/src/services/Github/PullRequest.ts
+++ b/src/services/Github/PullRequest.ts
@@ -29,7 +29,7 @@ export const assignOwners = async (
   number: number,
   usernames: string[]
 ): Promise<IssuesAddAssigneesResponseData> => {
-  const response = await client.issues.addAssignees({
+  const response = await client().issues.addAssignees({
     assignees: usernames,
     issue_number: number,
     owner: organizationName(),
@@ -113,7 +113,7 @@ export const getPullRequest = async (
   number: number
 ): Promise<PullsGetResponseData | undefined> => {
   try {
-    const response = await readClient.pulls.get({
+    const response = await readClient().pulls.get({
       owner: organizationName(),
       pull_number: number,
       repo,
@@ -156,7 +156,7 @@ export const assignReviewers = async (
     (username: string) => username !== pullRequest.user.login
   )
 
-  const response = await client.pulls.requestReviewers({
+  const response = await client().pulls.requestReviewers({
     reviewers,
     pull_number: number,
     owner: organizationName(),
@@ -188,7 +188,7 @@ export const listPullRequestCommits = async (
   repo: Repository,
   number: number
 ): Promise<PullsListCommitsResponseData | undefined> => {
-  const response = await readClient.pulls.listCommits({
+  const response = await readClient().pulls.listCommits({
     owner: organizationName(),
     pull_number: number,
     repo,
@@ -222,7 +222,7 @@ export const reviewPullRequest = async (
   event: 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES',
   body: string
 ): Promise<PullsCreateReviewResponseData> => {
-  const response = await client.pulls.createReview({
+  const response = await client().pulls.createReview({
     body,
     event,
     owner: organizationName(),
@@ -246,7 +246,7 @@ export const updatePullRequest = async (
   number: number,
   attributes: { [key: string]: string }
 ): Promise<PullsGetResponseData> => {
-  const response = await client.pulls.update({
+  const response = await client().pulls.update({
     ...attributes,
     owner: organizationName(),
     pull_number: number,

--- a/src/services/Github/Release.ts
+++ b/src/services/Github/Release.ts
@@ -181,7 +181,7 @@ const getReleasePullRequest = async (
   body: string
 ): Promise<PullsGetResponseData | undefined> => {
   info('Searching for an existing release pull request...')
-  const response = await readClient.pulls.list({
+  const response = await readClient().pulls.list({
     base: MasterBranchName,
     direction: 'desc',
     head: `${organizationName()}:${ReleaseBranchName}`,
@@ -330,7 +330,7 @@ export const createReleaseTag = async (
   releaseNotes: string
 ): Promise<ReposCreateReleaseResponseData> => {
   const name = `${tagName} (${releaseName})`
-  const response = await client.repos.createRelease({
+  const response = await client().repos.createRelease({
     body: releaseNotes,
     draft: false,
     name,

--- a/src/services/Github/Repository.ts
+++ b/src/services/Github/Repository.ts
@@ -20,7 +20,7 @@ export const compareCommits = async (
   base: Sha,
   head: Sha
 ): Promise<ReposCompareCommitsResponseData> => {
-  const response = await readClient.repos.compareCommits({
+  const response = await readClient().repos.compareCommits({
     owner: organizationName(),
     repo,
     base,
@@ -39,7 +39,7 @@ export const compareCommits = async (
 export const getNextPullRequestNumber = async (
   repo: Repository
 ): Promise<number> => {
-  const response = await readClient.pulls.list({
+  const response = await readClient().pulls.list({
     direction: 'desc',
     owner: organizationName(),
     page: 1,
@@ -65,7 +65,7 @@ export const getNextPullRequestNumber = async (
 export const getRepository = async (
   repo: Repository
 ): Promise<ReposGetResponseData> => {
-  const response = await readClient.repos.get({
+  const response = await readClient().repos.get({
     owner: organizationName(),
     repo,
   })

--- a/src/services/Github/__tests__/Branch.test.ts
+++ b/src/services/Github/__tests__/Branch.test.ts
@@ -8,14 +8,22 @@ import {
 } from '@octokit/types'
 
 import * as Branch from '@sr-services/Github/Branch'
-import { client, readClient } from '@sr-services/Github/Client'
 import * as Git from '@sr-services/Github/Git'
 import * as Repository from '@sr-services/Github/Repository'
 import { organizationName } from '@sr-services/Inputs'
-import { mockGithubBranch } from '@sr-tests/Mocks'
+import {
+  mockGithubBranch,
+  mockGithubClient,
+  mockReadClient,
+} from '@sr-tests/Mocks'
 
 const repo = 'my-repo'
 const branch = 'my-branch'
+
+jest.mock('@sr-services/Github/Client', () => ({
+  client: () => mockGithubClient,
+  readClient: () => mockReadClient,
+}))
 
 describe('Branch', () => {
   describe('getBranch', () => {
@@ -32,7 +40,7 @@ describe('Branch', () => {
 
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(readClient.repos, 'getBranch')
+        .spyOn(mockReadClient.repos, 'getBranch')
         .mockImplementation((_args?: GetBranchParams) =>
           Promise.resolve({
             data: mockGithubBranch,
@@ -46,7 +54,7 @@ describe('Branch', () => {
 
     it("returns undefined if the branch can't be found", async () => {
       const spy = jest
-        .spyOn(readClient.repos, 'getBranch')
+        .spyOn(mockReadClient.repos, 'getBranch')
         .mockImplementation((_args?: GetBranchParams) => {
           throw new Error('Branch not found')
         })
@@ -171,7 +179,7 @@ describe('Branch', () => {
 
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(client.git, 'deleteRef')
+        .spyOn(mockGithubClient.git, 'deleteRef')
         .mockImplementation((_args?: DeleteBranchParams) =>
           Promise.resolve({ status: 204 } as unknown as OctokitResponse<void>)
         )
@@ -183,7 +191,7 @@ describe('Branch', () => {
 
     it("returns undefined if the branch can't be found", async () => {
       const spy = jest
-        .spyOn(client.git, 'deleteRef')
+        .spyOn(mockGithubClient.git, 'deleteRef')
         .mockImplementation((_args?: DeleteBranchParams) => {
           throw new Error('Branch not found')
         })

--- a/src/services/Github/__tests__/Git.test.ts
+++ b/src/services/Github/__tests__/Git.test.ts
@@ -7,7 +7,6 @@ import {
   OctokitResponse,
 } from '@octokit/types'
 
-import { client, readClient } from '@sr-services/Github/Client'
 import {
   Branch,
   createGitBlob,
@@ -22,14 +21,20 @@ import {
   TreeTypes,
 } from '@sr-services/Github/Git'
 import { organizationName } from '@sr-services/Inputs'
+import { mockGithubClient, mockReadClient } from '@sr-tests/Mocks'
 
 const repo = 'my-repo'
+
+jest.mock('@sr-services/Github/Client', () => ({
+  client: () => mockGithubClient,
+  readClient: () => mockReadClient,
+}))
 
 describe('Git', () => {
   describe('createGitBlob', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(client.git, 'createBlob')
+        .spyOn(mockGithubClient.git, 'createBlob')
         .mockImplementation(
           (_args?: { owner: string; repo: Repository; content: string }) =>
             Promise.resolve({
@@ -50,7 +55,7 @@ describe('Git', () => {
   describe('createGitCommit', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(client.git, 'createCommit')
+        .spyOn(mockGithubClient.git, 'createCommit')
         .mockImplementation(
           (_args?: {
             owner: string
@@ -84,7 +89,7 @@ describe('Git', () => {
   describe('createGitBranch', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(client.git, 'createRef')
+        .spyOn(mockGithubClient.git, 'createRef')
         .mockImplementation(
           (_args?: {
             owner: string
@@ -111,7 +116,7 @@ describe('Git', () => {
   describe('createGitTree', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(client.git, 'createTree')
+        .spyOn(mockGithubClient.git, 'createTree')
         .mockImplementation(
           (_args?: {
             owner: string
@@ -146,7 +151,7 @@ describe('Git', () => {
   describe('getCommit', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(readClient.git, 'getCommit')
+        .spyOn(mockReadClient.git, 'getCommit')
         .mockImplementation(
           (_args?: { owner: string; repo: Repository; commit_sha: string }) =>
             Promise.resolve({

--- a/src/services/Github/__tests__/Label.test.ts
+++ b/src/services/Github/__tests__/Label.test.ts
@@ -5,12 +5,12 @@ import {
 } from '@octokit/types'
 
 import { InProgressLabel, PleaseReviewLabel } from '@sr-services/Constants'
-import * as Client from '@sr-services/Github/Client'
 import { Repository } from '@sr-services/Github/Git'
 import { addLabels, setLabels } from '@sr-services/Github/Label'
 import * as PullRequest from '@sr-services/Github/PullRequest'
 import { organizationName } from '@sr-services/Inputs'
 import {
+  mockGithubClient,
   mockGithubPullRequest,
   mockIssuesSetLabelsResponseData,
 } from '@sr-tests/Mocks'
@@ -20,6 +20,10 @@ jest.mock('@sr-services/Github/PullRequest', () => ({
 }))
 
 const repo = 'my-repo'
+
+jest.mock('@sr-services/Github/Client', () => ({
+  client: () => mockGithubClient,
+}))
 
 describe('PullRequest', () => {
   describe('addLabels', () => {
@@ -33,7 +37,7 @@ describe('PullRequest', () => {
           Promise.resolve(mockGithubPullRequest)
         )
       githubSetLabelsSpy = jest
-        .spyOn(Client.client.issues, 'setLabels')
+        .spyOn(mockGithubClient.issues, 'setLabels')
         .mockImplementation(
           (_args?: {
             issue_number: number
@@ -82,7 +86,7 @@ describe('PullRequest', () => {
   describe('setLabels', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(Client.client.issues, 'setLabels')
+        .spyOn(mockGithubClient.issues, 'setLabels')
         .mockImplementation(
           (_args?: {
             issue_number: number

--- a/src/services/Github/__tests__/Repository.test.ts
+++ b/src/services/Github/__tests__/Repository.test.ts
@@ -5,7 +5,6 @@ import {
   ReposGetResponseData,
 } from '@octokit/types'
 
-import { readClient } from '@sr-services/Github/Client'
 import { Repository, Sha } from '@sr-services/Github/Git'
 import {
   compareCommits,
@@ -14,15 +13,23 @@ import {
   repositoryUrl,
 } from '@sr-services/Github/Repository'
 import { organizationName } from '@sr-services/Inputs'
-import { mockGitCommit, mockGithubRepository } from '@sr-tests/Mocks'
+import {
+  mockGitCommit,
+  mockGithubRepository,
+  mockReadClient,
+} from '@sr-tests/Mocks'
 
 const repo = mockGithubRepository.name
+
+jest.mock('@sr-services/Github/Client', () => ({
+  readClient: () => mockReadClient,
+}))
 
 describe('Repository', () => {
   describe('compareCommits', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(readClient.repos, 'compareCommits')
+        .spyOn(mockReadClient.repos, 'compareCommits')
         .mockImplementation(
           (_args?: { base: Sha; head: Sha; owner: string; repo: Repository }) =>
             Promise.resolve({
@@ -46,7 +53,7 @@ describe('Repository', () => {
   describe('getNextPullRequestNumber', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(readClient.pulls, 'list')
+        .spyOn(mockReadClient.pulls, 'list')
         .mockImplementation(
           (_args?: {
             direction?: string
@@ -82,7 +89,7 @@ describe('Repository', () => {
   describe('getRepository', () => {
     it('calls the Github API', async () => {
       const spy = jest
-        .spyOn(readClient.repos, 'get')
+        .spyOn(mockReadClient.repos, 'get')
         .mockImplementation((_args?: { owner: string; repo: Repository }) =>
           Promise.resolve({
             data: mockGithubRepository,

--- a/src/services/Inputs.ts
+++ b/src/services/Inputs.ts
@@ -2,19 +2,19 @@ import { getInput } from '@actions/core'
 
 // The base URL to use when connecting to the internal credentials API.
 export const credentialsApiPrefix = (): string =>
-  getInput('credentials-api-prefix', { required: true })
+  getInput('credentials-api-prefix', { required: false })
 
 // The secret to use when connecting to the internal credentials API.
 export const credentialsApiSecret = (): string =>
-  getInput('credentials-api-secret', { required: true })
+  getInput('credentials-api-secret', { required: false })
 
 // Token with read access to Github - provided by Github.
 export const githubReadToken = (): string =>
-  getInput('repo-token', { required: true })
+  getInput('repo-token', { required: false })
 
 // Token with write access to Github - set in organization secrets.
 export const githubWriteToken = (): string =>
-  getInput('write-token', { required: true })
+  getInput('write-token', { required: false })
 
 // The email address to use when connecting to the Jira API.
 export const jiraEmail = (): string =>
@@ -29,12 +29,12 @@ export const jiraToken = (): string =>
 
 // The Github organization name.
 export const organizationName = (): string =>
-  getInput('organization-name', { required: true })
+  getInput('organization-name', { required: false })
 
 // ID of the Slack channel to post errors to, if we don't know where else to send them.
 export const slackErrorChannelId = (): string =>
-  getInput('slack-error-channel-id', { required: true })
+  getInput('slack-error-channel-id', { required: false })
 
 // Token with write access to Slack.
 export const slackToken = (): string =>
-  getInput('slack-token', { required: true })
+  getInput('slack-token', { required: false })

--- a/src/tests/Mocks.ts
+++ b/src/tests/Mocks.ts
@@ -1,3 +1,4 @@
+import { Octokit } from '@octokit/rest'
 import {
   IssuesAddAssigneesResponseData,
   IssuesAddLabelsResponseData,
@@ -65,6 +66,10 @@ export const mockGithubBranch = {
   name: 'my-branch',
   sha: 'branch-sha',
 } as unknown as ReposGetBranchResponseData
+
+export const mockGithubClient = new Octokit({ auth: 'my-token' })
+
+export const mockReadClient = new Octokit({ auth: 'my-token' })
 
 export const mockGithubCompareCommits = {
   commits: [mockGitCommit],


### PR DESCRIPTION
## Fail gracefully when required Github secrets are missing

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-436)

For some reason we consistently get a missing Github secret when adding labels:

&#x60;&#x60;&#x60;
Run Shuttlerock&#x2F;actions&#x2F;actions&#x2F;pull-request-labeled-action@master
&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:223
        throw new Error(&#x60;Input required and not supplied: ${name}&#x60;);
        ^

Error: Input required and not supplied: write-token
    at getInput (&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:223:15)
    at Inputs_githubWriteToken (&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:60151:56)
    at &#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:60232:60
    at &#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:62794:3
    at Object.&lt;anonymous&gt; (&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:62797:12)
    at Module._compile (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:959:30)
    at Object.Module._extensions..js (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:995:10)
    at Module.load (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:815:32)
    at Function.Module._load (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:727:14)
    at Function.Module.runMain (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:1047:10)
&#x60;&#x60;&#x60;

https:&#x2F;&#x2F;github.com&#x2F;Shuttlerock&#x2F;compliance&#x2F;runs&#x2F;2839919593?check_suite_focus&#x3D;true

The secret is definitely set, and re-running the action works fine. Investigation has not cast any light on this, so we should fail gracefully so the check suite still passes in these cases.

## How to test the PR

Wait for dependabot to create some PRs, and check that there are no failures.

## Deployment Notes

None