### PR TITLE
[SECURITY-437] Fail gracefully when required Github secrets are missing, take 2

### DIFF
--- a/.meta/SECURITY-437.md
+++ b/.meta/SECURITY-437.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-437
+
+Created at 2021-06-18T01:57:56.960Z


### PR DESCRIPTION

## Fail gracefully when required Github secrets are missing, take 2

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-437)

For some reason we consistently get a missing Github secret when adding labels:

&#x60;&#x60;&#x60;
Run Shuttlerock&#x2F;actions&#x2F;actions&#x2F;pull-request-labeled-action@master
&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:223
        throw new Error(&#x60;Input required and not supplied: ${name}&#x60;);
        ^

Error: Input required and not supplied: write-token
    at getInput (&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:223:15)
    at Inputs_githubWriteToken (&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:60151:56)
    at &#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:60232:60
    at &#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:62794:3
    at Object.&lt;anonymous&gt; (&#x2F;home&#x2F;runner&#x2F;work&#x2F;_actions&#x2F;Shuttlerock&#x2F;actions&#x2F;master&#x2F;actions&#x2F;pull-request-labeled-action&#x2F;index.js:62797:12)
    at Module._compile (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:959:30)
    at Object.Module._extensions..js (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:995:10)
    at Module.load (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:815:32)
    at Function.Module._load (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:727:14)
    at Function.Module.runMain (internal&#x2F;modules&#x2F;cjs&#x2F;loader.js:1047:10)
&#x60;&#x60;&#x60;

https:&#x2F;&#x2F;github.com&#x2F;Shuttlerock&#x2F;compliance&#x2F;runs&#x2F;2839919593?check_suite_focus&#x3D;true

The secret is definitely set, and re-running the action works fine. Investigation has not cast any light on this, so we should fail gracefully so the check suite still passes in these cases.

## How to test the PR

- How to test feature 1
  - Do this
  - Do that
  - Success
- How to test feature 2
- How to test feature 3

## Deployment Notes

It requires new Environmental variables:

- `EXAMPLE_ENV_VARIABLE=content`
- `EXAMPLE_ENV_VARIABLE2=content`
