### PR TITLE
[SECURITY-506] Allow PRs to be automatically created by Jira component

### DIFF
--- a/.meta/SECURITY-506.md
+++ b/.meta/SECURITY-506.md
@@ -1,0 +1,3 @@
+https://shuttlerock.atlassian.net/browse/SECURITY-506
+
+Created at 2021-08-30T06:15:21.418Z

--- a/actions/check-run-completed-action/index.js
+++ b/actions/check-run-completed-action/index.js
@@ -60963,6 +60963,7 @@ const JiraLabelSkipPR = 'Skip_PR';
 // Jira issue field names.
 const JiraFieldRepository = 'Repository';
 const JiraFieldStoryPointEstimate = 'Story point estimate';
+const JiraFieldStoryPoints = 'Story Points'; // Some projects use this instead of 'Story point estimate'.
 /**
  * Returns the field ID for the given human-readable field name.
  *
@@ -60994,12 +60995,16 @@ const populateExplicitFields = (issue) => {
     }
     // Find the story points, and include it explicitly. This is a bit ugly due to the way
     // Jira includes custom fields.
-    fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate);
-    if (fieldId) {
-        Object.assign(issue.fields, {
-            storyPointEstimate: issue.fields[fieldId],
-        });
-    }
+    ;
+    [JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach((fieldName) => {
+        fieldId = idForFieldName(issue, fieldName);
+        if (fieldId) {
+            const storyPointEstimate = issue.fields[fieldId];
+            if (storyPointEstimate) {
+                Object.assign(issue.fields, { storyPointEstimate });
+            }
+        }
+    });
     return issue;
 };
 /**

--- a/actions/check-suite-completed-action/index.js
+++ b/actions/check-suite-completed-action/index.js
@@ -60963,6 +60963,7 @@ const JiraLabelSkipPR = 'Skip_PR';
 // Jira issue field names.
 const JiraFieldRepository = 'Repository';
 const JiraFieldStoryPointEstimate = 'Story point estimate';
+const JiraFieldStoryPoints = 'Story Points'; // Some projects use this instead of 'Story point estimate'.
 /**
  * Returns the field ID for the given human-readable field name.
  *
@@ -60994,12 +60995,16 @@ const populateExplicitFields = (issue) => {
     }
     // Find the story points, and include it explicitly. This is a bit ugly due to the way
     // Jira includes custom fields.
-    fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate);
-    if (fieldId) {
-        Object.assign(issue.fields, {
-            storyPointEstimate: issue.fields[fieldId],
-        });
-    }
+    ;
+    [JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach((fieldName) => {
+        fieldId = idForFieldName(issue, fieldName);
+        if (fieldId) {
+            const storyPointEstimate = issue.fields[fieldId];
+            if (storyPointEstimate) {
+                Object.assign(issue.fields, { storyPointEstimate });
+            }
+        }
+    });
     return issue;
 };
 /**

--- a/actions/pull-request-closed-action/index.js
+++ b/actions/pull-request-closed-action/index.js
@@ -60959,6 +60959,7 @@ const JiraLabelSkipPR = 'Skip_PR';
 // Jira issue field names.
 const JiraFieldRepository = 'Repository';
 const JiraFieldStoryPointEstimate = 'Story point estimate';
+const JiraFieldStoryPoints = 'Story Points'; // Some projects use this instead of 'Story point estimate'.
 /**
  * Returns the field ID for the given human-readable field name.
  *
@@ -60990,12 +60991,16 @@ const populateExplicitFields = (issue) => {
     }
     // Find the story points, and include it explicitly. This is a bit ugly due to the way
     // Jira includes custom fields.
-    fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate);
-    if (fieldId) {
-        Object.assign(issue.fields, {
-            storyPointEstimate: issue.fields[fieldId],
-        });
-    }
+    ;
+    [JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach((fieldName) => {
+        fieldId = idForFieldName(issue, fieldName);
+        if (fieldId) {
+            const storyPointEstimate = issue.fields[fieldId];
+            if (storyPointEstimate) {
+                Object.assign(issue.fields, { storyPointEstimate });
+            }
+        }
+    });
     return issue;
 };
 /**

--- a/actions/pull-request-converted-to-draft-action/index.js
+++ b/actions/pull-request-converted-to-draft-action/index.js
@@ -60898,6 +60898,7 @@ const JiraLabelSkipPR = 'Skip_PR';
 // Jira issue field names.
 const JiraFieldRepository = 'Repository';
 const JiraFieldStoryPointEstimate = 'Story point estimate';
+const JiraFieldStoryPoints = 'Story Points'; // Some projects use this instead of 'Story point estimate'.
 /**
  * Returns the field ID for the given human-readable field name.
  *
@@ -60929,12 +60930,16 @@ const populateExplicitFields = (issue) => {
     }
     // Find the story points, and include it explicitly. This is a bit ugly due to the way
     // Jira includes custom fields.
-    fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate);
-    if (fieldId) {
-        Object.assign(issue.fields, {
-            storyPointEstimate: issue.fields[fieldId],
-        });
-    }
+    ;
+    [JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach((fieldName) => {
+        fieldId = idForFieldName(issue, fieldName);
+        if (fieldId) {
+            const storyPointEstimate = issue.fields[fieldId];
+            if (storyPointEstimate) {
+                Object.assign(issue.fields, { storyPointEstimate });
+            }
+        }
+    });
     return issue;
 };
 /**

--- a/actions/pull-request-labeled-action/index.js
+++ b/actions/pull-request-labeled-action/index.js
@@ -60979,6 +60979,7 @@ const JiraLabelSkipPR = 'Skip_PR';
 // Jira issue field names.
 const JiraFieldRepository = 'Repository';
 const JiraFieldStoryPointEstimate = 'Story point estimate';
+const JiraFieldStoryPoints = 'Story Points'; // Some projects use this instead of 'Story point estimate'.
 /**
  * Returns the field ID for the given human-readable field name.
  *
@@ -61010,12 +61011,16 @@ const populateExplicitFields = (issue) => {
     }
     // Find the story points, and include it explicitly. This is a bit ugly due to the way
     // Jira includes custom fields.
-    fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate);
-    if (fieldId) {
-        Object.assign(issue.fields, {
-            storyPointEstimate: issue.fields[fieldId],
-        });
-    }
+    ;
+    [JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach((fieldName) => {
+        fieldId = idForFieldName(issue, fieldName);
+        if (fieldId) {
+            const storyPointEstimate = issue.fields[fieldId];
+            if (storyPointEstimate) {
+                Object.assign(issue.fields, { storyPointEstimate });
+            }
+        }
+    });
     return issue;
 };
 /**

--- a/actions/pull-request-ready-for-review-action/index.js
+++ b/actions/pull-request-ready-for-review-action/index.js
@@ -60965,6 +60965,7 @@ const JiraLabelSkipPR = 'Skip_PR';
 // Jira issue field names.
 const JiraFieldRepository = 'Repository';
 const JiraFieldStoryPointEstimate = 'Story point estimate';
+const JiraFieldStoryPoints = 'Story Points'; // Some projects use this instead of 'Story point estimate'.
 /**
  * Returns the field ID for the given human-readable field name.
  *
@@ -60996,12 +60997,16 @@ const populateExplicitFields = (issue) => {
     }
     // Find the story points, and include it explicitly. This is a bit ugly due to the way
     // Jira includes custom fields.
-    fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate);
-    if (fieldId) {
-        Object.assign(issue.fields, {
-            storyPointEstimate: issue.fields[fieldId],
-        });
-    }
+    ;
+    [JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach((fieldName) => {
+        fieldId = idForFieldName(issue, fieldName);
+        if (fieldId) {
+            const storyPointEstimate = issue.fields[fieldId];
+            if (storyPointEstimate) {
+                Object.assign(issue.fields, { storyPointEstimate });
+            }
+        }
+    });
     return issue;
 };
 /**

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -62524,6 +62524,7 @@ const JiraLabelSkipPR = 'Skip_PR';
 // Jira issue field names.
 const JiraFieldRepository = 'Repository';
 const JiraFieldStoryPointEstimate = 'Story point estimate';
+const JiraFieldStoryPoints = 'Story Points'; // Some projects use this instead of 'Story point estimate'.
 /**
  * Returns the field ID for the given human-readable field name.
  *
@@ -62555,12 +62556,16 @@ const populateExplicitFields = (issue) => {
     }
     // Find the story points, and include it explicitly. This is a bit ugly due to the way
     // Jira includes custom fields.
-    fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate);
-    if (fieldId) {
-        Object.assign(issue.fields, {
-            storyPointEstimate: issue.fields[fieldId],
-        });
-    }
+    ;
+    [JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach((fieldName) => {
+        fieldId = idForFieldName(issue, fieldName);
+        if (fieldId) {
+            const storyPointEstimate = issue.fields[fieldId];
+            if (storyPointEstimate) {
+                Object.assign(issue.fields, { storyPointEstimate });
+            }
+        }
+    });
     return issue;
 };
 /**

--- a/actions/trigger-action/index.js
+++ b/actions/trigger-action/index.js
@@ -64326,7 +64326,7 @@ var createPullRequestForJiraIssue_awaiter = (undefined && undefined.__awaiter) |
  * @param {string} userCommand The command given by the user of the Jira issue we will base the pull request on.
  */
 const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestForJiraIssue_awaiter(void 0, void 0, void 0, function* () {
-    var _a, _b;
+    var _a, _b, _c, _d;
     const [issueKey, repositoryName] = userCommand.trim().split(/\s+/);
     (0,core.info)(`Creating a pull request for issue ${issueKey} / ${email}`);
     (0,core.info)('Fetching the Jira issue details...');
@@ -64340,7 +64340,9 @@ const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestF
     }
     const jiraUrl = issueUrl(issue.key);
     // If no repository is supplied then it will default to the Jira issue repository.
-    const repository = repositoryName || issue.fields.repository;
+    const repository = repositoryName ||
+        issue.fields.repository ||
+        ((_b = (((_a = issue.fields) === null || _a === void 0 ? void 0 : _a.components) || [])[0]) === null || _b === void 0 ? void 0 : _b.name);
     (0,core.info)(`The Jira URL is ${jiraUrl}`);
     (0,core.info)('Finding out who the pull request should belong to...');
     if (isNil_default()(issue.fields.assignee)) {
@@ -64396,8 +64398,8 @@ const createPullRequestForJiraIssue = (email, userCommand) => createPullRequestF
         // Decide if this is an epic.
         const epic = yield getEpic(issue.key);
         if (epic &&
-            !((_a = epic.fields.labels) === null || _a === void 0 ? void 0 : _a.includes(JiraLabelSkipPR)) &&
-            !((_b = issue.fields.labels) === null || _b === void 0 ? void 0 : _b.includes(JiraLabelSkipPR))) {
+            !((_c = epic.fields.labels) === null || _c === void 0 ? void 0 : _c.includes(JiraLabelSkipPR)) &&
+            !((_d = issue.fields.labels) === null || _d === void 0 ? void 0 : _d.includes(JiraLabelSkipPR))) {
             (0,core.info)(`Issue ${issue.key} belongs to epic ${epic.key} - creating an Epic pull request.`);
             const epicPr = yield createEpicPullRequest(epic, repository);
             baseBranchName = epicPr.head.ref;

--- a/src/actions/trigger-action/__tests__/fixtures/createPullRequestForJiraIssue.json
+++ b/src/actions/trigger-action/__tests__/fixtures/createPullRequestForJiraIssue.json
@@ -3,6 +3,6 @@
   "inputs": {
     "email": "dave@shuttlerock.com",
     "event": "createPullRequestForJiraIssue",
-    "param": "STUDIO-236"
+    "param": "DATA-46"
   }
 }

--- a/src/services/Jira/Issue.ts
+++ b/src/services/Jira/Issue.ts
@@ -92,6 +92,7 @@ export const JiraLabelSkipPR = 'Skip_PR'
 // Jira issue field names.
 export const JiraFieldRepository = 'Repository'
 export const JiraFieldStoryPointEstimate = 'Story point estimate'
+export const JiraFieldStoryPoints = 'Story Points' // Some projects use this instead of 'Story point estimate'.
 
 /**
  * Returns the field ID for the given human-readable field name.
@@ -133,16 +134,21 @@ const populateExplicitFields = (issue: Issue) => {
 
   // Find the story points, and include it explicitly. This is a bit ugly due to the way
   // Jira includes custom fields.
-  fieldId = idForFieldName(issue, JiraFieldStoryPointEstimate)
-  if (fieldId) {
-    Object.assign(issue.fields, {
-      storyPointEstimate: (
-        issue.fields as unknown as {
-          [customField: string]: number
+  ;[JiraFieldStoryPointEstimate, JiraFieldStoryPoints].forEach(
+    (fieldName: string) => {
+      fieldId = idForFieldName(issue, fieldName)
+      if (fieldId) {
+        const storyPointEstimate = (
+          issue.fields as unknown as {
+            [customField: string]: number
+          }
+        )[fieldId]
+        if (storyPointEstimate) {
+          Object.assign(issue.fields, { storyPointEstimate })
         }
-      )[fieldId],
-    })
-  }
+      }
+    }
+  )
 
   return issue
 }

--- a/src/services/Jira/Issue.ts
+++ b/src/services/Jira/Issue.ts
@@ -19,9 +19,12 @@ interface HttpError {
 
 type FieldNames = { [name: string]: string }
 
+type Component = { name: string }
+
 export interface Issue {
   fields: {
     assignee?: User
+    components?: Component[]
     description?: string
     issuetype: {
       name: string

--- a/src/triggers/createPullRequestForJiraIssue.ts
+++ b/src/triggers/createPullRequestForJiraIssue.ts
@@ -60,7 +60,10 @@ export const createPullRequestForJiraIssue = async (
 
   const jiraUrl = issueUrl(issue.key)
   // If no repository is supplied then it will default to the Jira issue repository.
-  const repository = repositoryName || issue.fields.repository
+  const repository =
+    repositoryName ||
+    issue.fields.repository ||
+    (issue.fields?.components || [])[0]?.name
   info(`The Jira URL is ${jiraUrl}`)
 
   info('Finding out who the pull request should belong to...')


### PR DESCRIPTION
## Allow PRs to be automatically created by Jira component

[Jira Task](https://shuttlerock.atlassian.net/browse/SECURITY-506)

We use the &#x60;repository&#x60; field now, but it is a custom add-on that isn&#39;t available in &#39;classic&#39; projects. We should also check the &#x60;Components&#x60; field if the &#x60;repository&#x60; is not found.

## How to test the PR

`act --job trigger_action --eventpath src/actions/trigger-action/__tests__/fixtures/createPullRequestForJiraIssue.json`

## Deployment Notes

None