### PR TITLE
Release Candidate 2022-04-18-0614 (Written Whale)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.6.0",
-    "@actions/exec": "^1.1.0",
+    "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.0",
     "@octokit/rest": "^18.0.9",
     "@slack/web-api": "^6.7.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "prettier": "2.5.1",
     "ts-jest": "^26.5.6",
     "tscpaths": "^0.0.9",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^27.4.1",
     "@types/jira-client": "^7.1.4",
-    "@types/lodash": "^4.14.179",
+    "@types/lodash": "^4.14.181",
     "@types/mustache": "^4.1.2",
     "@types/node": "^17.0.24",
     "@types/node-fetch": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@actions/http-client" "^1.0.11"
 
-"@actions/exec@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.0.tgz#53441d968e56d2fec69ad3f15773d4d94e01162c"
-  integrity sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==
+"@actions/exec@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.1.tgz#2e43f28c54022537172819a7cf886c844221a611"
+  integrity sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==
   dependencies:
     "@actions/io" "^1.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,10 +1256,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.179":
-  version "4.14.179"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
-  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
+"@types/lodash@^4.14.181":
+  version "4.14.181"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.181.tgz#d1d3740c379fda17ab175165ba04e2d03389385d"
+  integrity sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==
 
 "@types/minimatch@*":
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6501,10 +6501,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Release Candidate 2022-04-18-0614 (Written Whale)

### Dependency updates

- Bump @types/lodash from 4.14.179 to [4.14.181](https://github.com/Shuttlerock/actions/commit/d2dc30298503c9e6cb08332dac108469d20fe7da)
- Bump @actions/exec from 1.1.0 to [1.1.1](https://github.com/Shuttlerock/actions/commit/0f0c9d3ee7b040738154664a62877ee6545ab6cd)
- Bump typescript from 4.6.2 to [4.6.3](https://github.com/Shuttlerock/actions/commit/bd2732ddef0661b7faa06f07372657484bd535ae)
